### PR TITLE
Add functionality to refresh underlying metadata from a stream.

### DIFF
--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -106,7 +106,7 @@ namespace PhoneNumbers
             bool isAlternateFormatsMetadata = false)
         {
 #if NET35
-            var document = XDocument.Load(new XmlTextReader(input));
+            var document = XDocument.Load(new XmlTextReader(metadataStream));
 #else
             var document = XDocument.Load(metadataStream);
 #endif


### PR DESCRIPTION
The purpose of this change is to allow a new instance of a PhoneNumberUtil to be created with a fresh copy of the metadata to allow dynamic updates for validation that don't require a rebuild/restart of the service using it.  
Thanks!