### PR TITLE
feat: fix code coverage not generated for phonenumber.test project and remove old code coverage upload from appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ testgeocoding.zip
 
 # Performance tests artifacts
 csharp/PhoneNumbers.PerformanceTest/BenchmarkDotNet.Artifacts/
+
+# Coverage reports
+coverage/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,16 +24,13 @@ branches:
     - main
 before_build:
   - dotnet restore csharp -s https://api.nuget.org/v3/index.json
-  - choco install opencover.portable
-  - choco install codecov
   - ps: Compress-Archive -Path "resources\geocoding\*" -DestinationPath "resources\geocoding.zip"
   - ps: Compress-Archive -Path "resources\test\geocoding\*" -DestinationPath "resources\test\testgeocoding.zip"
 build_script:
   - dotnet pack -c Release csharp\PhoneNumbers
   - dotnet pack -c Release csharp\PhoneNumbers.Extensions
 test_script:
-  - OpenCover.Console.exe -register:user -target:dotnet.exe -targetargs:"test csharp\PhoneNumbers.sln" -filter:"+[PhoneNumbers]* -[PhoneNumbers.Test]*" -excludebyattribute:*.CompilerGenerated*^ -oldStyle -returntargetcode
-  - codecov -f results.xml
+  - dotnet test csharp/PhoneNumbers.sln --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
 artifacts:
   - path: csharp\PhoneNumbers\bin\Release\libphonenumber-csharp.*
   - path: csharp\PhoneNumbers.Extensions\bin\Release\libphonenumber-csharp.extensions.*

--- a/csharp/PhoneNumbers.Extensions.Test/PhoneNumbers.Extensions.Test.csproj
+++ b/csharp/PhoneNumbers.Extensions.Test/PhoneNumbers.Extensions.Test.csproj
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj
+++ b/csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj
@@ -25,6 +25,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Getting a 
```
Data collection : Unable to find a datacollector with friendly name 'XPlat Code Coverage'.
Data collection : Could not find data collector 'XPlat Code Coverage'
```
error because coverlet.collector not installed in PhoneNumbers.Test project

# Changes
- fix code coverage not generated for phonenumber.test project
- remove old code coverage upload from appveyor
