### PR TITLE
Match slices without materialising them when parsing

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -678,6 +678,26 @@ namespace PhoneNumbers
             return ValidPhoneNumber().IsMatch(number);
         }
 
+        /// <summary>
+        /// Whether the rule matches everything from <paramref name="start"/> onwards. Both of these
+        /// only ever fed a slice to a regex, so on targets with span matching the slice never becomes
+        /// a string.
+        /// </summary>
+        private static bool IsMatchAllFrom(PhoneRegex rule, string value, int start) =>
+#if NET7_0_OR_GREATER
+            rule.IsMatchAll(value.AsSpan(start));
+#else
+            rule.IsMatchAll(value.Substring(start));
+#endif
+
+        /// <summary>Whether the first <paramref name="length"/> characters look like a phone number.</summary>
+        private static bool IsViablePhoneNumberPrefix(string number, int length) =>
+#if NET7_0_OR_GREATER
+            length >= MIN_LENGTH_FOR_NSN && ValidPhoneNumber().IsMatch(number.AsSpan(0, length));
+#else
+            IsViablePhoneNumber(number.Substring(0, length));
+#endif
+
         private static void Normalize(StringBuilder number)
         {
             if (IsValidAlphaPhone(number))
@@ -2572,26 +2592,6 @@ namespace PhoneNumbers
         /// <param name="number">The non-normalized telephone number that we wish to strip the extension from.</param>
         /// <param name="numberString">The same number as a string</param>
         /// <returns>The phone extension.</returns>
-        /// <summary>
-        /// Whether the rule matches everything from <paramref name="start"/> onwards. Both of these
-        /// only ever fed a slice to a regex, so on targets with span matching the slice never becomes
-        /// a string.
-        /// </summary>
-        private static bool IsMatchAllFrom(PhoneRegex rule, string value, int start) =>
-#if NET7_0_OR_GREATER
-            rule.IsMatchAll(value.AsSpan(start));
-#else
-            rule.IsMatchAll(value.Substring(start));
-#endif
-
-        /// <summary>Whether the first <paramref name="length"/> characters look like a phone number.</summary>
-        private static bool IsViablePhoneNumberPrefix(string number, int length) =>
-#if NET7_0_OR_GREATER
-            length >= MIN_LENGTH_FOR_NSN && ValidPhoneNumber().IsMatch(number.AsSpan(0, length));
-#else
-            IsViablePhoneNumber(number.Substring(0, length));
-#endif
-
         static string MaybeStripExtension(StringBuilder number, string numberString)
         {
             var m = ExtnPattern().Match(numberString);

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -2540,7 +2540,7 @@ namespace PhoneNumbers
                 {
                     // If the original number was viable, and the resultant number is not, we return.
                     if (isViableOriginalNumber &&
-                        !nationalNumberRule.IsMatchAll(numberString.Substring(prefixMatch.Length)))
+                        !IsMatchAllFrom(nationalNumberRule, numberString, prefixMatch.Length))
                         return false;
                     if (getCarrier && numOfGroups > 1 && prefixMatch.Groups[numOfGroups - 1].Success)
                         carrierCode = prefixMatch.Groups[1].Value;
@@ -2572,12 +2572,32 @@ namespace PhoneNumbers
         /// <param name="number">The non-normalized telephone number that we wish to strip the extension from.</param>
         /// <param name="numberString">The same number as a string</param>
         /// <returns>The phone extension.</returns>
+        /// <summary>
+        /// Whether the rule matches everything from <paramref name="start"/> onwards. Both of these
+        /// only ever fed a slice to a regex, so on targets with span matching the slice never becomes
+        /// a string.
+        /// </summary>
+        private static bool IsMatchAllFrom(PhoneRegex rule, string value, int start) =>
+#if NET7_0_OR_GREATER
+            rule.IsMatchAll(value.AsSpan(start));
+#else
+            rule.IsMatchAll(value.Substring(start));
+#endif
+
+        /// <summary>Whether the first <paramref name="length"/> characters look like a phone number.</summary>
+        private static bool IsViablePhoneNumberPrefix(string number, int length) =>
+#if NET7_0_OR_GREATER
+            length >= MIN_LENGTH_FOR_NSN && ValidPhoneNumber().IsMatch(number.AsSpan(0, length));
+#else
+            IsViablePhoneNumber(number.Substring(0, length));
+#endif
+
         static string MaybeStripExtension(StringBuilder number, string numberString)
         {
             var m = ExtnPattern().Match(numberString);
             // If we find a potential extension, and the number preceding this is a viable number, we assume
             // it is an extension.
-            if (m.Success && IsViablePhoneNumber(numberString.Substring(0, m.Index)))
+            if (m.Success && IsViablePhoneNumberPrefix(numberString, m.Index))
             {
                 // The numbers are captured into groups in the regular expression.
                 for (int i = 1, length = m.Groups.Count; i < length; i++)

--- a/csharp/PhoneNumbers/PhoneRegex.cs
+++ b/csharp/PhoneNumbers/PhoneRegex.cs
@@ -60,6 +60,15 @@ namespace PhoneNumbers
         public string Replace(string value, string replacement) => regex.Value.Replace(value, replacement);
 
         public bool IsMatchAll(string value) => allRegex.Value.IsMatch(value);
+
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// Lets callers test a slice without materialising it. Internal because a public member here
+        /// would exist on the net8.0 and net10.0 assets but not on netstandard2.0. At a major version
+        /// the string overloads should become span overloads outright - see issue #375.
+        /// </summary>
+        internal bool IsMatchAll(ReadOnlySpan<char> value) => allRegex.Value.IsMatch(value);
+#endif
         public Match MatchAll(string value) => allRegex.Value.Match(value);
 
         public bool IsMatchBeginning(string value) => beginRegex.Value.IsMatch(value);


### PR DESCRIPTION
Two `Substring` calls on the parse path existed only to hand a slice to a regex:

- `MaybeStripNationalPrefixAndCarrierCode` — `numberString.Substring(prefixMatch.Length)` for an
  `IsMatchAll` check
- `MaybeStripExtension` — `numberString.Substring(0, m.Index)` for the viability check

On net7.0+ `Regex.IsMatch(ReadOnlySpan<char>)` means neither slice needs to become a string. Both
call sites now go through a small helper that holds the `#if`, so the parse logic itself reads the
same as before — this file is kept diffable against the upstream Java.

The `PhoneRegex` span overload is `internal`: a public one would exist on the net8.0 and net10.0
assets but not netstandard2.0, which is what package validation's cross-framework check polices.
Replacing the public `string` overloads outright is recorded on #375 for a major version.

These are the paths #381 made measurable — an E164 parse never reaches either, since both regexes
fail and cost nothing. Watch `ParseNationalFormat` and `ParseWithExtension` allocation.
