### PR TITLE
feat: fix issue with NormalizeDiallableCharsOnly function removing hash symbol

### DIFF
--- a/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
@@ -420,6 +420,14 @@ namespace PhoneNumbers.Test
         }
 
         [Fact]
+        public void TestNormaliseStripNonDiallableCharacters()
+        {
+            const string inputNumber = "03*4-56&+1a#234";
+            const string expectedOutput = "03*456+1#234";
+            Assert.Equal(expectedOutput, PhoneNumberUtil.NormalizeDiallableCharsOnly(inputNumber));
+        }
+
+        [Fact]
         public void TestFormatUSNumber()
         {
             Assert.Equal("650 253 0000", phoneUtil.Format(USNumber, PhoneNumberFormat.NATIONAL));

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -97,7 +97,7 @@ namespace PhoneNumbers
         // A map that contains characters that are essential when dialing. That means any of the
         // characters in this map must not be removed from a number when dialling, otherwise the call will
         // not reach the intended destination.
-        private static char MapDiallableChar(char c) => c is >= '0' and <= '9' or '+' or '*' ? c : '\0';
+        private static char MapDiallableChar(char c) => c is >= '0' and <= '9' or '+' or '*' or '#' ? c : '\0';
 
         // For performance reasons, amalgamate both into one map.
         private static char MapAlphaPhone(char c)


### PR DESCRIPTION
See line 190 in the official repo, https://github.com/google/libphonenumber/blob/master/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java#L190

it allows hash instead of removing it