### PR TITLE
Skip the match groups when stripping a national prefix

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -2553,9 +2553,13 @@ namespace PhoneNumbers
                 // prefixMatcher.group(numOfGroups) == null implies nothing was captured by the capturing
                 // groups in possibleNationalPrefix; therefore, no transformation is necessary, and we just
                 // remove the national prefix.
-                var numOfGroups = prefixMatch.Groups.Count;
                 var transformRule = metadata.NationalPrefixTransformRule;
-                if (string.IsNullOrEmpty(transformRule) ||
+                var hasTransformRule = !string.IsNullOrEmpty(transformRule);
+                // Reaching for Groups materialises a GroupCollection plus a Group per access, so
+                // only do it when the transform rule or a carrier code actually needs one. Both
+                // conditions below short-circuit before touching it otherwise.
+                var numOfGroups = hasTransformRule || getCarrier ? prefixMatch.Groups.Count : 0;
+                if (!hasTransformRule ||
                     !prefixMatch.Groups[numOfGroups - 1].Success)
                 {
                     // If the original number was viable, and the resultant number is not, we return.
@@ -2848,7 +2852,7 @@ namespace PhoneNumbers
                     "The string supplied is too short to be a phone number.");
 
             var normalizedNationalNumberString = normalizedNationalNumber.ToString();
-            if (regionMetadata != null && MaybeStripNationalPrefixAndCarrierCode(normalizedNationalNumber, normalizedNationalNumberString, regionMetadata, true, out var carrierCode))
+            if (regionMetadata != null && MaybeStripNationalPrefixAndCarrierCode(normalizedNationalNumber, normalizedNationalNumberString, regionMetadata, keepRawInput, out var carrierCode))
             {
                 // We require that the NSN remaining after stripping the national prefix and carrier code be
                 // long enough to be a possible length for the region. Otherwise, we don't do the stripping,


### PR DESCRIPTION
`ParseNationalFormat` costs 581 B against `ParseOnly`'s 350 B. Same cause as #383: reaching for
`Match.Groups` materialises a `GroupCollection` plus a `Group` per access, which the fiddle probe
showed was more expensive than the match itself.

Two changes, both avoiding work rather than restructuring logic:

**The carrier code is computed even when it is thrown away.** `ParseHelper` passed `true` for
`getCarrier`, but the result is only consumed under `if (keepRawInput && ...)`. It now passes
`keepRawInput`, so a plain `Parse` skips `Groups[1].Value` — a string — and the group accesses
reaching it. The public `MaybeStripNationalPrefixAndCarrierCode` overload is untouched.

**`numOfGroups` was computed unconditionally.** `var numOfGroups = prefixMatch.Groups.Count;` ran
before the branch that needs it, so the `GroupCollection` was built even when the transform rule is
empty — the common case, since most regions have none. It is now computed only when the transform
rule or a carrier code actually requires it, and both conditions short-circuit before touching
`Groups` otherwise.

Net effect for `Parse` on a national-format number in a region with no transform rule: `Groups` is
never touched at all.

Watch `ParseNationalFormat`; `ParseOnly` and `ParseWithExtension` should not move.
