### PR TITLE
Use embedded xml resources for .NET 3.5

### DIFF
--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -91,7 +91,7 @@ namespace PhoneNumbers
             using (var input = asm.GetManifestResourceStream(name))
             {
 #if NET35
-		document = XDocument.Load(new XmlTextReader(input));
+                document = XDocument.Load(new XmlTextReader(input));
 #else
                 document = XDocument.Load(input);
 #endif

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -20,6 +20,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+#if NET35
+using System.Xml;
+#endif
 using System.Xml.Linq;
 
 namespace PhoneNumbers

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -80,10 +80,7 @@ namespace PhoneNumbers
             bool isAlternateFormatsMetadata)
         {
             XDocument document;
-#if NET35
-            document = XDocument.Load(name);
-#else
-#if  NET40
+#if (NET35 || NET40)
             var asm = Assembly.GetExecutingAssembly();
 #else
             var asm = typeof(PhoneNumberUtil).GetTypeInfo().Assembly;

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -89,7 +89,6 @@ namespace PhoneNumbers
             {
                 document = XDocument.Load(input);
             }
-#endif
 
             var metadataCollection = new PhoneMetadataCollection.Builder();
             var metadataFilter = GetMetadataFilter(liteBuild, specialBuild);

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -87,7 +87,14 @@ namespace PhoneNumbers
 #endif
             using (var input = asm.GetManifestResourceStream(name))
             {
+#if NET35
+		using (var reader = Xml.XmlReader.Create(input))
+		{
+			document = XDocument.Load(reader);
+		}
+#else
                 document = XDocument.Load(input);
+#endif
             }
 
             var metadataCollection = new PhoneMetadataCollection.Builder();

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -91,10 +91,7 @@ namespace PhoneNumbers
             using (var input = asm.GetManifestResourceStream(name))
             {
 #if NET35
-		using (var reader = Xml.XmlReader.Create(input))
-		{
-			document = XDocument.Load(reader);
-		}
+		document = XDocument.Load(new XmlTextReader(input));
 #else
                 document = XDocument.Load(input);
 #endif


### PR DESCRIPTION
Since 6a75a40218b we are not trying to use dll embedded resources.
Instead we are tying to load directly the XDocument from filesystem.

This commit should fix the problem by using embedded dll resources.
Although further tests required to ensure that external resources still work.