### PR TITLE
Add offline geocoder benchmarks, and fix the crash they exposed

### DIFF
--- a/.github/workflows/run_performance_tests.yml
+++ b/.github/workflows/run_performance_tests.yml
@@ -94,3 +94,29 @@ jobs:
           path: benchmark-artifact/
           retention-days: 7
           if-no-files-found: error
+
+      # BenchmarkDotNet exits 0 even when a benchmark throws — it reports that row as NA and carries
+      # on. Without this the job stays green while measuring nothing. Runs after the upload so the
+      # partial results are still available for diagnosis.
+      - name: Fail on benchmarks that produced no result
+        run: |
+          failed=0
+          for dir in \
+            "csharp/PhoneNumbers.PerformanceTest/BenchmarkDotNet.Artifacts/results" \
+            "/tmp/base-tree/csharp/PhoneNumbers.PerformanceTest/BenchmarkDotNet.Artifacts/results"
+          do
+            if [ ! -d "${dir}" ]
+            then
+              continue
+            fi
+            if grep -hE '\|[[:space:]]*NA[[:space:]]*\|' "${dir}"/*-report-github.md 2> /dev/null
+            then
+              echo "error: the rows above from ${dir} have no measurement" >&2
+              failed=1
+            fi
+          done
+          if [ "${failed}" -ne 0 ]
+          then
+            exit 1
+          fi
+          echo "every benchmark produced a result"

--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberOfflineGeocoderBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberOfflineGeocoderBenchmark.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace PhoneNumbers.PerformanceTest.Benchmarks
+{
+    /// <summary>
+    /// Geocoding had no benchmark coverage at all. Two measurements: the end-to-end description
+    /// lookup a consumer actually calls, and <see cref="Locale.GetDisplayCountry"/> on its own,
+    /// which isolates the country-name table behind the fallback path.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net10_0)]
+    public class PhoneNumberOfflineGeocoderBenchmark
+    {
+        private PhoneNumberOfflineGeocoder _geocoder = null!;
+        private PhoneNumber[] _numbers = null!;
+        private Locale[] _locales = null!;
+
+        [Params(1000)]
+        public int PhoneNumberCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var phoneNumberUtil = PhoneNumberUtil.GetInstance();
+            _geocoder = PhoneNumberOfflineGeocoder.GetInstance();
+
+            var numbers = new List<PhoneNumber>(PhoneNumberCount);
+            foreach (var benchmarkCase in PhoneNumberBenchmarkData.Create(phoneNumberUtil, PhoneNumberCount))
+            {
+                try
+                {
+                    numbers.Add(phoneNumberUtil.Parse(benchmarkCase.NumberToParse, benchmarkCase.DefaultRegion));
+                }
+                catch (NumberParseException)
+                {
+                    // Measuring geocoding, not exception throwing.
+                }
+            }
+
+            _numbers = numbers.ToArray();
+
+            // One locale per region that actually resolves, so the display-country benchmark walks
+            // the whole table instead of repeatedly hitting one warm entry. Not every phone-metadata
+            // region is an ISO country (AC and TA, for instance), so the resolvable ones are
+            // selected here rather than assumed.
+            _locales = phoneNumberUtil.GetSupportedRegions()
+                .OrderBy(regionCode => regionCode, StringComparer.Ordinal)
+                .Select(regionCode => new Locale("en", regionCode))
+                .Where(locale => locale.GetDisplayCountry("en").Length > 0)
+                .ToArray();
+
+            // Warm the lazily-loaded prefix maps so the benchmarks measure steady-state lookups.
+            foreach (var number in _numbers)
+            {
+                _geocoder.GetDescriptionForNumber(number, Locale.English);
+            }
+        }
+
+        [Benchmark]
+        public int GetDescriptionForNumber()
+        {
+            var checksum = 0;
+            for (var i = 0; i < _numbers.Length; i++)
+                checksum += _geocoder.GetDescriptionForNumber(_numbers[i], Locale.English).Length;
+            return checksum;
+        }
+
+        [Benchmark]
+        public int GetDisplayCountry()
+        {
+            var checksum = 0;
+            for (var i = 0; i < _locales.Length; i++)
+                checksum += _locales[i].GetDisplayCountry("en").Length;
+            return checksum;
+        }
+    }
+}

--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberOfflineGeocoderBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberOfflineGeocoderBenchmark.cs
@@ -44,9 +44,9 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             _numbers = numbers.ToArray();
 
             // One locale per region that actually resolves, so the display-country benchmark walks
-            // the whole table instead of repeatedly hitting one warm entry. Not every phone-metadata
-            // region is an ISO country (AC and TA, for instance), so the resolvable ones are
-            // selected here rather than assumed.
+            // the whole table instead of repeatedly hitting one warm entry. AC and XK are phone
+            // regions with no localised name, and they return empty rather than resolving, so the
+            // Length check drops them.
             _locales = phoneNumberUtil.GetSupportedRegions()
                 .OrderBy(regionCode => regionCode, StringComparer.Ordinal)
                 .Select(regionCode => new Locale("en", regionCode))

--- a/csharp/PhoneNumbers.PerformanceTest/README.md
+++ b/csharp/PhoneNumbers.PerformanceTest/README.md
@@ -32,6 +32,9 @@ Other available benchmarks:
   with phone numbers embedded between filler sentences.
 - `*ParsingHelpersBenchmark*` — `PhoneNumberUtil.ExtractPossibleNumber` measured separately
   for clean inputs (no leading junk) and inputs that force the strip path.
+- `*PhoneNumberOfflineGeocoderBenchmark*` — `PhoneNumberOfflineGeocoder.GetDescriptionForNumber`
+  end-to-end, plus `Locale.GetDisplayCountry` on its own to isolate the country-name table that
+  backs the fallback path when a number has no finer-grained area description.
 - `*ColdStartBenchmark*` — cost a consumer pays the first time they touch the library: bare
   `PhoneNumberUtil` construction, construction plus lazy-load of every region's metadata,
   and an isolated first-region lookup. Uses BDN's `RunStrategy.ColdStart` with

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberOfflineGeocoder.cs
@@ -33,6 +33,17 @@ namespace PhoneNumbers.Test
             Assert.Equal(string.Empty, new Locale("en", string.Empty).GetDisplayCountry("abc"));
         }
 
+        [Theory]
+        // Phone-metadata regions that are not ISO countries, so they have no localised name at all.
+        // These used to throw KeyNotFoundException out of the geocoder.
+        [InlineData("AC")]
+        [InlineData("XK")]
+        public void GetDisplayCountry_WhenCountryHasNoLocalisedName_ShouldReturnAnEmptyDisplayCountry(
+            string regionCode)
+        {
+            Assert.Equal(string.Empty, new Locale("en", regionCode).GetDisplayCountry("en"));
+        }
+
         [Fact]
         public void GetDisplayCountry_WhenUnknownLanguage_ShouldReturnADefaultDisplayCountry()
         {

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -67,11 +67,17 @@ namespace PhoneNumbers
 
         private static string GetCountryName(string country, string language)
         {
-            var names = LocaleData.Data[country];
+            // Not every phone-metadata region is an ISO country, so some have no entry at all: AC
+            // (calling code 247) and XK are both reachable here via GetRegionDisplayName. Returning
+            // null lets the caller run its language fallback and end up with an empty description,
+            // which is what GetDescriptionForNumber documents for a region it cannot name.
+            if (!LocaleData.Data.TryGetValue(country, out var names))
+                return null;
             if (!names.TryGetValue(language, out var name))
                 return null;
+            // A leading '*' marks a name shared with another language, stored once and pointed at.
             if (name.Length > 0 && name[0] == '*')
-                return names[name.Substring(1)];
+                return names.TryGetValue(name.Substring(1), out var sharedName) ? sharedName : null;
             return name;
         }
     }


### PR DESCRIPTION
`PhoneNumberOfflineGeocoder` had no benchmark coverage, so geocoding regressions are invisible. The
first run of the new benchmarks immediately found a crash bug and a hole in the perf gate, so this is
now four commits.

**`test: add benchmarks for the offline geocoder`**

- **`GetDescriptionForNumber`** — end-to-end over the standard benchmark data set, warmed so it
  measures steady-state lookups rather than lazy prefix-map loading.
- **`GetDisplayCountry`** — one locale per resolvable region, isolating the country-name table behind
  the fallback used when a number has no finer-grained area description.

The second exists because that path has a concrete, non-breaking inefficiency worth measuring:
`Locale.GetDisplayCountry` walks a four-step language fallback and re-probes
`LocaleData.Data[country]` on every step, where one probe would do.

**`fix: stop the geocoder throwing for regions with no localised name`**

`GetCountryName` indexed `LocaleData.Data[country]` unguarded. `LocaleData` is generated from
`java.util.Locale.getISOCountries()`, but **AC** (calling code 247) and **XK** are phone-metadata
regions that aren't ISO countries, so they have no entry. `GetRegionDisplayName` only guards `null`,
`ZZ` and `001`, so:

```
GetDescriptionForNumber(+247…) → GetCountryNameForNumber → GetRegionDisplayName("AC")
  → Locale.GetDisplayCountry → LocaleData.Data["AC"] → KeyNotFoundException
```

A public API throwing on valid input, and a porting divergence — Java's `getDisplayCountry` falls
back to the region code and never throws. Now returns null so the caller's language fallback runs and
the result is an empty description, which is what `GetDescriptionForNumber` already documents for a
region it can't name. The dedup-pointer lookup (`names[name.Substring(1)]`) got the same treatment.

The benchmark found this by accident: its setup called `GetDisplayCountry` to filter unresolvable
regions and died on `AC`.

**`ci: fail the perf job when a benchmark produces no result`**

The bug above did not fail CI. BenchmarkDotNet exits 0 when a benchmark throws — it prints `NA` for
that row and carries on — so `run_performance_tests` passed in 10m11s while measuring nothing:

```
| GetDescriptionForNumber | 1000 | NA | NA |
| GetDisplayCountry       | 1000 | NA | NA |
```

The job now scans both result sets for rows with no measurement and fails, after the artifact upload
so partial results stay available.

---

Landing separately from any geocoder optimisation so the base commit has a counterpart to compare
against — a benchmark added in the same PR as the change it measures reports nothing, because the
comparison runs the base commit's suite against the branch's.
