### PR TITLE
Benchmark the input shapes callers actually supply

### DIFF
--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberWorkflowBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/PhoneNumberWorkflowBenchmark.cs
@@ -16,6 +16,8 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
         private PhoneNumberUtil _phoneNumberUtil = null!;
         private PhoneNumberBenchmarkCase[] _phoneNumbers = null!;
         private PhoneNumber[] _parsedNumbers = null!;
+        private PhoneNumberBenchmarkCase[] _nationalFormat = null!;
+        private PhoneNumberBenchmarkCase[] _withExtension = null!;
 
         [Params(1000)]
         public int PhoneNumberCount { get; set; }
@@ -32,6 +34,23 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             {
                 _parsedNumbers[i] =
                     _phoneNumberUtil.Parse(_phoneNumbers[i].NumberToParse, _phoneNumbers[i].DefaultRegion);
+            }
+
+            // The seed data is all E164, which is the cheapest thing Parse can be handed: no national
+            // prefix to strip and no extension, so the two regex matches that dominate a real parse both
+            // fail and cost nothing. Re-render the same numbers the way callers usually supply them.
+            _nationalFormat = new PhoneNumberBenchmarkCase[_parsedNumbers.Length];
+            _withExtension = new PhoneNumberBenchmarkCase[_parsedNumbers.Length];
+            for (var i = 0; i < _parsedNumbers.Length; i++)
+            {
+                var region = _phoneNumbers[i].DefaultRegion;
+                _nationalFormat[i] = new PhoneNumberBenchmarkCase(
+                    _phoneNumberUtil.Format(_parsedNumbers[i], PhoneNumberFormat.NATIONAL), region);
+
+                var extended = new PhoneNumber.Builder().MergeFrom(_parsedNumbers[i])
+                    .SetExtension("123").Build();
+                _withExtension[i] = new PhoneNumberBenchmarkCase(
+                    _phoneNumberUtil.Format(extended, PhoneNumberFormat.INTERNATIONAL), region);
             }
         }
 
@@ -65,6 +84,42 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             for (var i = 0; i < _phoneNumbers.Length; i++)
             {
                 var phoneNumber = _phoneNumbers[i];
+                checksum += _phoneNumberUtil
+                    .Parse(phoneNumber.NumberToParse, phoneNumber.DefaultRegion).CountryCode;
+            }
+
+            return checksum;
+        }
+
+        /// <summary>
+        /// The same numbers in national format, so the national prefix actually gets stripped. That
+        /// path costs roughly twice what an E164 parse does, and it is what most callers hand in.
+        /// </summary>
+        [Benchmark]
+        public int ParseNationalFormat()
+        {
+            var checksum = 0;
+            for (var i = 0; i < _nationalFormat.Length; i++)
+            {
+                var phoneNumber = _nationalFormat[i];
+                checksum += _phoneNumberUtil
+                    .Parse(phoneNumber.NumberToParse, phoneNumber.DefaultRegion).CountryCode;
+            }
+
+            return checksum;
+        }
+
+        /// <summary>
+        /// With an extension, so the extension pattern matches rather than failing. A successful match
+        /// on that alternation is by far the most expensive thing a parse can do.
+        /// </summary>
+        [Benchmark]
+        public int ParseWithExtension()
+        {
+            var checksum = 0;
+            for (var i = 0; i < _withExtension.Length; i++)
+            {
+                var phoneNumber = _withExtension[i];
                 checksum += _phoneNumberUtil
                     .Parse(phoneNumber.NumberToParse, phoneNumber.DefaultRegion).CountryCode;
             }

--- a/csharp/PhoneNumbers.PerformanceTest/README.md
+++ b/csharp/PhoneNumbers.PerformanceTest/README.md
@@ -25,7 +25,9 @@ The `PhoneNumberWorkflowBenchmark` exercises the widest slice of the library; th
 completes in a few minutes on a single runtime. Alongside the end-to-end
 `ParseValidateAndFormatPhoneNumbers` it measures `ParseOnly`, `ValidateOnly` and `FormatOnly`
 against the same data, so a cost — allocation especially — can be attributed to a phase instead of
-only being visible as a total.
+only being visible as a total. `ParseNationalFormat` and `ParseWithExtension` re-render those same
+numbers the way callers usually supply them: the seed data is E164, which is the cheapest input
+`Parse` can take, since the national-prefix and extension patterns both fail and cost nothing.
 
 Other available benchmarks:
 


### PR DESCRIPTION
An allocation probe over `Parse` showed the seed data is the cheapest input the library can be handed:

| input | B/op |
|---|---:|
| `+16502530000` (E164 — what the benchmark uses) | 360 |
| `6502530000` national, no prefix | 456 |
| `020 7031 3000` national **with prefix** | 752 |
| `+1 650 253 0000 ext. 123` **with extension** | 1472 |

`PhoneNumberBenchmarkData` formats everything to E164, where the national-prefix and extension regexes
both *fail* — and a failed match returns the shared `Match.Empty` for free. A successful one allocates
the `Match`, a `GroupCollection` and a `Group` per group. So the two things that dominate a real parse
never run in the benchmark, and any fix for them would measure as zero.

Adds `ParseNationalFormat` and `ParseWithExtension`, re-rendering the same numbers via `Format`.
Separate benchmarks rather than mixing them into `ParseOnly`: blending would give one number that
can't attribute anything, and `ParseOnly` stays comparable to the figure tracked across earlier PRs.

Costs two benchmark cases (~45s per tree). Lands before the optimisation so the base commit has a
counterpart to compare against.
