### PR TITLE
perf: enable Compiled regex for dynamic metadata patterns

### DIFF
--- a/csharp/PhoneNumbers.MetadataBuilder/PhoneNumbers.MetadataBuilder.csproj
+++ b/csharp/PhoneNumbers.MetadataBuilder/PhoneNumbers.MetadataBuilder.csproj
@@ -34,6 +34,7 @@
     <Compile Include="..\PhoneNumbers\BuildPrefixMapFromBin.cs" Link="Linked\BuildPrefixMapFromBin.cs" />
     <Compile Include="..\PhoneNumbers\MetadataFilter.cs" Link="Linked\MetadataFilter.cs" />
     <Compile Include="..\PhoneNumbers\PhoneRegex.cs" Link="Linked\PhoneRegex.cs" />
+    <Compile Include="..\PhoneNumbers\InternalRegexOptions.cs" Link="Linked\InternalRegexOptions.cs" />
   </ItemGroup>
 
 </Project>

--- a/csharp/PhoneNumbers/PhoneRegex.cs
+++ b/csharp/PhoneNumbers/PhoneRegex.cs
@@ -37,9 +37,9 @@ namespace PhoneNumbers
         {
             this.pattern = pattern;
 
-            regex = new Lazy<Regex>(() => new Regex(this.pattern, RegexOptions.CultureInvariant), true);
-            allRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})$", RegexOptions.CultureInvariant), true);
-            beginRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})", RegexOptions.CultureInvariant), true);
+            regex = new Lazy<Regex>(() => new Regex(this.pattern, InternalRegexOptions.Default), true);
+            allRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})$", InternalRegexOptions.Default), true);
+            beginRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})", InternalRegexOptions.Default), true);
         }
 
         [Obsolete("This is an internal implementation detail not meant for public use")]


### PR DESCRIPTION
PhoneRegex caches the per-region/per-format patterns loaded from metadata (number formats, national-prefix-for-parsing, leading digits, IDD prefix, etc.) — these are exercised on every Parse / IsValidNumber / Format call. They were created with CultureInvariant only (interpreted) since the 2023 "reduce regex abuse" change.

Switch to InternalRegexOptions.Default (Compiled | CultureInvariant). The cache is bounded (one Regex per unique pattern, ~few thousand max) and entries live for process lifetime, so the per-pattern JIT cost is amortized after first use. Patterns are still constructed lazily, so cold-start cost only materializes for patterns actually exercised. Under NativeAOT, Compiled silently falls back to interpreted, so this change is AOT-safe.

Source-link InternalRegexOptions.cs into MetadataBuilder so its copy of PhoneRegex still compiles.

PhoneNumberWorkflowBenchmark on net9.0 (Apple M3):

  PhoneNumberCount   Baseline    Compiled    Δ
  1000               1.365 ms    1.208 ms    -11.5%
  10000              13.796 ms   11.817 ms   -14.3%
  100000             137.846 ms  118.501 ms  -14.0%

Allocations unchanged. Full test suite (348 tests) passes.

## Changes
-
