### PR TITLE
Add support for .NET 3.5

### DIFF
--- a/csharp/PhoneNumbers/Compat/ISet.cs
+++ b/csharp/PhoneNumbers/Compat/ISet.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace PhoneNumbers
+{
+    internal interface ISet<T> : ICollection<T>, IEnumerable<T>, IEnumerable
+    {
+        new bool Add(T item);
+    }
+}

--- a/csharp/PhoneNumbers/Compat/SortedSet.cs
+++ b/csharp/PhoneNumbers/Compat/SortedSet.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PhoneNumbers
+{
+    public class SortedSet<T> : ISet<T>
+    {
+        private SortedDictionary<T, object> items;
+
+        public SortedSet()
+        {
+            items = new SortedDictionary<T, object>();
+        }
+
+        public SortedSet(IEnumerable<T> collection) : this()
+        {
+            foreach (var item in collection)
+            {
+                Add(item);
+            }
+        }
+
+        public int Count
+        {
+            get => items.Count;
+        }
+
+        public bool IsReadOnly
+        {
+            get => false;
+        }
+
+        public bool Add(T item)
+        {
+            try
+            {
+                items.Add(item, null);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public void Clear()
+        {
+            items.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return items.ContainsKey(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            items.Keys.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return items.Keys.GetEnumerator();
+        }
+
+        public bool Remove(T item)
+        {
+            return items.Remove(item);
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            Add(item);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/csharp/PhoneNumbers/MetadataFilter.cs
+++ b/csharp/PhoneNumbers/MetadataFilter.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace PhoneNumbers
@@ -183,7 +184,11 @@ namespace PhoneNumbers
         {
             if (str == null)
                 throw new Exception("Null string should not be passed to ParseFieldMapFromString");
+#if NET35
+            if (string.IsNullOrEmpty(str) || str.All(char.IsWhiteSpace))
+#else
             if (string.IsNullOrWhiteSpace(str))
+#endif
                 throw new Exception("Null nor empty string should not be passed to ParseFieldMapFromString");
 
             var fieldMap = new Dictionary<string, SortedSet<string>>();

--- a/csharp/PhoneNumbers/MetadataManager.cs
+++ b/csharp/PhoneNumbers/MetadataManager.cs
@@ -45,7 +45,7 @@ namespace PhoneNumbers
 
         private static void LoadMedataFromFile(string filePrefix)
         {
-#if NET40
+#if (NET35 || NET40)
             var asm = Assembly.GetExecutingAssembly();
 #else
             var asm = typeof(MetadataManager).GetTypeInfo().Assembly;

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -107,7 +107,7 @@ namespace PhoneNumbers
         private void LoadMappingFileProvider()
         {
             var files = new SortedDictionary<int, HashSet<string>>();
-#if NET40
+#if (NET35 || NET40)
             var asm = Assembly.GetExecutingAssembly();
 #else
             var asm = typeof(PhoneNumberOfflineGeocoder).GetTypeInfo().Assembly;
@@ -154,7 +154,7 @@ namespace PhoneNumbers
 
         private void LoadAreaCodeMapFromFile(string fileName)
         {
-#if NET40
+#if (NET35 || NET40)
             var asm = Assembly.GetExecutingAssembly();
 #else
             var asm = typeof(PhoneNumberOfflineGeocoder).GetTypeInfo().Assembly;

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -541,7 +541,7 @@ namespace PhoneNumbers
 
         private void LoadMetadataFromFile(string filePrefix, string regionCode)
         {
-#if NET40
+#if (NET35 || NET40)
             var asm = Assembly.GetExecutingAssembly();
 #else
             var asm = typeof(PhoneNumberUtil).GetTypeInfo().Assembly;

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>libphonenumber-csharp</AssemblyTitle>
     <VersionPrefix>$(APPVEYOR_BUILD_VERSION)</VersionPrefix>
     <Authors>Patrick Mézard;Tom Clegg;Jarrod Alexander;Google;libphonenumber contributors</Authors>
-    <TargetFrameworks>net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>PhoneNumbers</AssemblyName>
     <PackageId>libphonenumber-csharp</PackageId>
     <PackageTags>phonenumber phone libphonenumber e164 e.164 international</PackageTags>
@@ -15,6 +15,10 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/twcclegg/libphonenumber-csharp</RepositoryUrl>
     <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <FrameworkPathOverride Condition=" '$(TargetFramework)' == 'net35' ">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,5 +31,15 @@
     <Reference Include="System.Core" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="compat\ISet.cs" />
+    <Compile Remove="compat\SortedSet.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <Compile Include="compat\ISet.cs" />
+    <Compile Include="compat\SortedSet.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is more of a suggestion than anything else. I understand that .NET 3.5 at this point is considered legacy and that in the long run supporting it might turn out to be a maintenance burden. However, some might find this useful (i.e. myself :wink:).

There's actually surprisingly little code that had to be changed. The missing `SortedSet<T>` was replaced with a custom implementation, based on the `SortedDictionary<T>` to achieve similar performance. It's not a complete `SortedSet<T>` implementation by any means; it only contains enough functionality to support the current use. This class and the corresponding interface are only included when targeting `net35`.