### PR TITLE
Close the Scorecard token-permission and unpinned-restore findings

### DIFF
--- a/.github/workflows/build_and_run_demo_tests.yml
+++ b/.github/workflows/build_and_run_demo_tests.yml
@@ -34,8 +34,10 @@ jobs:
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v5
         with:
           dotnet-version: 10.x
+      # --locked-mode fails the restore rather than silently resolving a different transitive
+      # version than packages.lock.json records.
       - name: Restore dependencies
-        run: dotnet restore PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj
+        run: dotnet restore PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj --locked-mode
         working-directory: ./csharp
       - name: Build
         run: dotnet build PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj --no-restore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only default; the analyze job below elevates only what it needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/create_new_release_on_new_metadata_update.yml
+++ b/.github/workflows/create_new_release_on_new_metadata_update.yml
@@ -24,16 +24,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-# Elevated above the read-only default because the update script pushes a commit
-# and creates a GitHub release via GITHUB_TOKEN. actions: write lets it dispatch
-# publish_nuget.yml, which the release's own push event cannot trigger.
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
   create_new_release_on_new_metadata_update:
     runs-on: ubuntu-latest
+    # Elevated above the read-only default at the job rather than the file level, so a
+    # workflow-wide write token is never minted. The update script pushes a commit and
+    # creates a GitHub release via GITHUB_TOKEN; actions: write lets it dispatch
+    # publish_nuget.yml, which the release's own push event cannot trigger.
+    permissions:
+      contents: write
+      actions: write
     steps:
       # Credentials are persisted on purpose: the update script pushes through this checkout.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -49,8 +49,9 @@ jobs:
           echo "VERSION=${tag#v}" >> "${GITHUB_ENV}"
           echo "publishing version ${tag#v}" >> "${GITHUB_STEP_SUMMARY}"
 
+      # --locked-mode matters most here: this is the restore whose output is published.
       - name: Restore dependencies
-        run: dotnet restore csharp --source https://api.nuget.org/v3/index.json
+        run: dotnet restore csharp --source https://api.nuget.org/v3/index.json --locked-mode
 
       - name: Pack
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # The default GITHUB_TOKEN cannot read classic branch-protection rules, which
+          # leaves the Branch-Protection check inconclusive. A fine-grained PAT with
+          # Administration: read lifts that. Falls back to the default token when the
+          # secret is absent so the workflow still runs, just without that one check.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
           # Publish results to the OpenSSF API so the README badge stays current.
           # Only runs on the default-branch push / schedule events above.
           publish_results: true


### PR DESCRIPTION
Closes the two actionable OpenSSF Scorecard findings (score is 7.3 as of today).

**Token-Permissions 0/10** — three warnings, all structural rather than actual over-grant:
- `codeql.yml` had no top-level `permissions:` block, so the file defaulted to whatever the repo
  default is. Now pinned to `contents: read`; the job's own block is unchanged.
- `create_new_release_on_new_metadata_update.yml` declared `contents: write` + `actions: write` at
  file level. Both moved to the job, so a workflow-wide write token is never minted. Same
  effective grant, same comment explaining why the writes are needed.

`post_performance_test_comment.yml` and `deploy-demo.yml` also carry top-level writes but were not
flagged — Scorecard only treats contents/actions/packages writes as high severity, and both of
those files have a single job, so moving them would change nothing. Left alone.

**Pinned-Dependencies 8/10** — "1 of 3 nugetCommand dependencies pinned". Adds `--locked-mode` to
the demo and publish restores, matching what the unit-test workflow already does. All eight
projects have a committed `packages.lock.json`, so this is enforcement, not new policy. It matters
most in `publish_nuget.yml`, which is the restore whose output ships.

**Branch-Protection −1** — the default `GITHUB_TOKEN` cannot read classic branch-protection rules.
Wires `repo_token` to a `SCORECARD_TOKEN` secret, falling back to `github.token` when the secret is
absent, so this is safe to merge before the PAT exists — the check just stays inconclusive until then.
