### PR TITLE
build: compare both packages against the 9.0.37 baseline

### DIFF
--- a/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
@@ -12,8 +12,9 @@
         <PackageTags>phonenumber phone libphonenumber e164 e.164 international extensions</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <!-- Baseline deferred; see the note in PhoneNumbers.csproj. -->
+        <!-- Baselined on the same release as PhoneNumbers.csproj; see the note there. -->
         <EnablePackageValidation>true</EnablePackageValidation>
+        <PackageValidationBaselineVersion>9.0.37</PackageValidationBaselineVersion>
         <NoWarn>$(NoWarn);CA1014;CA1031;CA1062</NoWarn>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -13,10 +13,10 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- No PackageValidationBaselineVersion yet: 9.0.36 still ships a net9.0 asset this package no
-         longer produces. Set it to the first release without net9.0 to compare against a baseline;
-         until then only the cross-target surface within this package is checked. -->
+    <!-- Every pack is compared against the latest release, the surface consumers upgrade from.
+         Restore downloads that package, so the version must be one already on nuget.org. -->
     <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>9.0.37</PackageValidationBaselineVersion>
     <!-- Rules enforced on top of the default set are listed in .editorconfig, with the reasoning. -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>


### PR DESCRIPTION
Sets `PackageValidationBaselineVersion` to 9.0.37 on both packable projects, clearing the TODO left when package validation was first enabled. Packs are now compared against the last release, so a removed or changed public member fails the build instead of shipping.

The old note said 9.0.36 could not be a baseline because it still ships a net9.0 asset. That is false: package validation treats net8.0 as compatible for a net9.0 consumer, and a run baselined on 9.0.36 passes. 9.0.37 is chosen because it is the latest release. No lock file changes are needed — `PackageDownload` items never enter `packages.lock.json`, and restore still fetches them under `--locked-mode`.

Verified by dispatching `build_and_run_unit_tests_linux` on this branch (green), with a control run pinned to a nonexistent 9.0.99 failing at restore with `NU1102 … Nearest version: 9.0.37`, which proves the baseline is really fetched and compared.