### PR TITLE
Fix null reference issue in number normalization 

### DIFF
--- a/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
@@ -369,6 +369,14 @@ namespace PhoneNumbers.Test
             Assert.Equal(expectedOutput, PhoneNumberUtil.ConvertAlphaCharactersInNumber(input));
         }
 
+        [Fact]
+        public void TestNormaliseNull()
+        {
+            const string inputNumber = null;
+            var expectedOutput = string.Empty;
+            Assert.Equal(expectedOutput,
+                PhoneNumberUtil.Normalize(inputNumber));
+        }
 
         [Fact]
         public void TestNormaliseRemovePunctuation()

--- a/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
@@ -25,6 +25,11 @@ namespace PhoneNumbers
         /// <returns>The normalized string version of the phone number.</returns>
         public static string Normalize(string number)
         {
+            if (number == null)
+            {
+                return string.Empty;
+            }
+
             Span<char> result = stackalloc char[number.Length];
             var resultLength = 0;
 
@@ -40,6 +45,11 @@ namespace PhoneNumbers
         /// <returns>The normalized string version of the phone number.</returns>
         public static string NormalizeDigitsOnly(string number)
         {
+            if (number == null)
+            {
+                return string.Empty;
+            }
+
             Span<char> result = stackalloc char[number.Length];
             var resultLength = 0;
 
@@ -55,6 +65,11 @@ namespace PhoneNumbers
         /// <returns> the normalized string version of the phone number</returns>
         public static string NormalizeDiallableCharsOnly(string number)
         {
+            if (number == null)
+            {
+                return string.Empty;
+            }
+
             Span<char> result = stackalloc char[number.Length];
             var resultLength = 0;
 
@@ -70,6 +85,11 @@ namespace PhoneNumbers
         /// <returns></returns>
         public static string ConvertAlphaCharactersInNumber(string number)
         {
+            if (number == null)
+            {
+                return string.Empty;
+            }
+
             Span<char> result = stackalloc char[number.Length];
             var resultLength = 0;
 


### PR DESCRIPTION
Restore old / netstandard behavior to .net version to return empty string when null is passed for the number parameter for the normalize functions rather than throw.
Resolves #206 