### PR TITLE
feat: fix tests failing when github actions metadata update script runs on a linux machine

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -164,13 +164,7 @@ namespace PhoneNumbers
 
         private static string[] ParseNameFromArchive(ZipArchiveEntry entry)
         {
-            const int expectedLength = 2;
-            var name = entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar);
-            if (name.Length < expectedLength)
-            {
-                name = entry.FullName.Split('.')[0].Split(Path.AltDirectorySeparatorChar);
-            }
-            return name;
+            return entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         private static SortedDictionary<int, HashSet<string>> LoadFileNamesFromManifestResources(Assembly asm, string prefix)

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -144,7 +144,15 @@ namespace PhoneNumbers
                 }
 
                 var name = ParseNameFromArchive(entry);
-                var country = int.Parse(name[1], CultureInfo.InvariantCulture);
+                int country;
+                try
+                {
+                    country = int.Parse(name[1], CultureInfo.InvariantCulture);
+                }
+                catch (FormatException)
+                {
+                    throw new Exception("Failed to parse zipped geocoding file name: " + entry.FullName);
+                }
                 var language = name[0];
                 if (!files.TryGetValue(country, out var languages))
                     files[country] = languages = new HashSet<string>();
@@ -157,20 +165,11 @@ namespace PhoneNumbers
         private static string[] ParseNameFromArchive(ZipArchiveEntry entry)
         {
             const int expectedLength = 2;
-            string[] name;
-            try
+            var name = entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar);
+            if (name.Length < expectedLength)
             {
-                name = entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar);
-                if (name.Length < expectedLength)
-                {
-                    name = entry.FullName.Split('.')[0].Split(Path.AltDirectorySeparatorChar);
-                }
+                name = entry.FullName.Split('.')[0].Split(Path.AltDirectorySeparatorChar);
             }
-            catch (FormatException)
-            {
-                throw new Exception("Failed to parse zipped geocoding file name: " + entry.FullName);
-            }
-
             return name;
         }
 

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -143,16 +143,8 @@ namespace PhoneNumbers
                     continue;
                 }
 
-                var name = entry.FullName.Split('.')[0].Split('\\');
-                int country;
-                try
-                {
-                    country = int.Parse(name[1], CultureInfo.InvariantCulture);
-                }
-                catch (FormatException)
-                {
-                    throw new Exception("Failed to parse zipped geocoding file name: " + entry.FullName);
-                }
+                var name = ParseNameFromArchive(entry);
+                var country = int.Parse(name[1], CultureInfo.InvariantCulture);
                 var language = name[0];
                 if (!files.TryGetValue(country, out var languages))
                     files[country] = languages = new HashSet<string>();
@@ -160,6 +152,26 @@ namespace PhoneNumbers
             }
 
             return files;
+        }
+
+        private static string[] ParseNameFromArchive(ZipArchiveEntry entry)
+        {
+            const int expectedLength = 2;
+            string[] name;
+            try
+            {
+                name = entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar);
+                if (name.Length < expectedLength)
+                {
+                    name = entry.FullName.Split('.')[0].Split(Path.AltDirectorySeparatorChar);
+                }
+            }
+            catch (FormatException)
+            {
+                throw new Exception("Failed to parse zipped geocoding file name: " + entry.FullName);
+            }
+
+            return name;
         }
 
         private static SortedDictionary<int, HashSet<string>> LoadFileNamesFromManifestResources(Assembly asm, string prefix)


### PR DESCRIPTION
[github action run](https://github.com/twcclegg/libphonenumber-csharp/actions/runs/6987957696) is failing due to the path separator, fix the issue by using both `Path.DirectorySeparatorChar` or `Path.AltDirectorySeparatorChar` and ensure zip file is parsed properly

@twcclegg this should fix the issue with the github action i've created

See successful run in my test project - https://github.com/wmundev/test-test-libphonenumber-csharp/actions/runs/6988539197/job/19016203551

See new release created successfully - https://github.com/wmundev/test-test-libphonenumber-csharp/releases/tag/v8.13.26