### PR TITLE
Check if the underlying dictionary already contains the key before ad…

### DIFF
--- a/csharp/PhoneNumbers/Compat/SortedSet.cs
+++ b/csharp/PhoneNumbers/Compat/SortedSet.cs
@@ -29,6 +29,10 @@ namespace PhoneNumbers
         {
             try
             {
+                if (items.ContainsKey(item))
+                {
+                    return false;
+                }
                 items.Add(item, null);
             }
             catch (ArgumentException)


### PR DESCRIPTION
…ding to prevent ArgumentExceptions being thrown. This affects performance in net35.

This is intended to fix this issue: https://github.com/twcclegg/libphonenumber-csharp/issues/87