### PR TITLE
fix: ship symbols in a .snupkg instead of embedding them in the assembly

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
-          path: artifacts/*.nupkg
+          path: artifacts/*.*nupkg
           if-no-files-found: error
 
       - name: NuGet login
@@ -73,6 +73,7 @@ jobs:
           user: twcclegg
 
       # --skip-duplicate so a re-run after a partial failure pushes only what is missing.
+      # The matching .snupkg next to each .nupkg is pushed with it; --no-symbols would skip it.
       - name: Push to nuget.org
         env:
           NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/run_all_tests_and_upload_code_coverage.yml
+++ b/.github/workflows/run_all_tests_and_upload_code_coverage.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-${{ runner.arch }}-
       - name: Run tests
-        run: dotnet test csharp/PhoneNumbers.sln --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+        run: dotnet test csharp/PhoneNumbers.sln --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --settings csharp/coverlet.runsettings --results-directory ./coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+# Generated data tables, not code under test. LocaleData alone is ~48k lines of static
+# initializer that always runs, so counting it reported ~98% project coverage while the
+# hand-written library sat near 77%. See issue #389.
+ignore:
+  - "csharp/PhoneNumbers/LocaleData.cs"
+  - "csharp/PhoneNumbers/CountryCodeToRegionCodeMap.cs"
+
 coverage:
   status:
     project:

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -43,4 +43,9 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
 </Project>

--- a/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
@@ -11,7 +11,6 @@
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <PackageTags>phonenumber phone libphonenumber e164 e.164 international extensions</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
-        <DebugType>embedded</DebugType>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Baseline deferred; see the note in PhoneNumbers.csproj. -->
         <EnablePackageValidation>true</EnablePackageValidation>

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -12,7 +12,6 @@
     <PackageTags>phonenumber phone libphonenumber e164 e.164 international</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <DebugType>embedded</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- No PackageValidationBaselineVersion yet: 9.0.36 still ships a net9.0 asset this package no
          longer produces. Set it to the first release without net9.0 to compare against a baseline;

--- a/csharp/coverlet.runsettings
+++ b/csharp/coverlet.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Exclude>[PhoneNumbers]PhoneNumbers.LocaleData,[PhoneNumbers]PhoneNumbers.CountryCodeToRegionCodeMap</Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
▎ DebugType=embedded (#340, released in 9.0.31) put a PDB inside every shipped assembly, so coverage collectors in consumers' test runs began instrumenting this library's ~48k-line generated LocaleData table — one report measured ~3.5 minutes of added time per test project (#389). This reverts to the SDK-default portable PDB and publishes symbols as a side-by-side .snupkg, which preserves debugging via the symbol server and Source Link while restoring the pre-9.0.31 footprint in consumers' output directories.

▎ Also excludes the generated data tables from our own coverage, which the embedded PDB had inflated from ~77% to ~98%; expect the Codecov project check to fail once against the old baseline.