### PR TITLE
Strip the national prefix without materialising a match

### DIFF
--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -2544,6 +2544,25 @@ namespace PhoneNumbers
             }
             // Attempt to parse the first digits as a national prefix.
             numberString ??= number.ToString();
+
+            // Whether the groups are needed at all is known before matching: only a transform rule or
+            // a requested carrier code reads them. Without either, the length of the prefix is the
+            // only thing this method uses, and that can be had without materialising a Match.
+            if (string.IsNullOrEmpty(metadata.NationalPrefixTransformRule) && !getCarrier)
+            {
+                var prefixLength = metadata.MatchNationalPrefixLengthForParsing(numberString);
+                if (prefixLength < 0)
+                    return false;
+
+                var rule = metadata.GeneralDesc.GetNationalNumberPattern();
+                // If the original number was viable, and the resultant number is not, we return.
+                if (rule.IsMatchAll(numberString) && !IsMatchAllFrom(rule, numberString, prefixLength))
+                    return false;
+
+                number?.Remove(0, prefixLength);
+                return true;
+            }
+
             var prefixMatch = metadata.MatchNationalPrefixForParsing(numberString);
             if (prefixMatch?.Success == true)
             {

--- a/csharp/PhoneNumbers/PhoneRegex.cs
+++ b/csharp/PhoneNumbers/PhoneRegex.cs
@@ -72,6 +72,19 @@ namespace PhoneNumbers
         public Match MatchAll(string value) => allRegex.Value.Match(value);
 
         public bool IsMatchBeginning(string value) => beginRegex.Value.IsMatch(value);
+
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// Length of the match anchored at the start, or -1 if there is none. EnumerateMatches yields
+        /// a ValueMatch struct, so a caller that only needs the length never materialises a Match.
+        /// </summary>
+        internal int MatchBeginningLength(ReadOnlySpan<char> value)
+        {
+            foreach (var match in beginRegex.Value.EnumerateMatches(value))
+                return match.Length;
+            return -1;
+        }
+#endif
         public Match MatchBeginning(string value) => beginRegex.Value.Match(value);
     }
 }

--- a/csharp/PhoneNumbers/Phonemetadata.cs
+++ b/csharp/PhoneNumbers/Phonemetadata.cs
@@ -136,6 +136,30 @@ namespace PhoneNumbers
             return PhoneRegex.Get(NationalPrefixForParsing).MatchBeginning(value);
         }
 
+        /// <summary>
+        /// How many characters of the national prefix <paramref name="value"/> starts with, or -1 if
+        /// it does not start with one. Callers that only need to know how much to strip use this so
+        /// no Match is materialised; the groups are only needed for a transform rule or carrier code.
+        /// </summary>
+        internal int MatchNationalPrefixLengthForParsing(string value)
+        {
+            if (_nationalPrefixForParsingLiteral == 0)
+                _nationalPrefixForParsingLiteral = (sbyte)(Regex.Escape(NationalPrefixForParsing) == NationalPrefixForParsing ? 1 : -1);
+
+            // A literal prefix matches itself, so its length is known without running the regex.
+            if (_nationalPrefixForParsingLiteral > 0)
+                return value.StartsWith(NationalPrefixForParsing, StringComparison.Ordinal)
+                    ? NationalPrefixForParsing.Length
+                    : -1;
+
+#if NET7_0_OR_GREATER
+            return PhoneRegex.Get(NationalPrefixForParsing).MatchBeginningLength(value.AsSpan());
+#else
+            var match = PhoneRegex.Get(NationalPrefixForParsing).MatchBeginning(value);
+            return match.Success ? match.Length : -1;
+#endif
+        }
+
         public bool HasNationalPrefixTransformRule => NationalPrefixTransformRule?.Length > 0;
         public string NationalPrefixTransformRule { get; internal set; } = "";
 


### PR DESCRIPTION
`ParseNationalFormat` still carries ~215 B over a plain E164 parse, and that residue is the `Match`
object itself — #384 removed the group accesses around it but the match remained.

Whether the groups are needed is knowable *before* matching: only a transform rule or a requested
carrier code reads them, and after #384 a plain `Parse` requests neither. Without them, the only
thing this method uses is the prefix *length*.

So there is now a fast path that never materialises a `Match`:

- **Literal prefixes** — the metadata already caches whether the pattern is a literal, and a literal
  matches itself, so the length is known without running a regex at all. Many regions are plain `0`.
- **Everything else on net7.0+** — `Regex.EnumerateMatches` yields a `ValueMatch` struct with
  `Index`/`Length` and allocates nothing.
- **netstandard2.0** — unchanged, falls back to `MatchBeginning`.

The slow path is untouched, so a transform rule or a carrier request behaves exactly as before, and
the public `MaybeStripNationalPrefixAndCarrierCode` overload still passes `carrierCode != null`.

Watch `ParseNationalFormat`; `ParseOnly` and `ParseWithExtension` should not move.
