### PR TITLE
fix: port behavior fixes from upstream Java libphonenumber

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -1146,7 +1146,7 @@ namespace PhoneNumbers
                     // found in the input string. However, this doesn't result in a number we can dial. For this
                     // reason, we treat the empty string the same as if it isn't set at all.
                     formattedNumber = numberNoExt.PreferredDomesticCarrierCode.Length > 0
-                        ? formattedNumber = FormatNationalNumberWithPreferredCarrierCode(numberNoExt, "")
+                        ? FormatNationalNumberWithPreferredCarrierCode(numberNoExt, "")
                         // Brazilian fixed line and mobile numbers need to be dialed with a carrier code when
                         // called within Brazil. Without that, most of the carriers won't connect the call.
                         // Because of that, we return an empty string here.
@@ -1189,8 +1189,8 @@ namespace PhoneNumbers
                         // dialling successfully from mobile devices. As we do not have complete information on
                         // special codes and to be consistent with formatting across all phone types we return
                         // the number in international format here.
-                        || (regionCode == "MX" || regionCode == "CL"
-                            || regionCode == "UZ" && isFixedLineOrMobile)
+                        || ((regionCode == "MX" || regionCode == "CL"
+                                || regionCode == "UZ") && isFixedLineOrMobile)
                         && CanBeInternationallyDialled(numberNoExt))
                     {
                         formattedNumber = Format(numberNoExt, PhoneNumberFormat.INTERNATIONAL);
@@ -1230,7 +1230,8 @@ namespace PhoneNumbers
         /// <returns>The formatted phone number in its original number format.</returns>
         public string FormatInOriginalFormat(PhoneNumber number, string regionCallingFrom)
         {
-            if (number.HasRawInput && !HasFormattingPatternForNumber(number))
+            var formatRule = ChooseFormattingPatternForNumber(number);
+            if (number.HasRawInput && formatRule == null)
             {
                 // We check if we have the formatting pattern because without that, we might format the number
                 // as a group without national prefix.
@@ -1274,10 +1275,6 @@ namespace PhoneNumbers
                         formattedNumber = nationalFormat;
                         break;
                     }
-                    var metadata = GetMetadataForRegion(regionCode);
-                    var nationalNumber = GetNationalSignificantNumber(number);
-                    var formatRule =
-                        ChooseFormattingPatternForNumber(metadata.numberFormat_, nationalNumber);
                     // When the format we apply to this number doesn't contain national prefix, we can just
                     // return the national format.
                     // TODO: Refactor the code below with the code in isNationalPrefixPresentIfRequired.
@@ -1344,7 +1341,7 @@ namespace PhoneNumbers
             return false;
         }
 
-        private bool HasFormattingPatternForNumber(PhoneNumber number)
+        private NumberFormat ChooseFormattingPatternForNumber(PhoneNumber number)
         {
             var countryCallingCode = number.CountryCode;
             var phoneNumberRegion = GetRegionCodeForCountryCode(countryCallingCode);
@@ -1352,12 +1349,10 @@ namespace PhoneNumbers
                 GetMetadataForRegionOrCallingCode(countryCallingCode, phoneNumberRegion);
             if (metadata == null)
             {
-                return false;
+                return null;
             }
             var nationalNumber = GetNationalSignificantNumber(number);
-            var formatRule =
-                ChooseFormattingPatternForNumber(metadata.numberFormat_, nationalNumber);
-            return formatRule != null;
+            return ChooseFormattingPatternForNumber(metadata.numberFormat_, nationalNumber);
         }
 
         /// <summary>

--- a/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
 
@@ -534,14 +535,13 @@ namespace PhoneNumbers
 
             var regionCode = GetRegionCodeForCountryCode(countryCode);
             var metadataForRegion = GetMetadataForRegionOrCallingCode(countryCode, regionCode);
-            MaybeAppendFormattedExtension(ref intermediateResult,
-                ref intermediateResultLength,
-                number,
-                metadataForRegion,
-                PhoneNumberFormat.INTERNATIONAL);
+            // Strip any extension already present in the raw input before appending the formatted one.
+            var body = new string(intermediateResult.Slice(0, intermediateResultLength));
+            var bodyBuilder = new StringBuilder(body);
+            MaybeStripExtension(bodyBuilder, body);
+            MaybeAppendFormattedExtension(number, metadataForRegion, PhoneNumberFormat.INTERNATIONAL, bodyBuilder);
 
-            return string.Concat(result1.Slice(0, result1Length),
-                intermediateResult.Slice(0, intermediateResultLength));
+            return string.Concat(result1.Slice(0, result1Length).ToString(), bodyBuilder.ToString());
         }
 
         internal static void NormalizeDigits(ref Span<char> span,

--- a/csharp/PhoneNumbers/PhoneNumberUtil.netstandard.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.netstandard.cs
@@ -408,22 +408,22 @@ namespace PhoneNumbers
                         : metadataForRegionCallingFrom.PreferredInternationalPrefix;
             }
 
-            var formattedNumber = new StringBuilder();
+            var formattedNumber = new StringBuilder(rawInput);
+            var regionCode = GetRegionCodeForCountryCode(countryCode);
+            var metadataForRegion = GetMetadataForRegionOrCallingCode(countryCode, regionCode);
+            // Strip any extension already present in the raw input before appending the formatted one.
+            MaybeStripExtension(formattedNumber, rawInput);
+            MaybeAppendFormattedExtension(number, metadataForRegion, PhoneNumberFormat.INTERNATIONAL, formattedNumber);
             if (internationalPrefixForFormatting.Length > 0)
             {
-                formattedNumber.Append(internationalPrefixForFormatting).Append(' ').Append(countryCode).Append(' ');
+                formattedNumber.Insert(0, ' ').Insert(0, countryCode).Insert(0, ' ').Insert(0, internationalPrefixForFormatting);
             }
             else
             {
                 // Invalid region entered as country-calling-from (so no metadata was found for it) or the
                 // region chosen has multiple international dialling prefixes.
-                formattedNumber.Append(PLUS_SIGN).Append(countryCode).Append(' ');
+                formattedNumber.Insert(0, ' ').Insert(0, countryCode).Insert(0, PLUS_SIGN);
             }
-
-            formattedNumber.Append(rawInput);
-            var regionCode = GetRegionCodeForCountryCode(countryCode);
-            var metadataForRegion = GetMetadataForRegionOrCallingCode(countryCode, regionCode);
-            MaybeAppendFormattedExtension(number, metadataForRegion, PhoneNumberFormat.INTERNATIONAL, formattedNumber);
             return formattedNumber.ToString();
         }
     }


### PR DESCRIPTION
- FormatNumberForMobileDialing: add parens around (MX || CL || UZ) so isFixedLineOrMobile applies to all three regions; previously C# operator precedence caused MX/CL to skip the constraint.
- FormatOutOfCountryKeepingAlphaChars: strip any extension already present in the raw input before appending the formatted extension, preventing duplicate extensions in the output (Java #3724).
- FormatInOriginalFormat: call ChooseFormattingPatternForNumber once and reuse the result instead of recomputing it (Java #3976).
- Drop redundant double-assignment in the BR carrier-code branch.

## Changes
-
