### PR TITLE
Add semicolon to singleExtensionSymbolParsing

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -376,7 +376,7 @@ namespace PhoneNumbers
             // For parsing, we are slightly more lenient in our interpretation than for matching. Here we
             // allow a "comma" as a possible extension indicator. When matching, this is hardly ever used to
             // indicate this.
-            var singleExtnSymbolsForParsing = "," + singleExtnSymbolsForMatching;
+            var singleExtnSymbolsForParsing = ",;" + singleExtnSymbolsForMatching;
 
             ExtnPatternsForParsing = CreateExtnPattern(singleExtnSymbolsForParsing);
             ExtnPatternsForMatching = CreateExtnPattern(singleExtnSymbolsForMatching);


### PR DESCRIPTION
To consistent state with https://github.com/google/libphonenumber/blob/f52af239997c35335894206a4a45f44558ee71a0/cpp/src/phonenumbers/phonenumberutil.cc#L687