### PR TITLE
feat: add in dotnet 9 fix for codeql build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
https://github.com/twcclegg/libphonenumber-csharp/actions/runs/11840336347/job/32993909242 is failing because no dotnet 9 is available on that github action

## Changes
- add in dotnet 9 fix for codeql build
