### PR TITLE
Read the flyweight map buffer from an array instead of a stream

### DIFF
--- a/csharp/PhoneNumbers.Test/TestAreaCodeMap.cs
+++ b/csharp/PhoneNumbers.Test/TestAreaCodeMap.cs
@@ -99,6 +99,36 @@ namespace PhoneNumbers.Test
         }
 
         [Fact]
+        public void TestFlyweightStorageRoundTripsShortSizedPrefixes()
+        {
+            var mapStorage = new FlyweightMapStorage();
+            mapStorage.ReadFromSortedMap(CreateFlyweightStorageMapCandidate());
+
+            Assert.Equal("1212|New York\n1213|New York\n1214|New York\n1480|Arizona\n",
+                mapStorage.ToString());
+        }
+
+        [Fact]
+        public void TestFlyweightStorageRoundTripsIntSizedPrefixes()
+        {
+            // Prefixes past short range, so the buffer stores them as 32-bit words rather than 16.
+            var sortedMap = new SortedDictionary<int, string>
+            {
+                [121212345] = "New York",
+                [121212346] = "New York",
+                [148034434] = "Arizona",
+                [148034435] = "Arizona"
+            };
+
+            var mapStorage = new FlyweightMapStorage();
+            mapStorage.ReadFromSortedMap(sortedMap);
+
+            Assert.Equal(
+                "121212345|New York\n121212346|New York\n148034434|Arizona\n148034435|Arizona\n",
+                mapStorage.ToString());
+        }
+
+        [Fact]
         public void TestGetSmallerMapStorageChoosesDefaultImpl_ShouldImplementToStringWithTheRightFormat()
         {
             var mapStorage = new AreaCodeMap().GetSmallerMapStorage(CreateDefaultStorageMapCandidate());

--- a/csharp/PhoneNumbers/FlyweightMapStorage.cs
+++ b/csharp/PhoneNumbers/FlyweightMapStorage.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace PhoneNumbers
@@ -160,46 +159,52 @@ namespace PhoneNumbers
             return wordSize == ShortNumBytes ? buffer.GetShort(index) : buffer.GetInt(index);
         }
 
-        private class ByteBuffer
+        /// <summary>
+        /// Fixed-size scratch buffer of 16- and 32-bit words. Reads land on the binary-search path in
+        /// <see cref="AreaCodeMap.Lookup"/>, so each one is a pair of array reads rather than a stream
+        /// seek through a BinaryReader. Byte order is little-endian, matching what the BinaryWriter
+        /// this replaced produced; the buffer never leaves the process, so only self-consistency
+        /// actually matters.
+        /// </summary>
+        private sealed class ByteBuffer
         {
-            private readonly BinaryReader reader;
-            private readonly MemoryStream stream;
-            private readonly BinaryWriter writer;
+            private readonly byte[] bytes;
 
             public ByteBuffer(int size)
             {
-                stream = new MemoryStream(new byte[size]);
-                reader = new BinaryReader(stream);
-                writer = new BinaryWriter(stream);
+                bytes = new byte[size];
             }
 
             public void PutShort(int offset, short value)
             {
-                stream.Seek(offset, SeekOrigin.Begin);
-                writer.Write(value);
+                bytes[offset] = (byte)value;
+                bytes[offset + 1] = (byte)(value >> 8);
             }
 
             public void PutInt(int offset, int value)
             {
-                stream.Seek(offset, SeekOrigin.Begin);
-                writer.Write(value);
+                bytes[offset] = (byte)value;
+                bytes[offset + 1] = (byte)(value >> 8);
+                bytes[offset + 2] = (byte)(value >> 16);
+                bytes[offset + 3] = (byte)(value >> 24);
             }
 
             public short GetShort(int offset)
             {
-                stream.Seek(offset, SeekOrigin.Begin);
-                return reader.ReadInt16();
+                return (short)(bytes[offset] | (bytes[offset + 1] << 8));
             }
 
             public int GetInt(int offset)
             {
-                stream.Seek(offset, SeekOrigin.Begin);
-                return reader.ReadInt32();
+                return bytes[offset]
+                    | (bytes[offset + 1] << 8)
+                    | (bytes[offset + 2] << 16)
+                    | (bytes[offset + 3] << 24);
             }
 
             public int GetCapacity()
             {
-                return stream.Capacity;
+                return bytes.Length;
             }
         }
     }


### PR DESCRIPTION
`FlyweightMapStorage.ByteBuffer` held a `MemoryStream` plus a `BinaryReader` and a `BinaryWriter`
purely to read 16- and 32-bit words out of a `byte[]`. Every read was a `Seek` followed by a
`BinaryReader` call.

Those reads are on the binary-search path: `AreaCodeMap.Lookup` calls `ReadWordFromBuffer` once per
probe, so a geocode does roughly log2(n) of them. They are now a pair of array reads.

Also drops three objects per buffer, two buffers per storage, one storage per (language, calling code)
prefix map — and removes the `CA1001` finding from #374 (the type owned disposable fields and was not
disposable; nothing actually leaked, since a `MemoryStream` over a `byte[]` has no unmanaged
resources, but the streams have no reason to exist).

Byte order stays little-endian to match what `BinaryWriter` produced. The buffer never leaves the
process so only self-consistency matters, but keeping the order avoids surprises.

Two tests cover the round-trip through both word sizes — `FlyweightMapStorage` and
`ReadFromSortedMap` are public, so they target that storage directly rather than depending on the
size heuristic that picks between storage strategies.
