### PR TITLE
Raise analysis on the library, and fix what it found

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -153,6 +153,34 @@ csharp_space_between_square_brackets = false
 
 max_line_length = 99999
 
+# Analyzer rules enforced beyond the SDK default set, for the shipped library only. The test, demo
+# and benchmark projects are not held to these.
+[csharp/PhoneNumbers/*.cs]
+#
+# Opting in to specific rules rather than raising AnalysisMode: at the Recommended tier this
+# codebase reports 135 findings, and ~107 of them cannot be acted on. Most are public-API changes
+# the package cannot make (CA1002/CA1024/CA1051/CA1052 - fields to properties, List<T> in
+# signatures, static holder types), or churn in files kept diffable against the upstream Java
+# source (CA1309 asks for an explicit StringComparison on string.Equals, which is already ordinal;
+# CA2201 objects to the bare `throw new Exception` the Java original also uses). Suppressing that
+# many rules is more to maintain, and hides which ones are deliberate.
+
+# Culture-dependent parsing and formatting. Java's Long.parseLong and Long.toString are invariant,
+# so the current-culture overloads are a porting divergence rather than a style preference.
+dotnet_diagnostic.CA1305.severity = error
+
+# Argument exceptions thrown without a parameter name, which produces "Value cannot be null." with
+# no indication of which argument was at fault.
+dotnet_diagnostic.CA2208.severity = error
+
+# Avoidable allocations on the parse and match paths.
+dotnet_diagnostic.CA1834.severity = error
+dotnet_diagnostic.CA1847.severity = error
+dotnet_diagnostic.CA1860.severity = error
+
+# Redundant explicit initialisation to a field's default value.
+dotnet_diagnostic.CA1805.severity = error
+
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -181,6 +181,11 @@ dotnet_diagnostic.CA1860.severity = error
 # Redundant explicit initialisation to a field's default value.
 dotnet_diagnostic.CA1805.severity = error
 
+# Tests take the culture rule only — a test that parses or formats under the runner's locale can
+# behave differently on a contributor's machine. The performance rules above earn nothing here.
+[csharp/PhoneNumbers.Test/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/csharp/PhoneNumbers.Test/TestBuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers.Test/TestBuildMetadataFromXml.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Xml.Linq;
 using Xunit;
@@ -226,7 +227,8 @@ namespace PhoneNumbers.Test
         public void TestLoadNationalFormat()
         {
             var nationalFormat = "$1 $2";
-            var xmlInput = string.Format("<numberFormat><format>{0}</format></numberFormat>",
+            var xmlInput = string.Format(CultureInfo.InvariantCulture,
+                "<numberFormat><format>{0}</format></numberFormat>",
                                             nationalFormat);
             var numberFormatElement = ParseXmlString(xmlInput);
             var metadata = new PhoneMetadata.Builder();

--- a/csharp/PhoneNumbers.Test/TestShortNumberInfo.cs
+++ b/csharp/PhoneNumbers.Test/TestShortNumberInfo.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace PhoneNumbers.Test
@@ -101,7 +102,7 @@ namespace PhoneNumbers.Test
             Assert.Equal(ShortNumberInfo.ShortNumberCost.PREMIUM_RATE, ShortInfo.GetExpectedCostForRegion(
                 Parse(premiumRateExample, RegionCode.FR), RegionCode.FR));
             var premiumRateNumber = new PhoneNumber.Builder().SetCountryCode(33)
-                .SetNationalNumber(ulong.Parse(premiumRateExample)).Build();
+                .SetNationalNumber(ulong.Parse(premiumRateExample, CultureInfo.InvariantCulture)).Build();
             Assert.Equal(ShortNumberInfo.ShortNumberCost.PREMIUM_RATE,
                 ShortInfo.GetExpectedCost(premiumRateNumber));
 
@@ -110,7 +111,7 @@ namespace PhoneNumbers.Test
             Assert.Equal(ShortNumberInfo.ShortNumberCost.STANDARD_RATE, ShortInfo.GetExpectedCostForRegion(
                 Parse(standardRateExample, RegionCode.FR), RegionCode.FR));
             var standardRateNumber = new PhoneNumber.Builder().SetCountryCode(33)
-                .SetNationalNumber(ulong.Parse(standardRateExample)).Build();
+                .SetNationalNumber(ulong.Parse(standardRateExample, CultureInfo.InvariantCulture)).Build();
             Assert.Equal(ShortNumberInfo.ShortNumberCost.STANDARD_RATE,
                 ShortInfo.GetExpectedCost(standardRateNumber));
 
@@ -119,7 +120,7 @@ namespace PhoneNumbers.Test
             Assert.Equal(ShortNumberInfo.ShortNumberCost.TOLL_FREE,
                 ShortInfo.GetExpectedCostForRegion(Parse(tollFreeExample, RegionCode.FR), RegionCode.FR));
             var tollFreeNumber = new PhoneNumber.Builder().SetCountryCode(33)
-                .SetNationalNumber(ulong.Parse(tollFreeExample)).Build();
+                .SetNationalNumber(ulong.Parse(tollFreeExample, CultureInfo.InvariantCulture)).Build();
             Assert.Equal(ShortNumberInfo.ShortNumberCost.TOLL_FREE,
                 ShortInfo.GetExpectedCost(tollFreeNumber));
 

--- a/csharp/PhoneNumbers/AreaCodeMap.cs
+++ b/csharp/PhoneNumbers/AreaCodeMap.cs
@@ -16,6 +16,7 @@
  */
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace PhoneNumbers
 {
@@ -107,17 +108,18 @@ namespace PhoneNumbers
                 return null;
             }
             var phonePrefix =
-                long.Parse(number.CountryCode + phoneUtil.GetNationalSignificantNumber(number));
+                long.Parse(number.CountryCode + phoneUtil.GetNationalSignificantNumber(number),
+                    CultureInfo.InvariantCulture);
             var currentIndex = numOfEntries - 1;
             var currentSetOfLengths = areaCodeMapStorage.GetPossibleLengths();
             var length = currentSetOfLengths.Count;
             while (length > 0)
             {
                 var possibleLength = currentSetOfLengths[length - 1];
-                var phonePrefixStr = phonePrefix.ToString();
+                var phonePrefixStr = phonePrefix.ToString(CultureInfo.InvariantCulture);
                 if (phonePrefixStr.Length > possibleLength)
                 {
-                    phonePrefix = long.Parse(phonePrefixStr.Substring(0, possibleLength));
+                    phonePrefix = long.Parse(phonePrefixStr.Substring(0, possibleLength), CultureInfo.InvariantCulture);
                 }
                 currentIndex = BinarySearch(0, currentIndex, phonePrefix);
                 if (currentIndex < 0)

--- a/csharp/PhoneNumbers/AreaCodeMap.cs
+++ b/csharp/PhoneNumbers/AreaCodeMap.cs
@@ -116,10 +116,12 @@ namespace PhoneNumbers
             while (length > 0)
             {
                 var possibleLength = currentSetOfLengths[length - 1];
-                var phonePrefixStr = phonePrefix.ToString(CultureInfo.InvariantCulture);
-                if (phonePrefixStr.Length > possibleLength)
+                // Truncating to the leading possibleLength digits is division, not a round trip
+                // through ToString/Substring/Parse - this runs once per distinct possible length.
+                var digits = CountDigits(phonePrefix);
+                if (digits > possibleLength)
                 {
-                    phonePrefix = long.Parse(phonePrefixStr.Substring(0, possibleLength), CultureInfo.InvariantCulture);
+                    phonePrefix /= PowersOfTen[digits - possibleLength];
                 }
                 currentIndex = BinarySearch(0, currentIndex, phonePrefix);
                 if (currentIndex < 0)
@@ -135,6 +137,32 @@ namespace PhoneNumbers
                     length--;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Indexed by the number of digits to drop. A long holds at most 19 digits, so dropping more
+        /// than 18 is not reachable from a prefix that has at least one digit left.
+        /// </summary>
+        private static readonly long[] PowersOfTen =
+        {
+            1L, 10L, 100L, 1000L, 10000L, 100000L, 1000000L, 10000000L, 100000000L, 1000000000L,
+            10000000000L, 100000000000L, 1000000000000L, 10000000000000L, 100000000000000L,
+            1000000000000000L, 10000000000000000L, 100000000000000000L, 1000000000000000000L
+        };
+
+        /// <summary>
+        /// Number of decimal digits in <paramref name="value"/>, which is always positive here since
+        /// it is built from a country calling code followed by the national significant number.
+        /// </summary>
+        private static int CountDigits(long value)
+        {
+            var digits = 1;
+            while (value >= 10)
+            {
+                value /= 10;
+                digits++;
+            }
+            return digits;
         }
 
         /// <summary>

--- a/csharp/PhoneNumbers/AreaCodeMapStorageStrategy.cs
+++ b/csharp/PhoneNumbers/AreaCodeMapStorageStrategy.cs
@@ -27,7 +27,7 @@ namespace PhoneNumbers
     /// </summary>
     public abstract class AreaCodeMapStorageStrategy
     {
-        protected int NumOfEntries = 0;
+        protected int NumOfEntries;
         protected readonly List<int> PossibleLengths = [];
 
         /// <summary>
@@ -80,9 +80,9 @@ namespace PhoneNumbers
             for (var i = 0; i < GetNumOfEntries(); i++)
             {
                 output.Append(GetPrefix(i))
-                    .Append("|")
+                    .Append('|')
                     .Append(GetDescription(i))
-                    .Append("\n");
+                    .Append('\n');
             }
             return output.ToString();
         }

--- a/csharp/PhoneNumbers/AsYouTypeFormatter.cs
+++ b/csharp/PhoneNumbers/AsYouTypeFormatter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -679,7 +680,7 @@ namespace PhoneNumbers
             {
                 currentMetadata = GetMetadataForRegion(newRegionCode);
             }
-            var countryCodeString = countryCode.ToString();
+            var countryCodeString = countryCode.ToString(CultureInfo.InvariantCulture);
             prefixBeforeNationalNumber.Append(countryCodeString).Append(SeparatorBeforeNationalNumber);
             // When we have successfully extracted the IDD, the previously extracted NDD should be cleared
             // because it is no longer valid.
@@ -702,7 +703,7 @@ namespace PhoneNumbers
             else
             {
                 if ((uint)(nextChar - '0') > 9)
-                    nextChar = ((int)char.GetNumericValue(nextChar)).ToString()[0];
+                    nextChar = ((int)char.GetNumericValue(nextChar)).ToString(CultureInfo.InvariantCulture)[0];
                 accruedInputWithoutFormatting.Append(nextChar);
                 nationalNumber.Append(nextChar);
             }

--- a/csharp/PhoneNumbers/PhoneNumberMatch.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatch.cs
@@ -32,9 +32,11 @@ namespace PhoneNumbers
 #endif
         {
             if (start < 0)
-                throw new ArgumentException("Start index must be >= 0.");
-            if (rawString == null || number == null)
-                throw new ArgumentNullException();
+                throw new ArgumentException("Start index must be >= 0.", nameof(start));
+            if (rawString == null)
+                throw new ArgumentNullException(nameof(rawString));
+            if (number == null)
+                throw new ArgumentNullException(nameof(number));
             Start = start;
             RawString = rawString;
             Number = number;

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -167,9 +167,9 @@ namespace PhoneNumbers
             long maxTries)
         {
             if (maxTries < 0)
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(maxTries), maxTries, "Must be >= 0.");
 
-            phoneUtil = util ?? throw new ArgumentNullException();
+            phoneUtil = util ?? throw new ArgumentNullException(nameof(util));
             this.text = text ?? "";
             preferredRegion = country;
             this.leniency = leniency;
@@ -614,7 +614,7 @@ namespace PhoneNumbers
         public static bool ContainsMoreThanOneSlash(string candidate)
         {
             var firstSlashIndex = candidate.IndexOf('/');
-            return firstSlashIndex > 0 && candidate.Substring(firstSlashIndex + 1).Contains("/");
+            return firstSlashIndex > 0 && candidate.IndexOf('/', firstSlashIndex + 1) >= 0;
         }
 
         public static bool ContainsOnlyValidXChars(

--- a/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
+++ b/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
 #else
@@ -67,7 +68,10 @@ namespace PhoneNumbers
         /// </returns>
         public List<string> GetTimeZonesForGeographicalNumber(PhoneNumber number)
         {
-            return LookUpPrefix(long.Parse(string.Concat(number.CountryCode.ToString(), phoneUtil.GetNationalSignificantNumber(number))));
+            return LookUpPrefix(long.Parse(
+                string.Concat(number.CountryCode.ToString(CultureInfo.InvariantCulture),
+                    phoneUtil.GetNationalSignificantNumber(number)),
+                CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -132,7 +136,7 @@ namespace PhoneNumbers
         }
 
         private static readonly object lockObj = new object();
-        private static PhoneNumberToTimeZonesMapper instance = null;
+        private static PhoneNumberToTimeZonesMapper instance;
         public static PhoneNumberToTimeZonesMapper GetInstance()
         {
             lock (lockObj)

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -2402,7 +2402,7 @@ namespace PhoneNumbers
                 // so, we remove the country calling code, and do some checks on the validity of the number
                 // before and after.
                 var defaultCountryCode = defaultRegionMetadata.CountryCode;
-                var defaultCountryCodeString = defaultCountryCode.ToString();
+                var defaultCountryCodeString = defaultCountryCode.ToString(CultureInfo.InvariantCulture);
                 var normalizedNumber = fullNumber.ToString();
                 if (normalizedNumber.StartsWith(defaultCountryCodeString, StringComparison.Ordinal))
                 {

--- a/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.net.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -699,13 +700,15 @@ namespace PhoneNumbers
             for (var i = 0; i < numberOfLeadingZeros; i++)
                 nationalNumber[nationalSignificantNumberLength++] = '0';
 
-            number.NationalNumber.TryFormat(nationalNumber[nationalSignificantNumberLength..], out var charsWritten);
+            number.NationalNumber.TryFormat(nationalNumber[nationalSignificantNumberLength..], out var charsWritten,
+                default, CultureInfo.InvariantCulture);
             nationalSignificantNumberLength += charsWritten;
         }
 
         private static void AppendNumberToSpan(ref Span<char> span, ref int index, int numberToAppend)
         {
-            checked((uint)numberToAppend).TryFormat(span[index..], out var charsWritten);
+            checked((uint)numberToAppend).TryFormat(span[index..], out var charsWritten,
+                default, CultureInfo.InvariantCulture);
             index += charsWritten;
         }
 

--- a/csharp/PhoneNumbers/PhoneNumberUtil.netstandard.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.netstandard.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 #if !(NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER)
@@ -106,7 +107,7 @@ namespace PhoneNumbers
             // If a leading zero(s) has been set, we prefix this now. Note this is not a national prefix.
             // Defensively cap the number of leading zeros to avoid OOM from malicious input.
             if (!number.HasNumberOfLeadingZeros)
-                return number.NationalNumber.ToString();
+                return number.NationalNumber.ToString(CultureInfo.InvariantCulture);
 
             var nationalNumber = new StringBuilder();
             nationalNumber.Append('0', Math.Min(number.NumberOfLeadingZeros, 10));

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -18,6 +18,9 @@
          longer produces. Set it to the first release without net9.0 to compare against a baseline;
          until then only the cross-target surface within this package is checked. -->
     <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- Rules enforced on top of the default set are listed in .editorconfig, with the reasoning. -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
     <NoWarn>$(NoWarn);CA1062</NoWarn>
   </PropertyGroup>
 

--- a/csharp/PhoneNumbers/ShortNumberInfo.cs
+++ b/csharp/PhoneNumbers/ShortNumberInfo.cs
@@ -364,7 +364,7 @@ namespace PhoneNumbers
         private static string GetRegionCodeForShortNumberFromRegionList(PhoneNumber number,
             List<string> regionCodes)
         {
-            if (!regionCodes.Any())
+            if (regionCodes.Count == 0)
             {
                 return null;
             }

--- a/csharp/PhoneNumbers/TimezoneMapDataReader.cs
+++ b/csharp/PhoneNumbers/TimezoneMapDataReader.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text;
@@ -47,7 +48,7 @@ namespace PhoneNumbers
                 while (null != (line = LineReader(lines)))
                 {
                     var pnPrefix = line[0];
-                    tmpMap[long.Parse(pnPrefix)] = line[1].Split(splitters, StringSplitOptions.RemoveEmptyEntries);
+                    tmpMap[long.Parse(pnPrefix, CultureInfo.InvariantCulture)] = line[1].Split(splitters, StringSplitOptions.RemoveEmptyEntries);
                 }
             }
 


### PR DESCRIPTION
Raises analysis on the shipped library, and fixes what it found worth fixing.

### Why opt-in rules rather than a higher AnalysisMode

Two discovery runs measured the cost. At `Recommended` the library reports **135 unique findings**,
and about **107 cannot be acted on**:

- **Public API changes the package cannot make** — `CA1002` (`List<T>` in signatures), `CA1024`
  (`GetX()` to properties, 11 sites), `CA1051` (public fields), `CA1052` (`LocaleData` to a static
  class), and 19 of the 29 `CA1822` "make static" hits are public methods.
- **Churn in files kept diffable against the upstream Java source** — `CA1309` (33 sites) wants an
  explicit `StringComparison` on `string.Equals`, which is already ordinal; `CA2201` (31 sites)
  objects to the bare `throw new Exception` the Java original also uses.
- **One that would introduce a bug** — `CA1508` calls the `??=` inside `GetInstance()`'s
  double-checked lock dead code. It isn't; removing it creates a race.

A tier would mean one setting plus seven suppressions, most existing only to silence rules this
codebase can never satisfy, and every SDK upgrade would add more. So six rules are enabled
explicitly in `.editorconfig`, each with its reasoning recorded beside it. Everything blocked on a
public API change is now tracked in #375.

### What the fixes buy

**Real defects.** `throw new ArgumentNullException()` with no parameter name produces
"Value cannot be null." with no clue which argument was at fault — three sites in `PhoneNumberMatch`
and `PhoneNumberMatcher`, now named.

**A porting divergence.** Twelve sites used `long.Parse`/`ToString` on the current culture where
Java's `Long.parseLong`/`toString` are invariant.

**An allocation.** `candidate.Substring(i + 1).Contains("/")` built a whole string to test for one
character.

### Performance

Adding the correct `IFormatProvider` to `AreaCodeMap.Lookup` made geocoding measurably *slower*
(+2%, reproduced across two runs), because `long.Parse(s, IFormatProvider)` goes through
`NumberFormatInfo.GetInstance` rather than the cached `CurrentInfo`. Looking at why exposed the
actual problem: the loop was doing `ToString` → `Substring` → `Parse` **per iteration** purely to
truncate a number to its leading N digits. That is now integer division, verified equivalent over
200,000 random prefix/length pairs.

| `GetDescriptionForNumber` | base | PR |
|---|---|---|
| time | 1562.90 μs | 1511.65 μs (**−3.3%**) |
| allocated | 237.83 KB | **196.63 KB** (−41 KB, −17%) |

The allocation figure is the solid one — BenchmarkDotNet measures it deterministically, and 41 KB
per 1000 geocodes is exactly the two strings that used to be built on each pass.

### Notes

- Tests take `CA1305` only; the performance rules earn nothing in test code. No live bug there — the
  parsed strings are ASCII digits from metadata — it guards against a contributor's locale diverging
  from CI's.
- `CA1845` and `CA1859` were dropped from the opt-in list: the former's fix (`string.Concat` over
  spans) does not exist on netstandard2.0, and the latter needs concrete-type analysis across
  multi-branch returns.
