### PR TITLE
Target .NET 8.0 and drop .NET 7.0

### DIFF
--- a/.github/workflows/build_and_run_unit_tests_linux.yml
+++ b/.github/workflows/build_and_run_unit_tests_linux.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore
         working-directory: ./csharp
-      - name: Test solution targeting dotnet7.0 only
-        run: dotnet test --no-build --verbosity normal -p:TargetFrameworks=net7.0
+      - name: Test solution targeting dotnet8.0 only
+        run: dotnet test --no-build --verbosity normal -p:TargetFrameworks=net8.0
         working-directory: ./csharp

--- a/.github/workflows/build_and_run_unit_tests_linux.yml
+++ b/.github/workflows/build_and_run_unit_tests_linux.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore
         working-directory: ./csharp
-      - name: Test solution targeting dotnet8.0 only
-        run: dotnet test --no-build --verbosity normal -p:TargetFrameworks=net8.0
+      - name: Test solution targeting dotnet7.0 only
+        run: dotnet test --no-build --verbosity normal -p:TargetFrameworks=net7.0
         working-directory: ./csharp

--- a/csharp/PhoneNumbers.Extensions.Test/PhoneNumbers.Extensions.Test.csproj
+++ b/csharp/PhoneNumbers.Extensions.Test/PhoneNumbers.Extensions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netframework4.8;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netframework4.8;net6.0;net8.0</TargetFrameworks>
         <NoWarn>$(NoWarn);1591;CA1014;CA1062;CA1707</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -10,7 +10,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0'">
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
       <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
@@ -7,7 +7,7 @@
         <PackageId>libphonenumber-csharp.extensions</PackageId>
         <VersionPrefix>$(APPVEYOR_BUILD_VERSION)</VersionPrefix>
         <Authors>Thomas Clegg</Authors>
-        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <PackageTags>phonenumber phone libphonenumber e164 e.164 international extensions</PackageTags>
         <PackageProjectUrl>https://github.com/twcclegg/libphonenumber-csharp</PackageProjectUrl>

--- a/csharp/PhoneNumbers.PerformanceTest/PhoneNumbers.PerformanceTest.csproj
+++ b/csharp/PhoneNumbers.PerformanceTest/PhoneNumbers.PerformanceTest.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netframework4.8;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netframework4.8;net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj
+++ b/csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netframework4.8;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netframework4.8;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>PhoneNumbers.Test</AssemblyName>
     <PackageId>PhoneNumbers.Test</PackageId>
     <DebugType>full</DebugType>
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -7,7 +7,7 @@
     <PackageId>libphonenumber-csharp</PackageId>
     <VersionPrefix>$(APPVEYOR_BUILD_VERSION)</VersionPrefix>
     <Authors>Patrick Mézard;Thomas Clegg;Jarrod Alexander;Google;libphonenumber contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <PackageTags>phonenumber phone libphonenumber e164 e.164 international</PackageTags>
     <PackageProjectUrl>https://github.com/twcclegg/libphonenumber-csharp</PackageProjectUrl>
@@ -25,7 +25,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/lib/github-actions-metadata-update.sh
+++ b/lib/github-actions-metadata-update.sh
@@ -113,7 +113,7 @@ cd ${GITHUB_ACTION_WORKING_DIRECTORY}
 cd csharp
 dotnet restore
 dotnet build --no-restore
-dotnet test --no-build --verbosity normal -p:TargetFrameworks=net7.0
+dotnet test --no-build --verbosity normal -p:TargetFrameworks=net8.0
 # Cleanup test dependencies
 rm -rf ${GITHUB_ACTION_WORKING_DIRECTORY}/resources/geocoding.zip
 rm -rf ${GITHUB_ACTION_WORKING_DIRECTORY}/resources/test/testgeocoding.zip


### PR DESCRIPTION
Hello 👋 This PR updates the targeting of the library.

## Changes
- .NET 8.0 is now explicitly targeted by the "main" library. It was already used in tests, but the main one only targeted 6, 7 and .NET Standard 2.0. 
- .NET 7.0 was removed as it [reached the end of life](https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/) in May 2024

Without this, using the library on .NET 8.0 means going over .NET Standard 2.0 which in turn pulls a ton of very old (dating back to 2016) dependencies via [System.IO.Compression](https://www.nuget.org/packages/System.IO.Compression#dependencies-body-tab), some of which even have [CVEs](https://github.com/advisories/GHSA-5f2m-466j-3848) on them.