### PR TITLE
fix: pin the release tag to the commit just pushed

### DIFF
--- a/lib/github-actions-metadata-update.sh
+++ b/lib/github-actions-metadata-update.sh
@@ -229,12 +229,13 @@ getReleaseDelta() {
 
 # generate_release_notes appends the commit/PR changelog below the links.
 createRelease() {
-    jq -n --arg tag "$2" --arg version "${2#v}" \
+    jq -n --arg tag "$2" --arg version "${2#v}" --arg commit "$3" \
         --arg pkg "${NUGET_PACKAGE_ID}" --arg ext "${NUGET_EXTENSIONS_PACKAGE_ID}" \
         --arg upstream "${UPSTREAM_REPOSITORY}" '
         {
             tag_name: $tag,
             name: $tag,
+            target_commitish: $commit,
             generate_release_notes: true,
             body: (
                 "[\($pkg) \($version)](https://www.nuget.org/packages/\($pkg)/\($version))"
@@ -453,8 +454,10 @@ git -c user.email='<>' -c user.name='libphonenumber-csharp-bot' \
     commit -m "feat: automatic upgrade to ${UPSTREAM_GITHUB_RELEASE_TAG}"
 git push
 
-createRelease "${GITHUB_REPOSITORY}" "${UPSTREAM_GITHUB_RELEASE_TAG}"
-log "created release ${UPSTREAM_GITHUB_RELEASE_TAG}"
+# Tag the commit just pushed, not whatever main's head is by the time github answers.
+RELEASE_COMMIT=$(git rev-parse HEAD)
+createRelease "${GITHUB_REPOSITORY}" "${UPSTREAM_GITHUB_RELEASE_TAG}" "${RELEASE_COMMIT}"
+log "created release ${UPSTREAM_GITHUB_RELEASE_TAG} at ${RELEASE_COMMIT}"
 
 dispatchPublish "${GITHUB_REPOSITORY}" "${UPSTREAM_GITHUB_RELEASE_TAG}"
 log "dispatched ${PUBLISH_WORKFLOW} for ${UPSTREAM_GITHUB_RELEASE_TAG}"


### PR DESCRIPTION
`createRelease` sent no `target_commitish`, so github created the tag at whatever `main`'s head was when it answered the call — not necessarily the metadata commit the script had just pushed and tested. A merge landing in that window would have pulled unrelated commits into the release.

Pass `git rev-parse HEAD` explicitly instead, and log the sha alongside the tag.

Verified: `bash -n` passes and the generated payload carries `target_commitish`. Per the REST docs the field is "[u]nused if the Git tag already exists", so this is inert on any replay of an existing tag.