### PR TITLE
Reuse the parse scratch buffers per thread

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -2743,7 +2743,7 @@ namespace PhoneNumbers
             if (numberToParse.Length > MAX_INPUT_STRING_LENGTH)
                 throw new NumberParseException(ErrorType.TOO_LONG, "The string supplied was too long to parse.");
 
-            var nationalNumber = new StringBuilder();
+            var nationalNumber = StringBuilderCache.Acquire(numberToParse.Length);
             BuildNationalNumberForParsing(numberToParse, nationalNumber);
 
             var nationalNumberString = nationalNumber.ToString();
@@ -2772,7 +2772,7 @@ namespace PhoneNumbers
             var regionMetadata = GetMetadataForRegion(defaultRegion);
             // Check to see if the number is given in international format so we know whether this number is
             // from the default region or not.
-            var normalizedNationalNumber = new StringBuilder();
+            var normalizedNationalNumber = StringBuilderCache.Acquire(numberToParse.Length);
             int countryCode;
             try
             {
@@ -2857,6 +2857,10 @@ namespace PhoneNumbers
 
             SetItalianLeadingZerosForPhoneNumber(normalizedNationalNumberString, phoneNumber);
             phoneNumber.NationalNumber = ulong.Parse(normalizedNationalNumberString, CultureInfo.InvariantCulture);
+
+            // Only on the way out: the throw paths above leave the buffers to the collector.
+            StringBuilderCache.Release(nationalNumber);
+            StringBuilderCache.Release(normalizedNationalNumber);
         }
 
         /// <summary>

--- a/csharp/PhoneNumbers/StringBuilderCache.cs
+++ b/csharp/PhoneNumbers/StringBuilderCache.cs
@@ -1,0 +1,61 @@
+#nullable disable
+using System;
+using System.Text;
+
+namespace PhoneNumbers
+{
+    /// <summary>
+    /// Per-thread reuse for the two scratch buffers a parse needs. ParseHelper allocated a
+    /// StringBuilder for the national number and another for its normalized form on every call, which
+    /// together accounted for roughly half of what a parse allocated.
+    /// <para>
+    /// Acquire clears the slot it takes from, so a nested parse - Parse is reachable from
+    /// IsNumberMatch and the example-number helpers - gets a fresh builder rather than sharing one
+    /// that is still in use. Buffers are only returned on the success path; the throw paths simply
+    /// leave them to the collector, which costs an allocation on the next call and nothing else.
+    /// </para>
+    /// </summary>
+    internal static class StringBuilderCache
+    {
+        /// <summary>
+        /// Parse rejects input longer than MAX_INPUT_STRING_LENGTH (250), so a buffer larger than this
+        /// grew for some other reason and is not worth keeping alive per thread.
+        /// </summary>
+        private const int MaxRetainedCapacity = 512;
+
+        [ThreadStatic] private static StringBuilder first;
+        [ThreadStatic] private static StringBuilder second;
+
+        public static StringBuilder Acquire(int capacity)
+        {
+            var candidate = first;
+            if (candidate != null && candidate.Capacity >= capacity)
+            {
+                first = null;
+                candidate.Clear();
+                return candidate;
+            }
+
+            candidate = second;
+            if (candidate != null && candidate.Capacity >= capacity)
+            {
+                second = null;
+                candidate.Clear();
+                return candidate;
+            }
+
+            return new StringBuilder(capacity);
+        }
+
+        public static void Release(StringBuilder builder)
+        {
+            if (builder.Capacity > MaxRetainedCapacity)
+                return;
+
+            if (first == null)
+                first = builder;
+            else if (second == null)
+                second = builder;
+        }
+    }
+}


### PR DESCRIPTION
#378's phase split showed `Parse` holds **351 KB of the 580 KB** per 1000 numbers (60%) while being
the *fastest* phase — `Format` is 2.4× slower but only 32% of allocation. So the allocation work
belongs in `Parse`, not the regex chain I'd have guessed at.

Of that ~351 B per number, roughly half is two `StringBuilder`s: `ParseHelper` allocates one for the
national number and another for its normalized form on every call, each an object plus a chunk.

They're now taken from a small per-thread cache, so a steady stream of parses on one thread reuses
the same two buffers. No method signatures change.

Reentrancy-safe by construction: `Acquire` nulls the slot it takes from, so a nested parse — `Parse`
is reachable from `IsNumberMatch` and the example-number helpers — gets a fresh builder rather than
sharing one still in use. Buffers are returned only on the success path; throw paths leave them to
the collector, costing one allocation next call and nothing else.

Watch `ParseOnly`'s Allocated column: BenchmarkDotNet measures that deterministically, so it's the
number that settles whether this worked.
