### PR TITLE
feat: add github action pr builds for building project, and running tests on linux and windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@
 
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
   - package-ecosystem: "nuget"
     directory: "/csharp/PhoneNumbers"
     schedule:

--- a/.github/workflows/build_and_run_unit_tests_linux.yml
+++ b/.github/workflows/build_and_run_unit_tests_linux.yml
@@ -1,0 +1,34 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: build_and_run_unit_tests_linux
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build_and_run_unit_tests_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.x
+      - name: Add zip files required for running tests
+        run: |
+          (cd resources/geocoding; zip -r ../../resources/geocoding.zip *)
+          (cd resources/test/geocoding; zip -r ../../../resources/test/testgeocoding.zip *)
+      - name: Restore dependencies
+        run: dotnet restore
+        working-directory: ./csharp
+      - name: Build solution
+        run: dotnet build --no-restore
+        working-directory: ./csharp
+      - name: Test PhoneNumbers.Test project
+        run: dotnet test --no-build --verbosity normal
+        working-directory: ./csharp/PhoneNumbers.Test

--- a/.github/workflows/build_and_run_unit_tests_linux.yml
+++ b/.github/workflows/build_and_run_unit_tests_linux.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: build_and_run_unit_tests_linux
 
 on:
@@ -29,6 +26,6 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore
         working-directory: ./csharp
-      - name: Test PhoneNumbers.Test project
-        run: dotnet test --no-build --verbosity normal
-        working-directory: ./csharp/PhoneNumbers.Test
+      - name: Test solution targeting dotnet7.0 only
+        run: dotnet test --no-build --verbosity normal -p:TargetFrameworks=net7.0
+        working-directory: ./csharp

--- a/.github/workflows/build_and_run_unit_tests_linux.yml
+++ b/.github/workflows/build_and_run_unit_tests_linux.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build_and_run_unit_tests_linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET

--- a/.github/workflows/build_and_run_unit_tests_windows.yml
+++ b/.github/workflows/build_and_run_unit_tests_windows.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build_and_run_unit_tests_windows:
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET

--- a/.github/workflows/build_and_run_unit_tests_windows.yml
+++ b/.github/workflows/build_and_run_unit_tests_windows.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: build_and_run_unit_tests_windows
 
 on:

--- a/.github/workflows/build_and_run_unit_tests_windows.yml
+++ b/.github/workflows/build_and_run_unit_tests_windows.yml
@@ -1,0 +1,34 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: build_and_run_unit_tests_windows
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build_and_run_unit_tests_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.x
+      - name: Add zip files required for running tests
+        run: |
+          Compress-Archive -Path "resources\geocoding\*" -DestinationPath "resources\geocoding.zip"
+          Compress-Archive -Path "resources\test\geocoding\*" -DestinationPath "resources\test\testgeocoding.zip"
+      - name: Restore dependencies
+        run: dotnet restore
+        working-directory: ./csharp
+      - name: Build solution
+        run: dotnet build --no-restore
+        working-directory: ./csharp
+      - name: Test solution
+        run: dotnet test --no-build --verbosity normal
+        working-directory: ./csharp

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -144,6 +144,11 @@ namespace PhoneNumbers
                 }
 
                 var name = entry.FullName.Split('.')[0].Split('\\');
+                // fallback to directory separator char if we are unable to use the original implementation of splitting the path
+                if (name.Length < 2)
+                {
+                    name = entry.FullName.Split('.')[0].Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                }
                 int country;
                 try
                 {


### PR DESCRIPTION
FYI @twcclegg , these are PR builds to run the unit tests on github actions whenever someone makes a new PR if you are interested in it

github actions are failing because of the zip files delimiter now only supports `\` and not `/`