### PR TITLE
chore: move the locale generator to temurin 25

### DIFF
--- a/.github/workflows/create_new_release_on_new_metadata_update.yml
+++ b/.github/workflows/create_new_release_on_new_metadata_update.yml
@@ -46,13 +46,13 @@ jobs:
           dotnet-version: 10.x
       # DumpLocale.java regenerates resources/locale/country_names.txt from java.util.Locale,
       # so the jdk is an input to the generated file rather than an incidental tool. Pinned
-      # to temurin 17 to match the header of the committed file - changing it would rewrite
+      # to temurin 25 to match the header of the committed file - changing it would rewrite
       # the locale data from a different CLDR version.
       - name: Setup Java
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '25'
       - name: Get new metadata information and create new GitHub release
         timeout-minutes: 30
         # The token is read from GITHUB_TOKEN below rather than passed as an

--- a/resources/locale/country_names.txt
+++ b/resources/locale/country_names.txt
@@ -3,8 +3,8 @@
 # A name of *xx means 'the name for language xx in this country', stored once.
 #
 # Auto-generated file, do not edit by hand. Generation info:
-# java.version=17.0.10
-# java.vendor=Azul Systems, Inc.
+# java.version=25.0.4
+# java.vendor=Eclipse Adoptium
 AD|aa|Andorra
 AD|ab|*aa
 AD|ae|*aa
@@ -34,7 +34,7 @@ AD|co|*aa
 AD|cr|*aa
 AD|cs|*aa
 AD|cu|*aa
-AD|cv|*aa
+AD|cv|*ce
 AD|cy|*aa
 AD|da|*aa
 AD|de|*aa
@@ -65,7 +65,7 @@ AD|he|אנדורה
 AD|hi|एंडोरा
 AD|ho|*aa
 AD|hr|*ak
-AD|ht|*aa
+AD|ht|*fr
 AD|hu|*aa
 AD|hy|Անդորրա
 AD|hz|*aa
@@ -94,7 +94,7 @@ AD|km|អង់ដូរ៉ា
 AD|kn|ಅಂಡೋರಾ
 AD|ko|안도라
 AD|kr|*aa
-AD|ks|اؠنڑورا
+AD|ks|اینڈورا
 AD|ku|*aa
 AD|kv|*aa
 AD|kw|*aa
@@ -110,7 +110,7 @@ AD|lu|Andore
 AD|lv|*ak
 AD|mg|*aa
 AD|mh|*aa
-AD|mi|*aa
+AD|mi|Anatōra
 AD|mk|*be
 AD|ml|അൻഡോറ
 AD|mn|*ce
@@ -132,7 +132,7 @@ AD|nv|*aa
 AD|ny|*aa
 AD|oc|*aa
 AD|oj|*aa
-AD|om|*aa
+AD|om|Andooraa
 AD|or|ଆଣ୍ଡୋରା
 AD|os|*aa
 AD|pa|ਅੰਡੋਰਾ
@@ -187,7 +187,7 @@ AD|vi|*aa
 AD|vo|*aa
 AD|wa|*aa
 AD|wo|Andoor
-AD|xh|*aa
+AD|xh|E-Andorra
 AD|yi|*ji
 AD|yo|Ààndórà
 AD|za|*aa
@@ -222,7 +222,7 @@ AE|co|*aa
 AE|cr|*aa
 AE|cs|Spojené arabské emiráty
 AE|cu|*aa
-AE|cv|*aa
+AE|cv|Арапсен Пӗрлешӳллӗ Эмирачӗ
 AE|cy|Emiradau Arabaidd Unedig
 AE|da|De Forenede Arabiske Emirater
 AE|de|Vereinigte Arabische Emirate
@@ -244,7 +244,7 @@ AE|fr|Émirats arabes unis
 AE|fy|Verenigde Arabyske Emiraten
 AE|ga|Aontas na nÉimíríochtaí Arabacha
 AE|gd|Na h-Iomaratan Arabach Aonaichte
-AE|gl|Os Emiratos Árabes Unidos
+AE|gl|*es
 AE|gn|*aa
 AE|gu|યુનાઇટેડ આરબ અમીરાત
 AE|gv|*aa
@@ -253,7 +253,7 @@ AE|he|איחוד האמירויות הערביות
 AE|hi|संयुक्त अरब अमीरात
 AE|ho|*aa
 AE|hr|*bs
-AE|ht|*aa
+AE|ht|*fr
 AE|hu|Egyesült Arab Emírségek
 AE|hy|Արաբական Միացյալ Էմիրություններ
 AE|hz|*aa
@@ -283,7 +283,7 @@ AE|kn|ಯುನೈಟೆಡ್ ಅರಬ್ ಎಮಿರೇಟ್ಸ್
 AE|ko|아랍에미리트
 AE|kr|*aa
 AE|ks|مُتحدہ عرَب امارات
-AE|ku|Emîrtiyên Erebî yên Yekbûyî
+AE|ku|Mîrgehên Erebî yên Yekbûyî
 AE|kv|*aa
 AE|kw|*aa
 AE|ky|Бириккен Араб Эмираттары
@@ -298,10 +298,10 @@ AE|lu|Lemila alabu
 AE|lv|Apvienotie Arābu Emirāti
 AE|mg|Emirà Arabo mitambatra
 AE|mh|*aa
-AE|mi|*aa
+AE|mi|Kotahitanga o ngā Whenua o Ārapi
 AE|mk|Обединети Арапски Емирати
 AE|ml|യുണൈറ്റഡ് അറബ് എമിറൈറ്റ്‌സ്
-AE|mn|Арабын Нэгдсэн Эмирт Улс
+AE|mn|Арабын Нэгдсэн Эмират Улс
 AE|mo|Emiratele Arabe Unite
 AE|mr|*hi
 AE|ms|Emiriah Arab Bersatu
@@ -320,7 +320,7 @@ AE|nv|*aa
 AE|ny|*aa
 AE|oc|*aa
 AE|oj|*aa
-AE|om|*aa
+AE|om|Yuunaatid Arab Emereet
 AE|or|ସଂଯୁକ୍ତ ଆରବ ଏମିରେଟସ୍
 AE|os|*aa
 AE|pa|ਸੰਯੁਕਤ ਅਰਬ ਅਮੀਰਾਤ
@@ -335,7 +335,7 @@ AE|ro|*mo
 AE|ru|ОАЭ
 AE|rw|*aa
 AE|sa|*aa
-AE|sc|*aa
+AE|sc|Emirados Àrabos Unidos
 AE|sd|*ps
 AE|se|Ovttastuvvan Arábaemiráhtat
 AE|sg|Arâbo Emirâti Ôko
@@ -375,7 +375,7 @@ AE|vi|Các Tiểu Vương quốc Ả Rập Thống nhất
 AE|vo|*aa
 AE|wa|*aa
 AE|wo|Emira Arab Ini
-AE|xh|*aa
+AE|xh|E-United Arab Emirates
 AE|yi|*aa
 AE|yo|Ẹmirate ti Awọn Arabu
 AE|za|*aa
@@ -410,7 +410,7 @@ AF|co|*aa
 AF|cr|*aa
 AF|cs|Afghánistán
 AF|cu|*aa
-AF|cv|*aa
+AF|cv|*bg
 AF|cy|*aa
 AF|da|*aa
 AF|de|*aa
@@ -486,7 +486,7 @@ AF|lu|Afuganisita
 AF|lv|Afganistāna
 AF|mg|*aa
 AF|mh|*aa
-AF|mi|*aa
+AF|mi|Awhekenetāna
 AF|mk|Авганистан
 AF|ml|അഫ്‌ഗാനിസ്ഥാൻ
 AF|mn|*bg
@@ -508,7 +508,7 @@ AF|nv|*aa
 AF|ny|*aa
 AF|oc|*aa
 AF|oj|*aa
-AF|om|*aa
+AF|om|Afgaanistaan
 AF|or|ଆଫଗାନିସ୍ତାନ୍
 AF|os|*aa
 AF|pa|ਅਫ਼ਗਾਨਿਸਤਾਨ
@@ -523,7 +523,7 @@ AF|ro|*af
 AF|ru|*bg
 AF|rw|*aa
 AF|sa|*aa
-AF|sc|*aa
+AF|sc|Afghànistan
 AF|sd|*fa
 AF|se|*aa
 AF|sg|Faganïta, Afganïstäan
@@ -532,7 +532,7 @@ AF|sk|*af
 AF|sl|*af
 AF|sm|*aa
 AF|sn|*ki
-AF|so|Afgaanistaan
+AF|so|*om
 AF|sq|*af
 AF|sr|*mk
 AF|ss|*aa
@@ -563,7 +563,7 @@ AF|vi|*aa
 AF|vo|*aa
 AF|wa|*aa
 AF|wo|Afganistaŋ
-AF|xh|*aa
+AF|xh|E-Afghanistan
 AF|yi|*ji
 AF|yo|Àfùgànístánì
 AF|za|*aa
@@ -574,7 +574,7 @@ AG|ab|*aa
 AG|ae|*aa
 AG|af|Antigua en Barbuda
 AG|ak|Antigua ne Baabuda
-AG|am|አንቲጓ እና ባሩዳ
+AG|am|አንቲጓ እና ባርቡዳ
 AG|an|*aa
 AG|ar|أنتيغوا وبربودا
 AG|as|এণ্টিগুৱা আৰু বাৰ্বুডা
@@ -598,7 +598,7 @@ AG|co|*aa
 AG|cr|*aa
 AG|cs|Antigua a Barbuda
 AG|cu|*aa
-AG|cv|*aa
+AG|cv|Антигуа тата Барбуда
 AG|cy|*cs
 AG|da|Antigua og Barbuda
 AG|de|Antigua und Barbuda
@@ -607,7 +607,7 @@ AG|dz|ཨན་ཊི་གུ་ཝ་ ཨེནཌ་ བྷར་བྷུ་
 AG|ee|́Antigua kple Barbuda nutome
 AG|el|Αντίγκουα και Μπαρμπούντα
 AG|en|*aa
-AG|eo|Antigvo-Barbudo
+AG|eo|Antigvo kaj Barbudo
 AG|es|Antigua y Barbuda
 AG|et|Antigua ja Barbuda
 AG|eu|Antigua eta Barbuda
@@ -629,7 +629,7 @@ AG|he|אנטיגואה וברבודה
 AG|hi|एंटिगुआ और बरबुडा
 AG|ho|*aa
 AG|hr|*bs
-AG|ht|*aa
+AG|ht|*fr
 AG|hu|Antigua és Barbuda
 AG|hy|Անտիգուա և Բարբուդա
 AG|hz|*aa
@@ -674,7 +674,7 @@ AG|lu|Antiga ne Barbuda
 AG|lv|Antigva un Barbuda
 AG|mg|Antiga sy Barboda
 AG|mh|*aa
-AG|mi|*aa
+AG|mi|Motu Nehe me Pāputa
 AG|mk|Антига и Барбуда
 AG|ml|ആൻറിഗ്വയും ബർബുഡയും
 AG|mn|Антигуа ба Барбуда
@@ -696,7 +696,7 @@ AG|nv|*aa
 AG|ny|*aa
 AG|oc|*aa
 AG|oj|*aa
-AG|om|*aa
+AG|om|Antiiguyaa fi Barbuudaa
 AG|or|ଆଣ୍ଟିଗୁଆ ଏବଂ ବାରବୁଦା
 AG|os|*aa
 AG|pa|ਐਂਟੀਗੁਆ ਅਤੇ ਬਾਰਬੁਡਾ
@@ -711,8 +711,8 @@ AG|ro|*mo
 AG|ru|*bg
 AG|rw|*aa
 AG|sa|*aa
-AG|sc|*aa
-AG|sd|انٽيگا ۽ باربوڊا
+AG|sc|*gl
+AG|sd|انٽيگا ۽ باربد
 AG|se|*et
 AG|sg|Antîgua na Barbûda
 AG|si|ඇන්ටිගුවා සහ බාබියුඩාව
@@ -751,7 +751,7 @@ AG|vi|Antigua và Barbuda
 AG|vo|*aa
 AG|wa|*aa
 AG|wo|Antiguwa ak Barbuda
-AG|xh|*aa
+AG|xh|E-Antigua & Barbuda
 AG|yi|*ji
 AG|yo|Ààntígúà àti Báríbúdà
 AG|za|*aa
@@ -775,7 +775,7 @@ AI|bg|Ангуила
 AI|bh|*aa
 AI|bi|*aa
 AI|bm|Angiya
-AI|bn|এ্যাঙ্গুইলা
+AI|bn|অ্যাঙ্গুইলা
 AI|bo|*aa
 AI|br|*aa
 AI|bs|Angvila
@@ -786,7 +786,7 @@ AI|co|*aa
 AI|cr|*aa
 AI|cs|*aa
 AI|cu|*aa
-AI|cv|*aa
+AI|cv|*ce
 AI|cy|*aa
 AI|da|*aa
 AI|de|*aa
@@ -847,7 +847,7 @@ AI|kn|ಆಂಗ್ವಿಲ್ಲಾ
 AI|ko|앵귈라
 AI|kr|*aa
 AI|ks|انگوئیلا
-AI|ku|*aa
+AI|ku|Anguîla
 AI|kv|*aa
 AI|kw|*aa
 AI|ky|*ce
@@ -862,7 +862,7 @@ AI|lu|Angiye
 AI|lv|Angilja
 AI|mg|*aa
 AI|mh|*aa
-AI|mi|*aa
+AI|mi|Anguira
 AI|mk|Ангвила
 AI|ml|ആൻഗ്വില്ല
 AI|mn|*ce
@@ -884,7 +884,7 @@ AI|nv|*aa
 AI|ny|*aa
 AI|oc|*aa
 AI|oj|*aa
-AI|om|*aa
+AI|om|Anguyilaa
 AI|or|ଆଙ୍ଗୁଇଲ୍ଲା
 AI|os|*aa
 AI|pa|ਅੰਗੁਇਲਾ
@@ -920,7 +920,7 @@ AI|ta|அங்கியுலா
 AI|te|ఆంగ్విల్లా
 AI|tg|Ангилия
 AI|th|แองกวิลลา
-AI|ti|ኣንጊላ
+AI|ti|ኣንጒላ
 AI|tk|Angilýa
 AI|tl|*aa
 AI|tn|*aa
@@ -939,7 +939,7 @@ AI|vi|*aa
 AI|vo|*aa
 AI|wa|*aa
 AI|wo|Angiiy
-AI|xh|*aa
+AI|xh|E-Anguilla
 AI|yi|*aa
 AI|yo|Ààngúlílà
 AI|za|*aa
@@ -974,7 +974,7 @@ AL|co|*aa
 AL|cr|*aa
 AL|cs|Albánie
 AL|cu|*aa
-AL|cv|*aa
+AL|cv|*ce
 AL|cy|*aa
 AL|da|Albanien
 AL|de|*da
@@ -1005,7 +1005,7 @@ AL|he|אלבניה
 AL|hi|अल्बानिया
 AL|ho|*aa
 AL|hr|*bs
-AL|ht|*aa
+AL|ht|*fr
 AL|hu|Albánia
 AL|hy|Ալբանիա
 AL|hz|*aa
@@ -1034,7 +1034,7 @@ AL|km|អាល់បានី
 AL|kn|ಅಲ್ಬೇನಿಯಾ
 AL|ko|알바니아
 AL|kr|*aa
-AL|ks|اؠلبانِیا
+AL|ks|البانیا
 AL|ku|Albanya
 AL|kv|*aa
 AL|kw|*aa
@@ -1050,7 +1050,7 @@ AL|lu|Alubani
 AL|lv|Albānija
 AL|mg|*aa
 AL|mh|*aa
-AL|mi|*aa
+AL|mi|Arapeinia
 AL|mk|Албанија
 AL|ml|അൽബേനിയ
 AL|mn|*ce
@@ -1072,7 +1072,7 @@ AL|nv|*aa
 AL|ny|*aa
 AL|oc|*aa
 AL|oj|*aa
-AL|om|*aa
+AL|om|Albaaniyaa
 AL|or|ଆଲବାନିଆ
 AL|os|*aa
 AL|pa|ਅਲਬਾਨੀਆ
@@ -1108,7 +1108,7 @@ AL|ta|அல்பேனியா
 AL|te|అల్బేనియా
 AL|tg|*bg
 AL|th|แอลเบเนีย
-AL|ti|ኣልቤኒያ
+AL|ti|ኣልባንያ
 AL|tk|Albaniýa
 AL|tl|*aa
 AL|tn|*aa
@@ -1127,7 +1127,7 @@ AL|vi|*aa
 AL|vo|*aa
 AL|wa|*aa
 AL|wo|*jv
-AL|xh|*aa
+AL|xh|E-Albania
 AL|yi|*ji
 AL|yo|Àlùbàníánì
 AL|za|*aa
@@ -1162,7 +1162,7 @@ AM|co|*aa
 AM|cr|*aa
 AM|cs|Arménie
 AM|cu|*aa
-AM|cv|*aa
+AM|cv|Армени
 AM|cy|*aa
 AM|da|Armenien
 AM|de|*da
@@ -1193,7 +1193,7 @@ AM|he|ארמניה
 AM|hi|आर्मेनिया
 AM|ho|*aa
 AM|hr|*bs
-AM|ht|*aa
+AM|ht|*cs
 AM|hu|Örményország
 AM|hy|Հայաստան
 AM|hz|*aa
@@ -1238,10 +1238,10 @@ AM|lu|Ameni
 AM|lv|Armēnija
 AM|mg|*aa
 AM|mh|*aa
-AM|mi|*aa
+AM|mi|Āmenia
 AM|mk|Ерменија
 AM|ml|അർമേനിയ
-AM|mn|Армени
+AM|mn|*cv
 AM|mo|*aa
 AM|mr|अर्मेनिया
 AM|ms|*aa
@@ -1260,7 +1260,7 @@ AM|nv|*aa
 AM|ny|*aa
 AM|oc|*aa
 AM|oj|*aa
-AM|om|*aa
+AM|om|Armeeniyaa
 AM|or|ଆର୍ମେନିଆ
 AM|os|*aa
 AM|pa|ਅਰਮੀਨੀਆ
@@ -1275,7 +1275,7 @@ AM|ro|*aa
 AM|ru|*bg
 AM|rw|*aa
 AM|sa|*aa
-AM|sc|*aa
+AM|sc|*ca
 AM|sd|ارمینیا
 AM|se|*aa
 AM|sg|Armenïi
@@ -1296,7 +1296,7 @@ AM|ta|அர்மேனியா
 AM|te|ఆర్మేనియా
 AM|tg|Арманистон
 AM|th|อาร์เมเนีย
-AM|ti|ኣርሜኒያ
+AM|ti|ኣርሜንያ
 AM|tk|*ku
 AM|tl|*aa
 AM|tn|*aa
@@ -1315,7 +1315,7 @@ AM|vi|*aa
 AM|vo|*aa
 AM|wa|*aa
 AM|wo|*sq
-AM|xh|*aa
+AM|xh|E-Armenia
 AM|yi|*ji
 AM|yo|Améníà
 AM|za|*aa
@@ -1350,7 +1350,7 @@ AO|co|*aa
 AO|cr|*aa
 AO|cs|*aa
 AO|cu|*aa
-AO|cv|*aa
+AO|cv|*be
 AO|cy|*aa
 AO|da|*aa
 AO|de|*aa
@@ -1426,7 +1426,7 @@ AO|lu|*aa
 AO|lv|*aa
 AO|mg|*aa
 AO|mh|*aa
-AO|mi|*aa
+AO|mi|Anakora
 AO|mk|*be
 AO|ml|അംഗോള
 AO|mn|Ангол
@@ -1448,7 +1448,7 @@ AO|nv|*aa
 AO|ny|*aa
 AO|oc|*aa
 AO|oj|*aa
-AO|om|*aa
+AO|om|Angoolaa
 AO|or|ଆଙ୍ଗୋଲା
 AO|os|*aa
 AO|pa|ਅੰਗੋਲਾ
@@ -1503,7 +1503,7 @@ AO|vi|*aa
 AO|vo|*aa
 AO|wa|*aa
 AO|wo|Àngolaa
-AO|xh|*aa
+AO|xh|E-Angola
 AO|yi|*ji
 AO|yo|Ààngólà
 AO|za|*aa
@@ -1513,7 +1513,7 @@ AQ|aa|Antarctica
 AQ|ab|*aa
 AQ|ae|*aa
 AQ|af|Antarktika
-AQ|ak|*aa
+AQ|ak|Antaatika
 AQ|am|አንታርክቲካ
 AQ|an|*aa
 AQ|ar|أنتاركتيكا
@@ -1538,7 +1538,7 @@ AQ|co|*aa
 AQ|cr|*aa
 AQ|cs|Antarktida
 AQ|cu|*aa
-AQ|cv|*aa
+AQ|cv|*ce
 AQ|cy|*aa
 AQ|da|Antarktis
 AQ|de|*da
@@ -1558,9 +1558,9 @@ AQ|fj|*aa
 AQ|fo|*da
 AQ|fr|Antarctique
 AQ|fy|*aa
-AQ|ga|an Antartaice
+AQ|ga|Antartaice
 AQ|gd|An Antartaig
-AQ|gl|A Antártida
+AQ|gl|*es
 AQ|gn|*aa
 AQ|gu|એન્ટાર્કટિકા
 AQ|gv|*aa
@@ -1569,7 +1569,7 @@ AQ|he|אנטארקטיקה
 AQ|hi|अंटार्कटिका
 AQ|ho|*aa
 AQ|hr|*af
-AQ|ht|*aa
+AQ|ht|*fr
 AQ|hu|Antarktisz
 AQ|hy|Անտարկտիդա
 AQ|hz|*aa
@@ -1614,7 +1614,7 @@ AQ|lu|*aa
 AQ|lv|*af
 AQ|mg|*aa
 AQ|mh|*aa
-AQ|mi|*aa
+AQ|mi|Te Kōpakatanga ki te Tonga
 AQ|mk|Антарктик
 AQ|ml|അന്റാർട്ടിക്ക
 AQ|mn|Антарктид
@@ -1636,7 +1636,7 @@ AQ|nv|*aa
 AQ|ny|*aa
 AQ|oc|*aa
 AQ|oj|*aa
-AQ|om|*aa
+AQ|om|Antaarkitikaa
 AQ|or|ଆଣ୍ଟାର୍କାଟିକା
 AQ|os|*aa
 AQ|pa|ਅੰਟਾਰਕਟਿਕਾ
@@ -1651,7 +1651,7 @@ AQ|ro|*aa
 AQ|ru|*ce
 AQ|rw|*aa
 AQ|sa|*aa
-AQ|sc|*aa
+AQ|sc|Antàrticu
 AQ|sd|انٽارڪٽيڪا
 AQ|se|Antárktis
 AQ|sg|*aa
@@ -1691,7 +1691,7 @@ AQ|vi|Nam Cực
 AQ|vo|*aa
 AQ|wa|*aa
 AQ|wo|Antarktik
-AQ|xh|*aa
+AQ|xh|E-Antarctica
 AQ|yi|*ji
 AQ|yo|Antakítíkà
 AQ|za|*aa
@@ -1726,7 +1726,7 @@ AR|co|*aa
 AR|cr|*aa
 AR|cs|*aa
 AR|cu|*aa
-AR|cv|*aa
+AR|cv|*ce
 AR|cy|Yr Ariannin
 AR|da|*aa
 AR|de|Argentinien
@@ -1748,16 +1748,16 @@ AR|fr|Argentine
 AR|fy|*af
 AR|ga|an Airgintín
 AR|gd|An Argantain
-AR|gl|A Arxentina
+AR|gl|Arxentina
 AR|gn|*aa
 AR|gu|આર્જેન્ટીના
 AR|gv|*aa
-AR|ha|Arjantiniya
+AR|ha|Ajentina
 AR|he|ארגנטינה
 AR|hi|अर्जेंटीना
 AR|ho|*aa
 AR|hr|*aa
-AR|ht|*aa
+AR|ht|*fr
 AR|hu|Argentína
 AR|hy|Արգենտինա
 AR|hz|*aa
@@ -1778,7 +1778,7 @@ AR|ji|אַרגענטינע
 AR|jv|Argèntina
 AR|ka|არგენტინა
 AR|kg|*aa
-AR|ki|Ajentina
+AR|ki|*ha
 AR|kj|*aa
 AR|kk|*ce
 AR|kl|*aa
@@ -1787,7 +1787,7 @@ AR|kn|ಅರ್ಜೆಂಟಿನಾ
 AR|ko|아르헨티나
 AR|kr|*aa
 AR|ks|أرجَنٹینا
-AR|ku|Arjentîn
+AR|ku|Arjantîn
 AR|kv|*aa
 AR|kw|*aa
 AR|ky|*ce
@@ -1802,7 +1802,7 @@ AR|lu|Alijantine
 AR|lv|Argentīna
 AR|mg|Arzantina
 AR|mh|*aa
-AR|mi|*aa
+AR|mi|Āketina
 AR|mk|*ce
 AR|ml|അർജന്റീന
 AR|mn|Аргентин
@@ -1813,7 +1813,7 @@ AR|mt|l-Arġentina
 AR|my|အာဂျင်တီးနား
 AR|na|*aa
 AR|nb|*aa
-AR|nd|*ki
+AR|nd|*ha
 AR|ne|अर्जेन्टिना
 AR|ng|*aa
 AR|nl|*af
@@ -1824,7 +1824,7 @@ AR|nv|*aa
 AR|ny|*aa
 AR|oc|*aa
 AR|oj|*aa
-AR|om|*aa
+AR|om|Arjentiinaa
 AR|or|ଆର୍ଜେଣ୍ଟିନା
 AR|os|*aa
 AR|pa|ਅਰਜਨਟੀਨਾ
@@ -1847,7 +1847,7 @@ AR|si|ආර්ජෙන්ටිනාව
 AR|sk|*hu
 AR|sl|*aa
 AR|sm|*aa
-AR|sn|*ki
+AR|sn|*ha
 AR|so|Arjentiina
 AR|sq|Argjentinë
 AR|sr|*ce
@@ -1855,7 +1855,7 @@ AR|ss|*aa
 AR|st|*aa
 AR|su|*aa
 AR|sv|*aa
-AR|sw|*ki
+AR|sw|*ha
 AR|ta|அர்ஜென்டினா
 AR|te|అర్జెంటీనా
 AR|tg|*ce
@@ -1879,7 +1879,7 @@ AR|vi|*aa
 AR|vo|*aa
 AR|wa|*aa
 AR|wo|Arsàntin
-AR|xh|*aa
+AR|xh|E-Argentina
 AR|yi|*ji
 AR|yo|Agentínà
 AR|za|*aa
@@ -1907,14 +1907,14 @@ AS|bn|আমেরিকান সামোয়া
 AS|bo|*aa
 AS|br|Samoa Amerikan
 AS|bs|Američka Samoa
-AS|ca|Samoa Nord-americana
+AS|ca|Samoa Americana
 AS|ce|Американ Самоа
 AS|ch|*aa
 AS|co|*aa
 AS|cr|*aa
 AS|cs|Americká Samoa
 AS|cu|*aa
-AS|cv|*aa
+AS|cv|Америка Самоа
 AS|cy|Samoa America
 AS|da|Amerikansk Samoa
 AS|de|Amerikanisch-Samoa
@@ -1924,7 +1924,7 @@ AS|ee|Amerika Samoa nutome
 AS|el|Αμερικανική Σαμόα
 AS|en|*aa
 AS|eo|*aa
-AS|es|Samoa Americana
+AS|es|*ca
 AS|et|Ameerika Samoa
 AS|eu|Samoa Estatubatuarra
 AS|fa|ساموآی امریکا
@@ -1936,7 +1936,7 @@ AS|fr|Samoa américaines
 AS|fy|Amerikaansk Samoa
 AS|ga|Samó Mheiriceá
 AS|gd|Samotha na h-Aimeireaga
-AS|gl|*es
+AS|gl|*ca
 AS|gn|*aa
 AS|gu|અમેરિકન સમોઆ
 AS|gv|*aa
@@ -1945,7 +1945,7 @@ AS|he|סמואה האמריקנית
 AS|hi|अमेरिकी समोआ
 AS|ho|*aa
 AS|hr|*bs
-AS|ht|*aa
+AS|ht|*fr
 AS|hu|Amerikai Szamoa
 AS|hy|Ամերիկյան Սամոա
 AS|hz|*aa
@@ -1958,7 +1958,7 @@ AS|ik|*aa
 AS|in|*id
 AS|io|*aa
 AS|is|Bandaríska Samóa
-AS|it|Samoa americane
+AS|it|Samoa Americane
 AS|iu|*aa
 AS|iw|*he
 AS|ja|米領サモア
@@ -1990,7 +1990,7 @@ AS|lu|Samoa wa Ameriki
 AS|lv|ASV Samoa
 AS|mg|Samoa amerikanina
 AS|mh|*aa
-AS|mi|*aa
+AS|mi|Hāmoa-Amerika
 AS|mk|*bg
 AS|ml|അമേരിക്കൻ സമോവ
 AS|mn|Америкийн Самоа
@@ -2012,22 +2012,22 @@ AS|nv|*aa
 AS|ny|*aa
 AS|oc|*aa
 AS|oj|*aa
-AS|om|*aa
+AS|om|Saamowa Ameerikaa
 AS|or|ଆମେରିକାନ୍ ସାମୋଆ
 AS|os|*aa
 AS|pa|ਅਮੈਰੀਕਨ ਸਮੋਆ
 AS|pi|*aa
 AS|pl|Samoa Amerykańskie
 AS|ps|امریکایی ساماوا
-AS|pt|*es
-AS|qu|*es
-AS|rm|*es
+AS|pt|*ca
+AS|qu|*ca
+AS|rm|*ca
 AS|rn|Samowa nyamerika
 AS|ro|*mo
 AS|ru|Американское Самоа
 AS|rw|*aa
 AS|sa|*aa
-AS|sc|*aa
+AS|sc|Samoa americanas
 AS|sd|آمريڪي ساموا
 AS|se|Amerihká Samoa
 AS|sg|Samöa tî Amerîka
@@ -2048,7 +2048,7 @@ AS|ta|அமெரிக்க சமோவா
 AS|te|అమెరికన్ సమోవా
 AS|tg|Самоаи Америка
 AS|th|อเมริกันซามัว
-AS|ti|ኣሜሪካ ሳሞኣ
+AS|ti|ኣመሪካዊት ሳሞኣ
 AS|tk|Amerikan Samoasy
 AS|tl|*aa
 AS|tn|*aa
@@ -2067,7 +2067,7 @@ AS|vi|Samoa thuộc Mỹ
 AS|vo|*aa
 AS|wa|*aa
 AS|wo|Samowa bu Amerig
-AS|xh|*aa
+AS|xh|E-American Samoa
 AS|yi|*aa
 AS|yo|Sámóánì ti Orílẹ́ède Àméríkà
 AS|za|*aa
@@ -2102,7 +2102,7 @@ AT|co|*aa
 AT|cr|*aa
 AT|cs|Rakousko
 AT|cu|*aa
-AT|cv|*aa
+AT|cv|*ce
 AT|cy|Awstria
 AT|da|Østrig
 AT|de|Österreich
@@ -2133,7 +2133,7 @@ AT|he|אוסטריה
 AT|hi|ऑस्ट्रिया
 AT|ho|*aa
 AT|hr|*bs
-AT|ht|*aa
+AT|ht|*fr
 AT|hu|Ausztria
 AT|hy|Ավստրիա
 AT|hz|*aa
@@ -2156,13 +2156,13 @@ AT|ka|ავსტრია
 AT|kg|*aa
 AT|ki|*aa
 AT|kj|*aa
-AT|kk|*bg
+AT|kk|Аустрия
 AT|kl|*aa
 AT|km|អូទ្រីស
 AT|kn|ಆಸ್ಟ್ರಿಯಾ
 AT|ko|오스트리아
 AT|kr|*aa
-AT|ks|آسٹِیا
+AT|ks|آسٹریا
 AT|ku|Awistirya
 AT|kv|*aa
 AT|kw|*aa
@@ -2178,7 +2178,7 @@ AT|lu|*ln
 AT|lv|*bs
 AT|mg|Aotrisy
 AT|mh|*aa
-AT|mi|*aa
+AT|mi|Ataria
 AT|mk|Австрија
 AT|ml|ഓസ്ട്രിയ
 AT|mn|*ce
@@ -2200,7 +2200,7 @@ AT|nv|*aa
 AT|ny|*aa
 AT|oc|*aa
 AT|oj|*aa
-AT|om|*aa
+AT|om|Awustiriyaa
 AT|or|ଅଷ୍ଟ୍ରିଆ
 AT|os|*aa
 AT|pa|ਆਸਟਰੀਆ
@@ -2215,7 +2215,7 @@ AT|ro|*aa
 AT|ru|*bg
 AT|rw|*aa
 AT|sa|*aa
-AT|sc|*aa
+AT|sc|*ca
 AT|sd|آسٽريا
 AT|se|Nuortariika
 AT|sg|Otrîsi
@@ -2236,7 +2236,7 @@ AT|ta|ஆஸ்திரியா
 AT|te|ఆస్ట్రియా
 AT|tg|*bg
 AT|th|ออสเตรีย
-AT|ti|*am
+AT|ti|ኦስትርያ
 AT|tk|Awstriýa
 AT|tl|*aa
 AT|tn|*aa
@@ -2248,14 +2248,14 @@ AT|tw|*aa
 AT|ty|*aa
 AT|ug|ئاۋىستىرىيە
 AT|uk|Австрія
-AT|ur|آسٹریا
+AT|ur|*ks
 AT|uz|*az
 AT|ve|*aa
 AT|vi|Áo
 AT|vo|*aa
 AT|wa|*aa
 AT|wo|Ótiriis
-AT|xh|*aa
+AT|xh|E-Austria
 AT|yi|*ji
 AT|yo|Asítíríà
 AT|za|*aa
@@ -2290,7 +2290,7 @@ AU|co|*aa
 AU|cr|*aa
 AU|cs|Austrálie
 AU|cu|*aa
-AU|cv|*aa
+AU|cv|*ce
 AU|cy|Awstralia
 AU|da|Australien
 AU|de|*da
@@ -2321,7 +2321,7 @@ AU|he|אוסטרליה
 AU|hi|ऑस्ट्रेलिया
 AU|ho|*aa
 AU|hr|*bs
-AU|ht|*aa
+AU|ht|*fr
 AU|hu|Ausztrália
 AU|hy|Ավստրալիա
 AU|hz|*aa
@@ -2344,7 +2344,7 @@ AU|ka|ავსტრალია
 AU|kg|*aa
 AU|ki|*aa
 AU|kj|*aa
-AU|kk|*bg
+AU|kk|Аустралия
 AU|kl|*aa
 AU|km|អូស្ត្រាលី
 AU|kn|ಆಸ್ಟ್ರೇಲಿಯಾ
@@ -2366,7 +2366,7 @@ AU|lu|Ositali
 AU|lv|Austrālija
 AU|mg|*br
 AU|mh|*aa
-AU|mi|*aa
+AU|mi|Ahitereiria
 AU|mk|Австралија
 AU|ml|ഓസ്‌ട്രേലിയ
 AU|mn|*ce
@@ -2388,7 +2388,7 @@ AU|nv|*aa
 AU|ny|*aa
 AU|oc|*aa
 AU|oj|*aa
-AU|om|*aa
+AU|om|Awustiraaliyaa
 AU|or|ଅଷ୍ଟ୍ରେଲିଆ
 AU|os|*aa
 AU|pa|ਆਸਟ੍ਰੇਲੀਆ
@@ -2403,7 +2403,7 @@ AU|ro|*aa
 AU|ru|*bg
 AU|rw|*aa
 AU|sa|*aa
-AU|sc|*aa
+AU|sc|*ca
 AU|sd|آسٽريليا
 AU|se|*pt
 AU|sg|Ostralïi, Sotralïi
@@ -2424,7 +2424,7 @@ AU|ta|ஆஸ்திரேலியா
 AU|te|ఆస్ట్రేలియా
 AU|tg|*bg
 AU|th|ออสเตรเลีย
-AU|ti|ኣውስትራሊያ
+AU|ti|ኣውስትራልያ
 AU|tk|Awstraliýa
 AU|tl|*aa
 AU|tn|*aa
@@ -2443,9 +2443,9 @@ AU|vi|*aa
 AU|vo|*aa
 AU|wa|*aa
 AU|wo|Ostarali
-AU|xh|*aa
+AU|xh|E-Australia
 AU|yi|*ji
-AU|yo|Ástràlìá
+AU|yo|Austrálíà
 AU|za|*aa
 AU|zh|澳大利亚
 AU|zu|i-Australia
@@ -2478,7 +2478,7 @@ AW|co|*aa
 AW|cr|*aa
 AW|cs|*aa
 AW|cu|*aa
-AW|cv|*aa
+AW|cv|*be
 AW|cy|*aa
 AW|da|*aa
 AW|de|*aa
@@ -2554,7 +2554,7 @@ AW|lu|*aa
 AW|lv|*aa
 AW|mg|Arobà
 AW|mh|*aa
-AW|mi|*aa
+AW|mi|Arūpa
 AW|mk|*be
 AW|ml|അറൂബ
 AW|mn|*be
@@ -2576,7 +2576,7 @@ AW|nv|*aa
 AW|ny|*aa
 AW|oc|*aa
 AW|oj|*aa
-AW|om|*aa
+AW|om|Arubaa
 AW|or|ଆରୁବା
 AW|os|*aa
 AW|pa|ਅਰੂਬਾ
@@ -2631,7 +2631,7 @@ AW|vi|*aa
 AW|vo|*aa
 AW|wa|*aa
 AW|wo|*aa
-AW|xh|*aa
+AW|xh|E-Aruba
 AW|yi|*ji
 AW|yo|Árúbà
 AW|za|*aa
@@ -2641,7 +2641,7 @@ AX|aa|Åland Islands
 AX|ab|*aa
 AX|ae|*aa
 AX|af|Ålandeilande
-AX|ak|*aa
+AX|ak|Aland Aeland
 AX|am|የአላንድ ደሴቶች
 AX|an|*aa
 AX|ar|جزر آلاند
@@ -2655,7 +2655,7 @@ AX|bg|Оландски острови
 AX|bh|*aa
 AX|bi|*aa
 AX|bm|*aa
-AX|bn|আলান্ড দ্বীপপুঞ্জ
+AX|bn|অলান্ড দ্বীপপুঞ্জ
 AX|bo|*aa
 AX|br|Inizi Åland
 AX|bs|Olandska ostrva
@@ -2666,7 +2666,7 @@ AX|co|*aa
 AX|cr|*aa
 AX|cs|Ålandy
 AX|cu|*aa
-AX|cv|*aa
+AX|cv|Аланди утравӗсем
 AX|cy|Ynysoedd Åland
 AX|da|Åland
 AX|de|Ålandinseln
@@ -2697,14 +2697,14 @@ AX|he|איי אולנד
 AX|hi|एलैंड द्वीपसमूह
 AX|ho|*aa
 AX|hr|Ålandski otoci
-AX|ht|*aa
+AX|ht|*fr
 AX|hu|Åland-szigetek
 AX|hy|Ալանդյան կղզիներ
 AX|hz|*aa
 AX|ia|Insulas Åland
 AX|id|Kepulauan Aland
 AX|ie|*aa
-AX|ig|Agwaetiti Aland
+AX|ig|*aa
 AX|ii|*aa
 AX|ik|*aa
 AX|in|*id
@@ -2727,7 +2727,7 @@ AX|kn|ಆಲ್ಯಾಂಡ್ ದ್ವೀಪಗಳು
 AX|ko|올란드 제도
 AX|kr|*aa
 AX|ks|ایلینڑ جٔزیٖرٕ
-AX|ku|*aa
+AX|ku|Giravên Alandê
 AX|kv|*aa
 AX|kw|*aa
 AX|ky|*kk
@@ -2742,7 +2742,7 @@ AX|lu|*aa
 AX|lv|Olandes salas
 AX|mg|*aa
 AX|mh|*aa
-AX|mi|*aa
+AX|mi|Motu Ōrana
 AX|mk|Оландски Острови
 AX|ml|അലൻഡ് ദ്വീപുകൾ
 AX|mn|Аландын арлууд
@@ -2764,7 +2764,7 @@ AX|nv|*aa
 AX|ny|*aa
 AX|oc|*aa
 AX|oj|*aa
-AX|om|*aa
+AX|om|Odoloota Alaand
 AX|or|ଅଲାଣ୍ଡ ଦ୍ଵୀପପୁଞ୍ଜ
 AX|os|*aa
 AX|pa|ਅਲੈਂਡ ਟਾਪੂ
@@ -2779,7 +2779,7 @@ AX|ro|*mo
 AX|ru|Аландские о-ва
 AX|rw|*aa
 AX|sa|*aa
-AX|sc|*aa
+AX|sc|Ìsulas Åland
 AX|sd|الند ٻيٽ
 AX|se|Ålánda
 AX|sg|*aa
@@ -2819,9 +2819,9 @@ AX|vi|Quần đảo Åland
 AX|vo|*aa
 AX|wa|*aa
 AX|wo|Duni Aalànd
-AX|xh|*aa
+AX|xh|E-Åland Islands
 AX|yi|*aa
-AX|yo|Àwọn Erékùsù ti Åland
+AX|yo|Àwọn Erékùsù ti Aland
 AX|za|*aa
 AX|zh|奥兰群岛
 AX|zu|i-Åland Islands
@@ -2829,7 +2829,7 @@ AZ|aa|Azerbaijan
 AZ|ab|*aa
 AZ|ae|*aa
 AZ|af|Azerbeidjan
-AZ|ak|Azebaegyan
+AZ|ak|Asabegyan
 AZ|am|አዘርባጃን
 AZ|an|*aa
 AZ|ar|أذربيجان
@@ -2854,7 +2854,7 @@ AZ|co|*aa
 AZ|cr|*aa
 AZ|cs|Ázerbájdžán
 AZ|cu|*aa
-AZ|cv|*aa
+AZ|cv|*be
 AZ|cy|Aserbaijan
 AZ|da|Aserbajdsjan
 AZ|de|Aserbaidschan
@@ -2885,7 +2885,7 @@ AZ|he|אזרבייג׳ן
 AZ|hi|अज़रबैजान
 AZ|ho|*aa
 AZ|hr|Azerbajdžan
-AZ|ht|*aa
+AZ|ht|*fr
 AZ|hu|Azerbajdzsán
 AZ|hy|Ադրբեջան
 AZ|hz|*aa
@@ -2914,8 +2914,8 @@ AZ|km|អាស៊ែបៃហ្សង់
 AZ|kn|ಅಜರ್ಬೈಜಾನ್
 AZ|ko|아제르바이잔
 AZ|kr|*aa
-AZ|ks|آزَرباجان
-AZ|ku|Azerbaycan
+AZ|ks|آذربائیجان
+AZ|ku|Azerbeycan
 AZ|kv|*aa
 AZ|kw|*aa
 AZ|ky|Азербайжан
@@ -2930,7 +2930,7 @@ AZ|lu|Ajelbayidja
 AZ|lv|Azerbaidžāna
 AZ|mg|*br
 AZ|mh|*aa
-AZ|mi|*aa
+AZ|mi|Atepaihānia
 AZ|mk|Азербејџан
 AZ|ml|അസർബൈജാൻ
 AZ|mn|*ky
@@ -2952,7 +2952,7 @@ AZ|nv|*aa
 AZ|ny|*aa
 AZ|oc|*aa
 AZ|oj|*aa
-AZ|om|*aa
+AZ|om|Azerbaajiyaan
 AZ|or|ଆଜେରବାଇଜାନ୍
 AZ|os|*aa
 AZ|pa|ਅਜ਼ਰਬਾਈਜਾਨ
@@ -2967,7 +2967,7 @@ AZ|ro|*br
 AZ|ru|*be
 AZ|rw|*aa
 AZ|sa|*aa
-AZ|sc|*aa
+AZ|sc|Azerbaigiàn
 AZ|sd|آذربائيجان
 AZ|se|Aserbaižan
 AZ|sg|Zerebaidyäan, Azerbaidyäan,
@@ -2988,26 +2988,26 @@ AZ|ta|அசர்பைஜான்
 AZ|te|అజర్బైజాన్
 AZ|tg|Озарбойҷон
 AZ|th|อาเซอร์ไบจาน
-AZ|ti|ኣዘርበጃን
+AZ|ti|ኣዘርባጃን
 AZ|tk|Azerbaýjan
 AZ|tl|*aa
 AZ|tn|*aa
 AZ|to|ʻAsapaisani
-AZ|tr|*ku
+AZ|tr|Azerbaycan
 AZ|ts|*aa
 AZ|tt|Әзәрбайҗан
 AZ|tw|*aa
 AZ|ty|*aa
 AZ|ug|ئەزەربەيجان
 AZ|uk|*be
-AZ|ur|آذربائیجان
+AZ|ur|*ks
 AZ|uz|Ozarbayjon
 AZ|ve|*aa
 AZ|vi|*aa
 AZ|vo|*aa
 AZ|wa|*aa
 AZ|wo|Aserbayjaŋ
-AZ|xh|*aa
+AZ|xh|E-Azerbaijan
 AZ|yi|*aa
 AZ|yo|Asẹ́bájánì
 AZ|za|*aa
@@ -3042,7 +3042,7 @@ BA|co|*aa
 BA|cr|*aa
 BA|cs|Bosna a Hercegovina
 BA|cu|*aa
-BA|cv|*aa
+BA|cv|Боснипе Герцеговина
 BA|cy|Bosnia a Herzegovina
 BA|da|Bosnien-Hercegovina
 BA|de|Bosnien und Herzegowina
@@ -3051,7 +3051,7 @@ BA|dz|བྷོས་ནི་ཡ་ ཨེནཌ་ ཧར་ཛི་གྷོ
 BA|ee|Bosnia kple Herzergovina nutome
 BA|el|Βοσνία - Ερζεγοβίνη
 BA|en|*aa
-BA|eo|Bosnio-Hercegovino
+BA|eo|Bosnujo kaj Hercegovino
 BA|es|Bosnia y Herzegovina
 BA|et|Bosnia ja Hertsegoviina
 BA|eu|Bosnia-Herzegovina
@@ -3073,13 +3073,13 @@ BA|he|בוסניה והרצגובינה
 BA|hi|बोस्निया और हर्ज़ेगोविना
 BA|ho|*aa
 BA|hr|*bs
-BA|ht|*aa
+BA|ht|*fr
 BA|hu|Bosznia-Hercegovina
 BA|hy|Բոսնիա և Հերցեգովինա
 BA|hz|*aa
 BA|ia|Bosnia e Herzegovina
 BA|id|Bosnia dan Herzegovina
-BA|ie|*aa
+BA|ie|*ia
 BA|ig|*aa
 BA|ii|*aa
 BA|ik|*aa
@@ -3103,7 +3103,7 @@ BA|kn|ಬೋಸ್ನಿಯಾ ಮತ್ತು ಹರ್ಜೆಗೋವಿನಾ
 BA|ko|보스니아 헤르체고비나
 BA|kr|*aa
 BA|ks|بوسنِیا تہٕ ہَرزِگووِنا
-BA|ku|Bosniya û Herzegovîna
+BA|ku|Bosna û Hersek
 BA|kv|*aa
 BA|kw|*aa
 BA|ky|Босния жана Герцеговина
@@ -3118,10 +3118,10 @@ BA|lu|Mbosini ne Hezegovine
 BA|lv|Bosnija un Hercegovina
 BA|mg|Bosnia sy Herzegovina
 BA|mh|*aa
-BA|mi|*aa
+BA|mi|Pōngia-Herekōwini
 BA|mk|*bg
 BA|ml|ബോസ്നിയയും ഹെർസഗോവിനയും
-BA|mn|Босни-Герцеговин
+BA|mn|Босни-Херцеговин
 BA|mo|Bosnia și Herțegovina
 BA|mr|बोस्निया अणि हर्जेगोविना
 BA|ms|*id
@@ -3140,7 +3140,7 @@ BA|nv|*aa
 BA|ny|*aa
 BA|oc|*aa
 BA|oj|*aa
-BA|om|*aa
+BA|om|Bosiiniyaa fi Herzoogovinaa
 BA|or|ବୋସନିଆ ଏବଂ ହର୍ଜଗୋଭିନା
 BA|os|*aa
 BA|pa|ਬੋਸਨੀਆ ਅਤੇ ਹਰਜ਼ੇਗੋਵੀਨਾ
@@ -3155,8 +3155,8 @@ BA|ro|*mo
 BA|ru|Босния и Герцеговина
 BA|rw|*aa
 BA|sa|*aa
-BA|sc|*aa
-BA|sd|بوسنيا ۽ ھرزيگوينا
+BA|sc|Bòsnia e Erzegòvina
+BA|sd|بوسنيا ۽ هرزوگووينا
 BA|se|*nb
 BA|sg|Bosnïi na Herzegovînni
 BA|si|බොස්නියාව සහ හර්සගොවීනාව
@@ -3195,7 +3195,7 @@ BA|vi|Bosnia và Herzegovina
 BA|vo|*aa
 BA|wa|*aa
 BA|wo|Bosni Ersegowin
-BA|xh|*aa
+BA|xh|EBosnia & Herzegovina
 BA|yi|*ji
 BA|yo|Bọ̀síníà àti Ẹtisẹgófínà
 BA|za|*aa
@@ -3219,7 +3219,7 @@ BB|bg|Барбадос
 BB|bh|*aa
 BB|bi|*aa
 BB|bm|Barbadi
-BB|bn|বারবাদোস
+BB|bn|বার্বাডোজ
 BB|bo|*aa
 BB|br|*aa
 BB|bs|*aa
@@ -3230,7 +3230,7 @@ BB|co|*aa
 BB|cr|*aa
 BB|cs|*aa
 BB|cu|*aa
-BB|cv|*aa
+BB|cv|*bg
 BB|cy|*aa
 BB|da|*aa
 BB|de|*aa
@@ -3261,7 +3261,7 @@ BB|he|ברבדוס
 BB|hi|बारबाडोस
 BB|ho|*aa
 BB|hr|*aa
-BB|ht|*aa
+BB|ht|*fr
 BB|hu|*aa
 BB|hy|Բարբադոս
 BB|hz|*aa
@@ -3290,7 +3290,7 @@ BB|km|បាបាដុស
 BB|kn|ಬಾರ್ಬಡೋಸ್
 BB|ko|바베이도스
 BB|kr|*aa
-BB|ks|باربیڈاس
+BB|ks|باربیڈوس
 BB|ku|*aa
 BB|kv|*aa
 BB|kw|*aa
@@ -3306,7 +3306,7 @@ BB|lu|Barebade
 BB|lv|Barbadosa
 BB|mg|Barbady
 BB|mh|*aa
-BB|mi|*aa
+BB|mi|Papatohe
 BB|mk|*bg
 BB|ml|ബാർബഡോസ്
 BB|mn|*bg
@@ -3328,7 +3328,7 @@ BB|nv|*aa
 BB|ny|*aa
 BB|oc|*aa
 BB|oj|*aa
-BB|om|*aa
+BB|om|Barbaaros
 BB|or|ବାରବାଡୋସ୍
 BB|os|*aa
 BB|pa|ਬਾਰਬਾਡੋਸ
@@ -3383,7 +3383,7 @@ BB|vi|*aa
 BB|vo|*aa
 BB|wa|*aa
 BB|wo|Barbad
-BB|xh|*aa
+BB|xh|EBarbados
 BB|yi|*ji
 BB|yo|Bábádósì
 BB|za|*aa
@@ -3418,7 +3418,7 @@ BD|co|*aa
 BD|cr|*aa
 BD|cs|Bangladéš
 BD|cu|*aa
-BD|cv|*aa
+BD|cv|*bg
 BD|cy|*aa
 BD|da|*aa
 BD|de|Bangladesch
@@ -3444,7 +3444,7 @@ BD|gl|*aa
 BD|gn|*aa
 BD|gu|બાંગ્લાદેશ
 BD|gv|*aa
-BD|ha|Bangiladas
+BD|ha|*aa
 BD|he|בנגלדש
 BD|hi|बांग्लादेश
 BD|ho|*aa
@@ -3479,7 +3479,7 @@ BD|kn|ಬಾಂಗ್ಲಾದೇಶ
 BD|ko|방글라데시
 BD|kr|*aa
 BD|ks|بَنگلادیش
-BD|ku|Bangladeş
+BD|ku|Bengladeş
 BD|kv|*aa
 BD|kw|*aa
 BD|ky|*bg
@@ -3494,7 +3494,7 @@ BD|lu|Benguladeshi
 BD|lv|Bangladeša
 BD|mg|Bangladesy
 BD|mh|*aa
-BD|mi|*aa
+BD|mi|Pākaratēhi
 BD|mk|*bg
 BD|ml|ബംഗ്ലാദേശ്
 BD|mn|*bg
@@ -3516,7 +3516,7 @@ BD|nv|*aa
 BD|ny|*aa
 BD|oc|*aa
 BD|oj|*aa
-BD|om|*aa
+BD|om|Banglaadish
 BD|or|ବାଂଲାଦେଶ
 BD|os|*aa
 BD|pa|ਬੰਗਲਾਦੇਸ਼
@@ -3531,7 +3531,7 @@ BD|ro|*aa
 BD|ru|*bg
 BD|rw|*aa
 BD|sa|*aa
-BD|sc|*aa
+BD|sc|Bangladèsh
 BD|sd|بنگلاديش
 BD|se|*aa
 BD|sg|Bengladêshi
@@ -3552,12 +3552,12 @@ BD|ta|பங்களாதேஷ்
 BD|te|బంగ్లాదేశ్
 BD|tg|*bg
 BD|th|บังกลาเทศ
-BD|ti|*am
-BD|tk|*ku
+BD|ti|ባንግላደሽ
+BD|tk|Bangladeş
 BD|tl|*aa
 BD|tn|*aa
 BD|to|Pengilātesi
-BD|tr|*ku
+BD|tr|*tk
 BD|ts|*aa
 BD|tt|*bg
 BD|tw|*aa
@@ -3571,7 +3571,7 @@ BD|vi|*aa
 BD|vo|*aa
 BD|wa|*aa
 BD|wo|Bengalades
-BD|xh|*aa
+BD|xh|EBangladesh
 BD|yi|*ji
 BD|yo|Bángáládésì
 BD|za|*aa
@@ -3606,7 +3606,7 @@ BE|co|*aa
 BE|cr|*aa
 BE|cs|Belgie
 BE|cu|*aa
-BE|cv|*aa
+BE|cv|*ce
 BE|cy|Gwlad Belg
 BE|da|Belgien
 BE|de|*da
@@ -3637,15 +3637,15 @@ BE|he|בלגיה
 BE|hi|बेल्जियम
 BE|ho|*aa
 BE|hr|*bs
-BE|ht|*aa
+BE|ht|*fr
 BE|hu|*aa
 BE|hy|Բելգիա
 BE|hz|*aa
 BE|ia|Belgica
 BE|id|*br
-BE|ie|*aa
+BE|ie|*br
 BE|ig|*aa
-BE|ii|*aa
+BE|ii|ꀘꆹꏃ
 BE|ik|*aa
 BE|in|*br
 BE|io|*aa
@@ -3682,7 +3682,7 @@ BE|lu|Belejiki
 BE|lv|Beļģija
 BE|mg|Belzika
 BE|mh|*aa
-BE|mi|*aa
+BE|mi|Peretiama
 BE|mk|Белгија
 BE|ml|ബെൽജിയം
 BE|mn|*ce
@@ -3704,7 +3704,7 @@ BE|nv|*aa
 BE|ny|*aa
 BE|oc|*aa
 BE|oj|*aa
-BE|om|*aa
+BE|om|Beeljiyeem
 BE|or|ବେଲଜିୟମ୍
 BE|os|*aa
 BE|pa|ਬੈਲਜੀਅਮ
@@ -3719,7 +3719,7 @@ BE|ro|*br
 BE|ru|*kk
 BE|rw|*aa
 BE|sa|*aa
-BE|sc|*aa
+BE|sc|Bèlgiu
 BE|sd|بيلجيم
 BE|se|*br
 BE|sg|Bêleze, Belezîki
@@ -3740,7 +3740,7 @@ BE|ta|பெல்ஜியம்
 BE|te|బెల్జియం
 BE|tg|*bg
 BE|th|เบลเยียม
-BE|ti|ቤልጀም
+BE|ti|ቤልጅዩም
 BE|tk|Belgiýa
 BE|tl|*aa
 BE|tn|*aa
@@ -3759,7 +3759,7 @@ BE|vi|Bỉ
 BE|vo|*aa
 BE|wa|*aa
 BE|wo|Belsig
-BE|xh|*aa
+BE|xh|EBelgium
 BE|yi|*ji
 BE|yo|Bégíọ́mù
 BE|za|*aa
@@ -3794,7 +3794,7 @@ BF|co|*aa
 BF|cr|*aa
 BF|cs|*aa
 BF|cu|*aa
-BF|cv|*aa
+BF|cv|Буркина-Фасо
 BF|cy|*aa
 BF|da|*aa
 BF|de|*aa
@@ -3848,7 +3848,7 @@ BF|ka|ბურკინა-ფასო
 BF|kg|*aa
 BF|ki|Bukinafaso
 BF|kj|*aa
-BF|kk|Буркина-Фасо
+BF|kk|*cv
 BF|kl|*aa
 BF|km|បួគីណាហ្វាសូ
 BF|kn|ಬುರ್ಕಿನಾ ಫಾಸೊ
@@ -3858,7 +3858,7 @@ BF|ks|بُرکِنا فیسو
 BF|ku|Burkîna Faso
 BF|kv|*aa
 BF|kw|*aa
-BF|ky|*kk
+BF|ky|*cv
 BF|la|*aa
 BF|lb|*aa
 BF|lg|*bm
@@ -3870,7 +3870,7 @@ BF|lu|*ki
 BF|lv|Burkinafaso
 BF|mg|Borkina Faso
 BF|mh|*aa
-BF|mi|*aa
+BF|mi|Pākina Wharo
 BF|mk|*bg
 BF|ml|ബർക്കിന ഫാസോ
 BF|mn|*bg
@@ -3892,7 +3892,7 @@ BF|nv|*aa
 BF|ny|*aa
 BF|oc|*aa
 BF|oj|*aa
-BF|om|*aa
+BF|om|Burkiinaa Faasoo
 BF|or|ବୁର୍କିନା ଫାସୋ
 BF|os|*aa
 BF|pa|ਬੁਰਕੀਨਾ ਫ਼ਾਸੋ
@@ -3904,7 +3904,7 @@ BF|qu|*aa
 BF|rm|*aa
 BF|rn|*bm
 BF|ro|*aa
-BF|ru|*kk
+BF|ru|*cv
 BF|rw|*aa
 BF|sa|*aa
 BF|sc|*aa
@@ -3926,7 +3926,7 @@ BF|sv|*aa
 BF|sw|*ki
 BF|ta|புர்கினா ஃபாஸோ
 BF|te|బుర్కినా ఫాసో
-BF|tg|*kk
+BF|tg|*cv
 BF|th|บูร์กินาฟาโซ
 BF|ti|*am
 BF|tk|*sq
@@ -3935,7 +3935,7 @@ BF|tn|*aa
 BF|to|Pekano Faso
 BF|tr|*aa
 BF|ts|*aa
-BF|tt|*kk
+BF|tt|*cv
 BF|tw|*aa
 BF|ty|*aa
 BF|ug|بۇركىنا فاسو
@@ -3947,7 +3947,7 @@ BF|vi|*aa
 BF|vo|*aa
 BF|wa|*aa
 BF|wo|Burkina Faaso
-BF|xh|*aa
+BF|xh|EBurkina Faso
 BF|yi|*ji
 BF|yo|Bùùkíná Fasò
 BF|za|*aa
@@ -3958,7 +3958,7 @@ BG|ab|*aa
 BG|ae|*aa
 BG|af|Bulgarye
 BG|ak|Bɔlgeria
-BG|am|ቡልጌሪያ
+BG|am|ቡልጋሪያ
 BG|an|*aa
 BG|ar|بلغاريا
 BG|as|বুলগেৰিয়া
@@ -3982,7 +3982,7 @@ BG|co|*aa
 BG|cr|*aa
 BG|cs|Bulharsko
 BG|cu|*aa
-BG|cv|*aa
+BG|cv|*ce
 BG|cy|Bwlgaria
 BG|da|Bulgarien
 BG|de|*da
@@ -4013,7 +4013,7 @@ BG|he|בולגריה
 BG|hi|बुल्गारिया
 BG|ho|*aa
 BG|hr|*bs
-BG|ht|*aa
+BG|ht|*fr
 BG|hu|Bulgária
 BG|hy|Բուլղարիա
 BG|hz|*aa
@@ -4058,7 +4058,7 @@ BG|lu|*ln
 BG|lv|Bulgārija
 BG|mg|Biolgaria
 BG|mh|*aa
-BG|mi|*aa
+BG|mi|Purukāria
 BG|mk|Бугарија
 BG|ml|ബൾഗേറിയ
 BG|mn|Болгар
@@ -4080,7 +4080,7 @@ BG|nv|*aa
 BG|ny|*aa
 BG|oc|*aa
 BG|oj|*aa
-BG|om|*aa
+BG|om|Bulgaariyaa
 BG|or|ବୁଲଗେରିଆ
 BG|os|*aa
 BG|pa|ਬੁਲਗਾਰੀਆ
@@ -4116,7 +4116,7 @@ BG|ta|பல்கேரியா
 BG|te|బల్గేరియా
 BG|tg|Булғория
 BG|th|บัลแกเรีย
-BG|ti|ቡልጋሪያ
+BG|ti|ቡልጋርያ
 BG|tk|Bolgariýa
 BG|tl|*aa
 BG|tn|*aa
@@ -4135,7 +4135,7 @@ BG|vi|*aa
 BG|vo|*aa
 BG|wa|*aa
 BG|wo|Bilgari
-BG|xh|*aa
+BG|xh|EBulgaria
 BG|yi|*ji
 BG|yo|Bùùgáríà
 BG|za|*aa
@@ -4159,7 +4159,7 @@ BH|bg|Бахрейн
 BH|bh|*aa
 BH|bi|*aa
 BH|bm|Bareyini
-BH|bn|বাহরাইন
+BH|bn|বাহারিন
 BH|bo|*aa
 BH|br|*af
 BH|bs|*af
@@ -4170,7 +4170,7 @@ BH|co|*aa
 BH|cr|*aa
 BH|cs|Bahrajn
 BH|cu|*aa
-BH|cv|*aa
+BH|cv|*bg
 BH|cy|*aa
 BH|da|*aa
 BH|de|*aa
@@ -4196,12 +4196,12 @@ BH|gl|*aa
 BH|gn|*aa
 BH|gu|બેહરીન
 BH|gv|*aa
-BH|ha|Baharan
+BH|ha|Baharen
 BH|he|בחריין
 BH|hi|बहरीन
 BH|ho|*aa
 BH|hr|*af
-BH|ht|*aa
+BH|ht|*fr
 BH|hu|*af
 BH|hy|Բահրեյն
 BH|hz|*aa
@@ -4246,7 +4246,7 @@ BH|lu|Bahrene
 BH|lv|Bahreina
 BH|mg|*aa
 BH|mh|*aa
-BH|mi|*aa
+BH|mi|Pāreina
 BH|mk|Бахреин
 BH|ml|ബഹ്റിൻ
 BH|mn|*bg
@@ -4268,7 +4268,7 @@ BH|nv|*aa
 BH|ny|*aa
 BH|oc|*aa
 BH|oj|*aa
-BH|om|*aa
+BH|om|Baahireen
 BH|or|ବାହାରିନ୍
 BH|os|*aa
 BH|pa|ਬਹਿਰੀਨ
@@ -4283,7 +4283,7 @@ BH|ro|*aa
 BH|ru|*bg
 BH|rw|*aa
 BH|sa|*aa
-BH|sc|*aa
+BH|sc|*af
 BH|sd|*ps
 BH|se|*aa
 BH|sg|Bahrâina
@@ -4323,7 +4323,7 @@ BH|vi|*aa
 BH|vo|*aa
 BH|wa|*aa
 BH|wo|Bahreyin
-BH|xh|*aa
+BH|xh|EBahrain
 BH|yi|*aa
 BH|yo|Báránì
 BH|za|*aa
@@ -4358,7 +4358,7 @@ BI|co|*aa
 BI|cr|*aa
 BI|cs|*aa
 BI|cu|*aa
-BI|cv|*aa
+BI|cv|*bg
 BI|cy|*aa
 BI|da|*aa
 BI|de|*aa
@@ -4419,7 +4419,7 @@ BI|kn|ಬುರುಂಡಿ
 BI|ko|부룬디
 BI|kr|*aa
 BI|ks|بورَنڈِ
-BI|ku|Burundî
+BI|ku|Bûrûndî
 BI|kv|*aa
 BI|kw|*aa
 BI|ky|*bg
@@ -4434,7 +4434,7 @@ BI|lu|*aa
 BI|lv|Burundija
 BI|mg|Borondi
 BI|mh|*aa
-BI|mi|*aa
+BI|mi|Puruniti
 BI|mk|*bg
 BI|ml|ബറുണ്ടി
 BI|mn|*bg
@@ -4456,7 +4456,7 @@ BI|nv|*aa
 BI|ny|*aa
 BI|oc|*aa
 BI|oj|*aa
-BI|om|*aa
+BI|om|Burundii
 BI|or|ବୁରୁଣ୍ଡି
 BI|os|*aa
 BI|pa|ਬੁਰੁੰਡੀ
@@ -4492,7 +4492,7 @@ BI|ta|புருண்டி
 BI|te|బురుండి
 BI|tg|*bg
 BI|th|บุรุนดี
-BI|ti|ቡሩንዲ
+BI|ti|*am
 BI|tk|*aa
 BI|tl|*aa
 BI|tn|*aa
@@ -4511,7 +4511,7 @@ BI|vi|*aa
 BI|vo|*aa
 BI|wa|*aa
 BI|wo|*aa
-BI|xh|*aa
+BI|xh|EBurundi
 BI|yi|*he
 BI|yo|Bùùrúndì
 BI|za|*aa
@@ -4546,7 +4546,7 @@ BJ|co|*aa
 BJ|cr|*aa
 BJ|cs|*aa
 BJ|cu|*aa
-BJ|cv|*aa
+BJ|cv|*bg
 BJ|cy|*aa
 BJ|da|*aa
 BJ|de|*aa
@@ -4577,14 +4577,14 @@ BJ|he|בנין
 BJ|hi|बेनिन
 BJ|ho|*aa
 BJ|hr|*aa
-BJ|ht|*aa
+BJ|ht|*fr
 BJ|hu|*aa
 BJ|hy|Բենին
 BJ|hz|*aa
 BJ|ia|*aa
 BJ|id|*aa
 BJ|ie|*aa
-BJ|ig|*ha
+BJ|ig|*aa
 BJ|ii|*aa
 BJ|ik|*aa
 BJ|in|*aa
@@ -4622,7 +4622,7 @@ BJ|lu|Bene
 BJ|lv|Benina
 BJ|mg|*aa
 BJ|mh|*aa
-BJ|mi|*aa
+BJ|mi|Penīna
 BJ|mk|*bg
 BJ|ml|ബെനിൻ
 BJ|mn|*bg
@@ -4644,7 +4644,7 @@ BJ|nv|*aa
 BJ|ny|*aa
 BJ|oc|*aa
 BJ|oj|*aa
-BJ|om|*aa
+BJ|om|Beenii
 BJ|or|ବେନିନ୍
 BJ|os|*aa
 BJ|pa|ਬੇਨਿਨ
@@ -4699,7 +4699,7 @@ BJ|vi|*aa
 BJ|vo|*aa
 BJ|wa|*aa
 BJ|wo|*ff
-BJ|xh|*aa
+BJ|xh|EBenin
 BJ|yi|*ji
 BJ|yo|Bẹ̀nẹ̀
 BJ|za|*aa
@@ -4709,8 +4709,8 @@ BL|aa|St. Barthélemy
 BL|ab|*aa
 BL|ae|*aa
 BL|af|Sint Barthélemy
-BL|ak|*aa
-BL|am|ቅዱስ በርቴሎሜ
+BL|ak|St. Baatilemi
+BL|am|ሴንት ባርቴሌሚ
 BL|an|*aa
 BL|ar|سان بارتليمي
 BL|as|ছেইণ্ট বাৰ্থলেমে
@@ -4723,18 +4723,18 @@ BL|bg|Сен Бартелеми
 BL|bh|*aa
 BL|bi|*aa
 BL|bm|*aa
-BL|bn|সেন্ট বারথেলিমি
+BL|bn|সেন্ট বার্থেলেমি
 BL|bo|*aa
 BL|br|Saint Barthélemy
 BL|bs|Sveti Bartolomej
-BL|ca|*br
+BL|ca|Saint-Barthélemy
 BL|ce|Сен-Бартельми
 BL|ch|*aa
 BL|co|*aa
 BL|cr|*aa
 BL|cs|Svatý Bartoloměj
 BL|cu|*aa
-BL|cv|*aa
+BL|cv|Сен-Бартелеми
 BL|cy|*br
 BL|da|*br
 BL|de|*aa
@@ -4745,14 +4745,14 @@ BL|el|Άγιος Βαρθολομαίος
 BL|en|*aa
 BL|eo|*aa
 BL|es|San Bartolomé
-BL|et|Saint-Barthélemy
+BL|et|*ca
 BL|eu|*br
 BL|fa|سن بارتلمی
 BL|ff|*aa
-BL|fi|*et
+BL|fi|*ca
 BL|fj|*aa
 BL|fo|*aa
-BL|fr|*et
+BL|fr|*ca
 BL|fy|*br
 BL|ga|*br
 BL|gd|*br
@@ -4765,20 +4765,20 @@ BL|he|סנט ברתולומיאו
 BL|hi|सेंट बार्थेलेमी
 BL|ho|*aa
 BL|hr|*br
-BL|ht|*aa
-BL|hu|*et
+BL|ht|*ca
+BL|hu|*ca
 BL|hy|Սուրբ Բարդուղիմեոս
 BL|hz|*aa
-BL|ia|*aa
+BL|ia|Sancte Bartholomeo
 BL|id|*br
 BL|ie|*aa
-BL|ig|Barthélemy Dị nsọ
+BL|ig|*aa
 BL|ii|*aa
 BL|ik|*aa
 BL|in|*br
 BL|io|*aa
 BL|is|Sankti Bartólómeusareyjar
-BL|it|*et
+BL|it|*ca
 BL|iu|*aa
 BL|iw|*he
 BL|ja|サン・バルテルミー
@@ -4788,19 +4788,19 @@ BL|ka|სენ-ბართელმი
 BL|kg|*aa
 BL|ki|*aa
 BL|kj|*aa
-BL|kk|Сен-Бартелеми
+BL|kk|*cv
 BL|kl|*aa
 BL|km|សាំង​បាថេឡេមី
 BL|kn|ಸೇಂಟ್ ಬಾರ್ಥೆಲೆಮಿ
 BL|ko|생바르텔레미
 BL|kr|*aa
 BL|ks|سینٹ بارتَھیلمی
-BL|ku|*et
+BL|ku|Saint Barthelemy
 BL|kv|*aa
 BL|kw|*aa
 BL|ky|Сент Бартелеми
 BL|la|*aa
-BL|lb|*et
+BL|lb|*ca
 BL|lg|*aa
 BL|li|*aa
 BL|ln|*aa
@@ -4810,44 +4810,44 @@ BL|lu|*aa
 BL|lv|Senbartelmī
 BL|mg|*aa
 BL|mh|*aa
-BL|mi|*aa
+BL|mi|Hato Pāteremi
 BL|mk|Свети Вартоломеј
 BL|ml|സെന്റ് ബാർത്തലമി
 BL|mn|Сент-Бартельми
-BL|mo|*et
+BL|mo|*ca
 BL|mr|*hi
 BL|ms|St. Barthelemy
 BL|mt|*br
 BL|my|စိန့်ဘာသယ်လ်မီ
 BL|na|*aa
-BL|nb|*et
+BL|nb|*ca
 BL|nd|*aa
 BL|ne|सेन्ट बार्थेलेमी
 BL|ng|*aa
-BL|nl|*et
-BL|nn|*br
-BL|no|*et
+BL|nl|*ca
+BL|nn|*ca
+BL|no|*ca
 BL|nr|*aa
 BL|nv|*aa
 BL|ny|*aa
 BL|oc|*aa
 BL|oj|*aa
-BL|om|*aa
+BL|om|St. Barzeleemii
 BL|or|ସେଣ୍ଟ ବାର୍ଥେଲେମି
 BL|os|*aa
 BL|pa|ਸੇਂਟ ਬਾਰਥੇਲੇਮੀ
 BL|pi|*aa
-BL|pl|*et
+BL|pl|*ca
 BL|ps|سينټ بارتيلمي
 BL|pt|São Bartolomeu
 BL|qu|*es
 BL|rm|Son Barthélemy
 BL|rn|*aa
-BL|ro|*et
-BL|ru|*kk
+BL|ro|*ca
+BL|ru|*cv
 BL|rw|*aa
 BL|sa|*aa
-BL|sc|*aa
+BL|sc|Santu Bartolomeu
 BL|sd|سینٽ برٿلیمی
 BL|se|*br
 BL|sg|*aa
@@ -4868,12 +4868,12 @@ BL|ta|செயின்ட் பார்தேலெமி
 BL|te|సెయింట్ బర్థెలిమి
 BL|tg|Сент-Бартелми
 BL|th|เซนต์บาร์เธเลมี
-BL|ti|ቅዱስ ባርተለሚይ
+BL|ti|ቅዱስ ባርተለሚ
 BL|tk|*sq
 BL|tl|*aa
 BL|tn|*aa
 BL|to|Sā Patēlemi
-BL|tr|Saint Barthelemy
+BL|tr|*ku
 BL|ts|*aa
 BL|tt|*ce
 BL|tw|*aa
@@ -4887,9 +4887,9 @@ BL|vi|*aa
 BL|vo|*aa
 BL|wa|*aa
 BL|wo|Saŋ Bartalemi
-BL|xh|*aa
+BL|xh|ESt. Barthélemy
 BL|yi|*aa
-BL|yo|*aa
+BL|yo|Ìlú Bátílẹ́mì
 BL|za|*aa
 BL|zh|圣巴泰勒米
 BL|zu|i-Saint Barthélemy
@@ -4922,7 +4922,7 @@ BM|co|*aa
 BM|cr|*aa
 BM|cs|Bermudy
 BM|cu|*aa
-BM|cv|*aa
+BM|cv|Бермуд утравӗсем
 BM|cy|*aa
 BM|da|*aa
 BM|de|*aa
@@ -4953,7 +4953,7 @@ BM|he|ברמודה
 BM|hi|बरमूडा
 BM|ho|*aa
 BM|hr|*bm
-BM|ht|*aa
+BM|ht|*ca
 BM|hu|*aa
 BM|hy|Բերմուդներ
 BM|hz|*aa
@@ -4982,7 +4982,7 @@ BM|km|ប៊ឺមុយដា
 BM|kn|ಬರ್ಮುಡಾ
 BM|ko|버뮤다
 BM|kr|*aa
-BM|ks|بٔرمیوڈا
+BM|ks|*ar
 BM|ku|Bermûda
 BM|kv|*aa
 BM|kw|*aa
@@ -4998,7 +4998,7 @@ BM|lu|*aa
 BM|lv|Bermudu salas
 BM|mg|Bermioda
 BM|mh|*aa
-BM|mi|*aa
+BM|mi|Pāmura
 BM|mk|Бермуди
 BM|ml|ബർമുഡ
 BM|mn|Бермуда
@@ -5020,7 +5020,7 @@ BM|nv|*aa
 BM|ny|*aa
 BM|oc|*aa
 BM|oj|*aa
-BM|om|*aa
+BM|om|Beermudaa
 BM|or|ବର୍ମୁଡା
 BM|os|*aa
 BM|pa|ਬਰਮੂਡਾ
@@ -5035,7 +5035,7 @@ BM|ro|*aa
 BM|ru|Бермудские о-ва
 BM|rw|*aa
 BM|sa|*aa
-BM|sc|*aa
+BM|sc|*es
 BM|sd|*ar
 BM|se|*aa
 BM|sg|Beremûda
@@ -5046,7 +5046,7 @@ BM|sm|*aa
 BM|sn|*aa
 BM|so|Barmuuda
 BM|sq|Bermude
-BM|sr|*mn
+BM|sr|*mk
 BM|ss|*aa
 BM|st|*aa
 BM|su|*aa
@@ -5056,7 +5056,7 @@ BM|ta|பெர்முடா
 BM|te|బెర్ముడా
 BM|tg|*mn
 BM|th|เบอร์มิวดา
-BM|ti|*am
+BM|ti|በርሙዳ
 BM|tk|*aa
 BM|tl|*aa
 BM|tn|*aa
@@ -5075,7 +5075,7 @@ BM|vi|*aa
 BM|vo|*aa
 BM|wa|*aa
 BM|wo|Bermid
-BM|xh|*aa
+BM|xh|EBermuda
 BM|yi|*ji
 BM|yo|Bémúdà
 BM|za|*aa
@@ -5110,7 +5110,7 @@ BN|co|*aa
 BN|cr|*aa
 BN|cs|*bs
 BN|cu|*aa
-BN|cv|*aa
+BN|cv|*ce
 BN|cy|*aa
 BN|da|*aa
 BN|de|Brunei Darussalam
@@ -5170,7 +5170,7 @@ BN|km|ព្រុយណេ
 BN|kn|ಬ್ರೂನಿ
 BN|ko|브루나이
 BN|kr|*aa
-BN|ks|بُرنٔے
+BN|ks|برونے
 BN|ku|Brûney
 BN|kv|*aa
 BN|kw|*aa
@@ -5186,7 +5186,7 @@ BN|lu|*ln
 BN|lv|Bruneja
 BN|mg|*aa
 BN|mh|*aa
-BN|mi|*aa
+BN|mi|Poronai
 BN|mk|Брунеј
 BN|ml|ബ്രൂണൈ
 BN|mn|*be
@@ -5208,7 +5208,7 @@ BN|nv|*aa
 BN|ny|*aa
 BN|oc|*aa
 BN|oj|*aa
-BN|om|*aa
+BN|om|Biruniyee
 BN|or|ବ୍ରୁନେଇ
 BN|os|*aa
 BN|pa|ਬਰੂਨੇਈ
@@ -5220,7 +5220,7 @@ BN|qu|*es
 BN|rm|*aa
 BN|rn|Buruneyi
 BN|ro|*aa
-BN|ru|*ce
+BN|ru|*be
 BN|rw|*aa
 BN|sa|*aa
 BN|sc|*aa
@@ -5263,7 +5263,7 @@ BN|vi|*aa
 BN|vo|*aa
 BN|wa|*aa
 BN|wo|Burney
-BN|xh|*aa
+BN|xh|eBrunei
 BN|yi|*he
 BN|yo|Búrúnẹ́lì
 BN|za|*aa
@@ -5298,7 +5298,7 @@ BO|co|*aa
 BO|cr|*aa
 BO|cs|Bolívie
 BO|cu|*aa
-BO|cv|*aa
+BO|cv|*ce
 BO|cy|Bolifia
 BO|da|*aa
 BO|de|Bolivien
@@ -5329,7 +5329,7 @@ BO|he|בוליביה
 BO|hi|बोलीविया
 BO|ho|*aa
 BO|hr|*bs
-BO|ht|*aa
+BO|ht|*fr
 BO|hu|*ca
 BO|hy|Բոլիվիա
 BO|hz|*aa
@@ -5374,7 +5374,7 @@ BO|lu|Mbolivi
 BO|lv|Bolīvija
 BO|mg|*aa
 BO|mh|*aa
-BO|mi|*aa
+BO|mi|Poriwia
 BO|mk|Боливија
 BO|ml|ബൊളീവിയ
 BO|mn|*ce
@@ -5396,8 +5396,8 @@ BO|nv|*aa
 BO|ny|*aa
 BO|oc|*aa
 BO|oj|*aa
-BO|om|*aa
-BO|or|ବୋଲଭିଆ
+BO|om|Boliiviyaa
+BO|or|ବୋଲିଭିଆ
 BO|os|*aa
 BO|pa|ਬੋਲੀਵੀਆ
 BO|pi|*aa
@@ -5411,7 +5411,7 @@ BO|ro|*aa
 BO|ru|*bg
 BO|rw|*aa
 BO|sa|*aa
-BO|sc|*aa
+BO|sc|Bolìvia
 BO|sd|بوليويا
 BO|se|*aa
 BO|sg|Bolivïi
@@ -5432,7 +5432,7 @@ BO|ta|பொலிவியா
 BO|te|బొలీవియా
 BO|tg|*bg
 BO|th|โบลิเวีย
-BO|ti|*am
+BO|ti|ቦሊቭያ
 BO|tk|Boliwiýa
 BO|tl|*aa
 BO|tn|*aa
@@ -5451,7 +5451,7 @@ BO|vi|*aa
 BO|vo|*aa
 BO|wa|*aa
 BO|wo|Boliwi
-BO|xh|*aa
+BO|xh|EBolivia
 BO|yi|*ji
 BO|yo|Bọ̀lífíyà
 BO|za|*aa
@@ -5486,7 +5486,7 @@ BQ|co|*aa
 BQ|cr|*aa
 BQ|cs|Karibské Nizozemsko
 BQ|cu|*aa
-BQ|cv|*aa
+BQ|cv|Бонэйр, Синт-Эстатиус тата Саба
 BQ|cy|Antilles yr Iseldiroedd
 BQ|da|De tidligere Nederlandske Antiller
 BQ|de|Karibische Niederlande
@@ -5497,7 +5497,7 @@ BQ|el|Ολλανδία Καραϊβικής
 BQ|en|*aa
 BQ|eo|*aa
 BQ|es|Caribe neerlandés
-BQ|et|Hollandi Kariibi mere saared
+BQ|et|Kariibi Madalmaad
 BQ|eu|Karibeko Herbehereak
 BQ|fa|جزایر کارائیب هلند
 BQ|ff|*aa
@@ -5517,11 +5517,11 @@ BQ|he|האיים הקריביים ההולנדיים
 BQ|hi|कैरिबियन नीदरलैंड
 BQ|ho|*aa
 BQ|hr|Karipski otoci Nizozemske
-BQ|ht|*aa
+BQ|ht|*fr
 BQ|hu|Holland Karib-térség
 BQ|hy|Կարիբյան Նիդեռլանդներ
 BQ|hz|*aa
-BQ|ia|*aa
+BQ|ia|Paises Basse caribe
 BQ|id|Belanda Karibia
 BQ|ie|*aa
 BQ|ig|*aa
@@ -5530,7 +5530,7 @@ BQ|ik|*aa
 BQ|in|*id
 BQ|io|*aa
 BQ|is|Karíbahafshluti Hollands
-BQ|it|Caraibi olandesi
+BQ|it|Caraibi Olandesi
 BQ|iu|*aa
 BQ|iw|*he
 BQ|ja|オランダ領カリブ
@@ -5546,8 +5546,8 @@ BQ|km|ហូឡង់ ការ៉ាប៊ីន
 BQ|kn|ಕೆರೀಬಿಯನ್ ನೆದರ್‌ಲ್ಯಾಂಡ್ಸ್
 BQ|ko|네덜란드령 카리브
 BQ|kr|*aa
-BQ|ks|برطانوی قُطبہِ جَنوٗبی علاقہٕ
-BQ|ku|*aa
+BQ|ks|کیریبین نیدرلینڈس
+BQ|ku|Holendaya Karayîbê
 BQ|kv|*aa
 BQ|kw|*aa
 BQ|ky|Кариб Нидерланддары
@@ -5562,7 +5562,7 @@ BQ|lu|*aa
 BQ|lv|Nīderlandes Karību salas
 BQ|mg|*aa
 BQ|mh|*aa
-BQ|mi|*aa
+BQ|mi|Karapīana Hōrana
 BQ|mk|Карипска Холандија
 BQ|ml|കരീബിയൻ നെതർലാൻഡ്സ്
 BQ|mn|Карибын Нидерланд
@@ -5584,7 +5584,7 @@ BQ|nv|*aa
 BQ|ny|*aa
 BQ|oc|*aa
 BQ|oj|*aa
-BQ|om|*aa
+BQ|om|Neezerlaandota Kariibaan
 BQ|or|କାରବିୟନ୍‌ ନେଦରଲ୍ୟାଣ୍ଡ
 BQ|os|*aa
 BQ|pa|ਕੈਰੇਬੀਆਈ ਨੀਦਰਲੈਂਡ
@@ -5599,7 +5599,7 @@ BQ|ro|*mo
 BQ|ru|Бонэйр, Синт-Эстатиус и Саба
 BQ|rw|*aa
 BQ|sa|*aa
-BQ|sc|*aa
+BQ|sc|Caràibes olandesas
 BQ|sd|ڪيريبين نيدرلينڊ
 BQ|se|*aa
 BQ|sg|*aa
@@ -5618,16 +5618,16 @@ BQ|sv|Karibiska Nederländerna
 BQ|sw|Uholanzi ya Karibiani
 BQ|ta|கரீபியன் நெதர்லாந்து
 BQ|te|కరీబియన్ నెదర్లాండ్స్
-BQ|tg|*aa
+BQ|tg|Кариби Нидерланд
 BQ|th|เนเธอร์แลนด์แคริบเบียน
-BQ|ti|ካሪቢያን ኔዘርላንድስ
+BQ|ti|ካሪብያን ኔዘርላንድ
 BQ|tk|Karib Niderlandlary
 BQ|tl|*aa
 BQ|tn|*aa
 BQ|to|Kalipiane fakahōlani
 BQ|tr|Karayip Hollandası
 BQ|ts|*aa
-BQ|tt|*aa
+BQ|tt|Кариб Нидерландлары
 BQ|tw|*aa
 BQ|ty|*aa
 BQ|ug|كارىب دېڭىزى گوللاندىيە
@@ -5638,10 +5638,10 @@ BQ|ve|*aa
 BQ|vi|Ca-ri-bê Hà Lan
 BQ|vo|*aa
 BQ|wa|*aa
-BQ|wo|*aa
-BQ|xh|*aa
+BQ|wo|Pays-Bas bu Caraïbe
+BQ|xh|ECaribbean Netherlands
 BQ|yi|*aa
-BQ|yo|*aa
+BQ|yo|Kàríbíánì ti Nẹ́dálándì
 BQ|za|*aa
 BQ|zh|荷属加勒比区
 BQ|zu|i-Caribbean Netherlands
@@ -5674,7 +5674,7 @@ BR|co|*aa
 BR|cr|*aa
 BR|cs|Brazílie
 BR|cu|*aa
-BR|cv|*aa
+BR|cv|*ce
 BR|cy|*ca
 BR|da|Brasilien
 BR|de|*da
@@ -5696,7 +5696,7 @@ BR|fr|Brésil
 BR|fy|Brazilië
 BR|ga|an Bhrasaíl
 BR|gd|Braisil
-BR|gl|O Brasil
+BR|gl|*ca
 BR|gn|*aa
 BR|gu|બ્રાઝિલ
 BR|gv|*aa
@@ -5705,7 +5705,7 @@ BR|he|ברזיל
 BR|hi|ब्राज़ील
 BR|ho|*aa
 BR|hr|*aa
-BR|ht|*aa
+BR|ht|*fr
 BR|hu|Brazília
 BR|hy|Բրազիլիա
 BR|hz|*aa
@@ -5735,7 +5735,7 @@ BR|kn|ಬ್ರೆಜಿಲ್
 BR|ko|브라질
 BR|kr|*aa
 BR|ks|برازِل
-BR|ku|Brazîl
+BR|ku|Brezîlya
 BR|kv|*aa
 BR|kw|*aa
 BR|ky|*bg
@@ -5750,7 +5750,7 @@ BR|lu|Mnulezile
 BR|lv|Brazīlija
 BR|mg|Brezila
 BR|mh|*aa
-BR|mi|Parahi
+BR|mi|Parīhi
 BR|mk|Бразил
 BR|ml|ബ്രസീൽ
 BR|mn|*mk
@@ -5772,7 +5772,7 @@ BR|nv|*aa
 BR|ny|*aa
 BR|oc|*aa
 BR|oj|*aa
-BR|om|*aa
+BR|om|Biraazil
 BR|or|ବ୍ରାଜିଲ୍
 BR|os|*ce
 BR|pa|ਬ੍ਰਾਜ਼ੀਲ
@@ -5787,7 +5787,7 @@ BR|ro|*mo
 BR|ru|*bg
 BR|rw|*aa
 BR|sa|ब्राजील
-BR|sc|*aa
+BR|sc|*it
 BR|sd|برازيل
 BR|se|*ca
 BR|sg|Brezîli
@@ -5827,7 +5827,7 @@ BR|vi|*aa
 BR|vo|*aa
 BR|wa|*aa
 BR|wo|Beresil
-BR|xh|*aa
+BR|xh|EBrazil
 BR|yi|*ji
 BR|yo|Bàràsílì
 BR|za|*aa
@@ -5862,7 +5862,7 @@ BS|co|*aa
 BS|cr|*aa
 BS|cs|Bahamy
 BS|cu|*aa
-BS|cv|*aa
+BS|cv|Пахам утравӗсем
 BS|cy|Y Bahamas
 BS|da|*aa
 BS|de|*aa
@@ -5911,7 +5911,7 @@ BS|iu|*aa
 BS|iw|*he
 BS|ja|バハマ
 BS|ji|באַהאַמאַס
-BS|jv|*aa
+BS|jv|*ak
 BS|ka|ბაჰამის კუნძულები
 BS|kg|*aa
 BS|ki|*ak
@@ -5938,7 +5938,7 @@ BS|lu|Bahamase
 BS|lv|Bahamu salas
 BS|mg|*aa
 BS|mh|*aa
-BS|mi|*aa
+BS|mi|Pahama
 BS|mk|Бахами
 BS|ml|ബഹാമാസ്
 BS|mn|Багамын арлууд
@@ -5960,7 +5960,7 @@ BS|nv|*aa
 BS|ny|*aa
 BS|oc|*aa
 BS|oj|*aa
-BS|om|*aa
+BS|om|Bahaamas
 BS|or|ବାହାମାସ୍
 BS|os|*aa
 BS|pa|ਬਹਾਮਾਸ
@@ -5984,7 +5984,7 @@ BS|sk|*cs
 BS|sl|*bs
 BS|sm|*aa
 BS|sn|*ak
-BS|so|Bahaamas
+BS|so|*om
 BS|sq|*ak
 BS|sr|*mk
 BS|ss|*aa
@@ -6000,7 +6000,7 @@ BS|ti|*am
 BS|tk|Bagama adalary
 BS|tl|*aa
 BS|tn|*aa
-BS|to|Pahama
+BS|to|*mi
 BS|tr|Bahamalar
 BS|ts|*aa
 BS|tt|Багам утраулары
@@ -6015,7 +6015,7 @@ BS|vi|*aa
 BS|vo|*aa
 BS|wa|*aa
 BS|wo|*aa
-BS|xh|*aa
+BS|xh|EBahamas
 BS|yi|*ji
 BS|yo|Bàhámásì
 BS|za|*aa
@@ -6050,7 +6050,7 @@ BT|co|*aa
 BT|cr|*aa
 BT|cs|Bhútán
 BT|cu|*aa
-BT|cv|*aa
+BT|cv|*be
 BT|cy|*aa
 BT|da|*aa
 BT|de|*aa
@@ -6081,7 +6081,7 @@ BT|he|בהוטן
 BT|hi|भूटान
 BT|ho|*aa
 BT|hr|*ak
-BT|ht|*aa
+BT|ht|*br
 BT|hu|Bhután
 BT|hy|Բութան
 BT|hz|*aa
@@ -6126,7 +6126,7 @@ BT|lu|*ki
 BT|lv|Butāna
 BT|mg|Bhotana
 BT|mh|*aa
-BT|mi|*aa
+BT|mi|Pūtana
 BT|mk|*be
 BT|ml|ഭൂട്ടാൻ
 BT|mn|*be
@@ -6148,7 +6148,7 @@ BT|nv|*aa
 BT|ny|*aa
 BT|oc|*aa
 BT|oj|*aa
-BT|om|*aa
+BT|om|Bihuutan
 BT|or|ଭୁଟାନ
 BT|os|*aa
 BT|pa|ਭੂਟਾਨ
@@ -6163,7 +6163,7 @@ BT|ro|*aa
 BT|ru|*be
 BT|rw|*aa
 BT|sa|*aa
-BT|sc|*aa
+BT|sc|Bhutàn
 BT|sd|ڀوٽان
 BT|se|*aa
 BT|sg|Butäan
@@ -6203,7 +6203,7 @@ BT|vi|*aa
 BT|vo|*aa
 BT|wa|*aa
 BT|wo|*bm
-BT|xh|*aa
+BT|xh|EBhutan
 BT|yi|*ji
 BT|yo|Bútánì
 BT|za|*aa
@@ -6231,14 +6231,14 @@ BV|bn|বোভেট দ্বীপ
 BV|bo|*aa
 BV|br|Enez Bouvet
 BV|bs|Ostrvo Buve
-BV|ca|Bouvet
+BV|ca|Illa Bouvet
 BV|ce|Бувен гӀайре
 BV|ch|*aa
 BV|co|*aa
 BV|cr|*aa
 BV|cs|Bouvetův ostrov
 BV|cu|*aa
-BV|cv|*aa
+BV|cv|Буве утравӗ
 BV|cy|Ynys Bouvet
 BV|da|Bouvetøen
 BV|de|Bouvetinsel
@@ -6260,7 +6260,7 @@ BV|fr|Île Bouvet
 BV|fy|Bouveteilân
 BV|ga|Oileán Bouvet
 BV|gd|Eilean Bouvet
-BV|gl|Illa Bouvet
+BV|gl|*ca
 BV|gn|*aa
 BV|gu|બૌવેત આઇલેન્ડ
 BV|gv|*aa
@@ -6269,14 +6269,14 @@ BV|he|האי בובה
 BV|hi|बोवेत द्वीप
 BV|ho|*aa
 BV|hr|Otok Bouvet
-BV|ht|*aa
+BV|ht|*fr
 BV|hu|Bouvet-sziget
 BV|hy|Բուվե կղզի
 BV|hz|*aa
 BV|ia|Insula de Bouvet
 BV|id|Pulau Bouvet
 BV|ie|*aa
-BV|ig|Agwaetiti Bouvet
+BV|ig|*aa
 BV|ii|*aa
 BV|ik|*aa
 BV|in|*id
@@ -6299,7 +6299,7 @@ BV|kn|ಬೋವೆಟ್ ದ್ವೀಪ
 BV|ko|부베섬
 BV|kr|*aa
 BV|ks|بووَٹ جٔزیٖرٕ
-BV|ku|*aa
+BV|ku|Girava Bouvetê
 BV|kv|*aa
 BV|kw|*aa
 BV|ky|*kk
@@ -6314,7 +6314,7 @@ BV|lu|*aa
 BV|lv|Buvē sala
 BV|mg|*aa
 BV|mh|*aa
-BV|mi|*aa
+BV|mi|Motu Pūwei
 BV|mk|Остров Буве
 BV|ml|ബൗവെട്ട് ദ്വീപ്
 BV|mn|Буве арал
@@ -6336,7 +6336,7 @@ BV|nv|*aa
 BV|ny|*aa
 BV|oc|*aa
 BV|oj|*aa
-BV|om|*aa
+BV|om|Odola Bowuvet
 BV|or|ବୌଭେଟ୍‌ ଦ୍ୱୀପ
 BV|os|*aa
 BV|pa|ਬੌਵੇਟ ਟਾਪੂ
@@ -6351,7 +6351,7 @@ BV|ro|*mo
 BV|ru|о-в Буве
 BV|rw|*aa
 BV|sa|*aa
-BV|sc|*aa
+BV|sc|Ìsula Bouvet
 BV|sd|بووٽ ٻيٽ
 BV|se|Bouvet-sullot
 BV|sg|*aa
@@ -6372,7 +6372,7 @@ BV|ta|பொவேட் தீவு
 BV|te|బువై దీవి
 BV|tg|Ҷазираи Буве
 BV|th|เกาะบูเว
-BV|ti|ደሴት ቡቬት
+BV|ti|ደሴት ቡቨት
 BV|tk|Buwe adasy
 BV|tl|*aa
 BV|tn|*aa
@@ -6391,7 +6391,7 @@ BV|vi|Đảo Bouvet
 BV|vo|*aa
 BV|wa|*aa
 BV|wo|Dunu Buwet
-BV|xh|*aa
+BV|xh|EBouvet Island
 BV|yi|*aa
 BV|yo|Erékùsù Bouvet
 BV|za|*aa
@@ -6426,7 +6426,7 @@ BW|co|*aa
 BW|cr|*aa
 BW|cs|*aa
 BW|cu|*aa
-BW|cv|*aa
+BW|cv|*bg
 BW|cy|*aa
 BW|da|*aa
 BW|de|Botsuana
@@ -6453,13 +6453,13 @@ BW|gn|*aa
 BW|gu|બોત્સ્વાના
 BW|gv|*aa
 BW|ha|Baswana
-BW|he|בוצוואנה
+BW|he|בוטסואנה
 BW|hi|बोत्स्वाना
 BW|ho|*aa
 BW|hr|*bs
 BW|ht|*aa
 BW|hu|*aa
-BW|hy|Բոթսվանա
+BW|hy|Բոտսվանա
 BW|hz|*aa
 BW|ia|*aa
 BW|id|*aa
@@ -6502,7 +6502,7 @@ BW|lu|Mbotswana
 BW|lv|Botsvāna
 BW|mg|Botsoana
 BW|mh|*aa
-BW|mi|*aa
+BW|mi|Poriwana
 BW|mk|Боцвана
 BW|ml|ബോട്സ്വാന
 BW|mn|Ботсван
@@ -6524,7 +6524,7 @@ BW|nv|*aa
 BW|ny|*aa
 BW|oc|*aa
 BW|oj|*aa
-BW|om|*aa
+BW|om|Botosowaanaa
 BW|or|ବୋଟସ୍ୱାନା
 BW|os|*aa
 BW|pa|ਬੋਤਸਵਾਨਾ
@@ -6579,7 +6579,7 @@ BW|vi|*aa
 BW|vo|*aa
 BW|wa|*aa
 BW|wo|*aa
-BW|xh|*aa
+BW|xh|EBotswana
 BW|yi|*ji
 BW|yo|Bọ̀tìsúwánà
 BW|za|*aa
@@ -6614,9 +6614,9 @@ BY|co|*aa
 BY|cr|*aa
 BY|cs|Bělorusko
 BY|cu|*aa
-BY|cv|*aa
+BY|cv|Беларуҫ
 BY|cy|Belarws
-BY|da|Hviderusland
+BY|da|*aa
 BY|de|*aa
 BY|dv|*aa
 BY|dz|བེལ་ཨ་རུ་སུ
@@ -6645,7 +6645,7 @@ BY|he|בלארוס
 BY|hi|बेलारूस
 BY|ho|*aa
 BY|hr|*bs
-BY|ht|*aa
+BY|ht|*fr
 BY|hu|Belarusz
 BY|hy|Բելառուս
 BY|hz|*aa
@@ -6690,7 +6690,7 @@ BY|lu|*ln
 BY|lv|Baltkrievija
 BY|mg|Belarosy
 BY|mh|*aa
-BY|mi|*aa
+BY|mi|Pērara
 BY|mk|Белорусија
 BY|ml|ബെലറൂസ്
 BY|mn|*be
@@ -6700,19 +6700,19 @@ BY|ms|*aa
 BY|mt|il-Belarussja
 BY|my|ဘီလာရုစ်
 BY|na|*aa
-BY|nb|Hviterussland
+BY|nb|*aa
 BY|nd|Bhelarusi
 BY|ne|*hi
 BY|ng|*aa
 BY|nl|*aa
-BY|nn|Kviterussland
-BY|no|*nb
+BY|nn|*aa
+BY|no|*aa
 BY|nr|*aa
 BY|nv|*aa
 BY|ny|*aa
 BY|oc|*aa
 BY|oj|*aa
-BY|om|*aa
+BY|om|Beelaarus
 BY|or|ବେଲାରୁଷ୍
 BY|os|*aa
 BY|pa|ਬੇਲਾਰੂਸ
@@ -6727,7 +6727,7 @@ BY|ro|*aa
 BY|ru|*be
 BY|rw|*aa
 BY|sa|*aa
-BY|sc|*aa
+BY|sc|Bielorùssia
 BY|sd|بیلارس
 BY|se|Vilges-Ruošša
 BY|sg|Belarüsi
@@ -6742,7 +6742,7 @@ BY|sr|*mk
 BY|ss|*aa
 BY|st|*aa
 BY|su|*aa
-BY|sv|Vitryssland
+BY|sv|*aa
 BY|sw|*aa
 BY|ta|பெலாரஸ்
 BY|te|బెలారస్
@@ -6767,7 +6767,7 @@ BY|vi|*aa
 BY|vo|*aa
 BY|wa|*aa
 BY|wo|Belaris
-BY|xh|*aa
+BY|xh|EBelarus
 BY|yi|*ji
 BY|yo|Bélárúsì
 BY|za|*aa
@@ -6802,7 +6802,7 @@ BZ|co|*aa
 BZ|cr|*aa
 BZ|cs|*aa
 BZ|cu|*aa
-BZ|cv|*aa
+BZ|cv|*bg
 BZ|cy|*aa
 BZ|da|*aa
 BZ|de|*aa
@@ -6862,7 +6862,7 @@ BZ|km|បេលី
 BZ|kn|ಬೆಲಿಜ್
 BZ|ko|벨리즈
 BZ|kr|*aa
-BZ|ks|بیلِج
+BZ|ks|بیلز
 BZ|ku|Belîze
 BZ|kv|*aa
 BZ|kw|*aa
@@ -6878,7 +6878,7 @@ BZ|lu|*aa
 BZ|lv|Beliza
 BZ|mg|*aa
 BZ|mh|*aa
-BZ|mi|*aa
+BZ|mi|Perīhi
 BZ|mk|Белизе
 BZ|ml|ബെലീസ്
 BZ|mn|*mk
@@ -6936,7 +6936,7 @@ BZ|ta|பெலிஸ்
 BZ|te|బెలిజ్
 BZ|tg|*bg
 BZ|th|เบลีซ
-BZ|ti|ቤሊዝ
+BZ|ti|*am
 BZ|tk|*ak
 BZ|tl|*aa
 BZ|tn|*aa
@@ -6955,7 +6955,7 @@ BZ|vi|*aa
 BZ|vo|*aa
 BZ|wa|*aa
 BZ|wo|*fo
-BZ|xh|*aa
+BZ|xh|EBelize
 BZ|yi|*ji
 BZ|yo|Bèlísẹ̀
 BZ|za|*aa
@@ -6990,7 +6990,7 @@ CA|co|*aa
 CA|cr|*aa
 CA|cs|*af
 CA|cu|*aa
-CA|cv|*aa
+CA|cv|*be
 CA|cy|*aa
 CA|da|*aa
 CA|de|*af
@@ -7012,7 +7012,7 @@ CA|fr|*aa
 CA|fy|*aa
 CA|ga|Ceanada
 CA|gd|*aa
-CA|gl|O Canadá
+CA|gl|*es
 CA|gn|*aa
 CA|gu|કેનેડા
 CA|gv|*aa
@@ -7028,7 +7028,7 @@ CA|hz|*aa
 CA|ia|*aa
 CA|id|*af
 CA|ie|*aa
-CA|ig|*af
+CA|ig|*aa
 CA|ii|*aa
 CA|ik|*aa
 CA|in|*af
@@ -7050,7 +7050,7 @@ CA|km|កាណាដា
 CA|kn|ಕೆನಡಾ
 CA|ko|캐나다
 CA|kr|*aa
-CA|ks|کینَڑا
+CA|ks|کینیڈا
 CA|ku|*af
 CA|kv|*aa
 CA|kw|*aa
@@ -7066,7 +7066,7 @@ CA|lu|*af
 CA|lv|Kanāda
 CA|mg|*af
 CA|mh|*aa
-CA|mi|*aa
+CA|mi|Kānata
 CA|mk|*be
 CA|ml|കാനഡ
 CA|mn|Канад
@@ -7088,7 +7088,7 @@ CA|nv|*aa
 CA|ny|*aa
 CA|oc|*aa
 CA|oj|*aa
-CA|om|*aa
+CA|om|Kanaadaa
 CA|or|କାନାଡା
 CA|os|*aa
 CA|pa|ਕੈਨੇਡਾ
@@ -7103,7 +7103,7 @@ CA|ro|*aa
 CA|ru|*be
 CA|rw|*aa
 CA|sa|*aa
-CA|sc|*aa
+CA|sc|Cànada
 CA|sd|ڪينيڊا
 CA|se|Kanáda
 CA|sg|Kanadäa
@@ -7128,7 +7128,7 @@ CA|ti|*am
 CA|tk|*af
 CA|tl|*aa
 CA|tn|*aa
-CA|to|Kānata
+CA|to|*mi
 CA|tr|*af
 CA|ts|*aa
 CA|tt|*be
@@ -7136,14 +7136,14 @@ CA|tw|*aa
 CA|ty|*aa
 CA|ug|كانادا
 CA|uk|*be
-CA|ur|کینیڈا
+CA|ur|*ks
 CA|uz|*af
 CA|ve|*aa
 CA|vi|*aa
 CA|vo|*aa
 CA|wa|*aa
 CA|wo|*ff
-CA|xh|*aa
+CA|xh|EKhanada
 CA|yi|*ji
 CA|yo|Kánádà
 CA|za|*aa
@@ -7153,7 +7153,7 @@ CC|aa|Cocos (Keeling) Islands
 CC|ab|*aa
 CC|ae|*aa
 CC|af|Kokoseilande
-CC|ak|*aa
+CC|ak|Kokoso Supɔ
 CC|am|ኮኮስ(ኬሊንግ) ደሴቶች
 CC|an|*aa
 CC|ar|جزر كوكوس (كيلينغ)
@@ -7171,14 +7171,14 @@ CC|bn|কোকোস (কিলিং) দ্বীপপুঞ্জ
 CC|bo|*aa
 CC|br|Inizi Kokoz
 CC|bs|Kokosova (Keelingova) ostrva
-CC|ca|Illes Cocos
+CC|ca|Illes Cocos (Keeling)
 CC|ce|Кокосийн гӀайренаш
 CC|ch|*aa
 CC|co|*aa
 CC|cr|*aa
 CC|cs|Kokosové ostrovy
 CC|cu|*aa
-CC|cv|*aa
+CC|cv|Кокос утравӗсем
 CC|cy|Ynysoedd Cocos (Keeling)
 CC|da|Cocosøerne
 CC|de|Kokosinseln
@@ -7208,12 +7208,12 @@ CC|ha|Tsibirai Cocos (Keeling)
 CC|he|איי קוקוס (קילינג)
 CC|hi|कोकोस (कीलिंग) द्वीपसमूह
 CC|ho|*aa
-CC|hr|Kokosovi (Keelingovi) otoci
-CC|ht|*aa
+CC|hr|Kokosovi (Keelingovi) Otoci
+CC|ht|*fr
 CC|hu|Kókusz (Keeling)-szigetek
 CC|hy|Կոկոսյան (Քիլինգ) կղզիներ
 CC|hz|*aa
-CC|ia|*aa
+CC|ia|Insulas Cocos (Keeling)
 CC|id|Kepulauan Cocos (Keeling)
 CC|ie|*aa
 CC|ig|Agwaetiti Cocos (Keeling)
@@ -7238,8 +7238,8 @@ CC|km|កោះ​កូកូស (គីលីង)
 CC|kn|ಕೊಕೊಸ್ (ಕೀಲಿಂಗ್) ದ್ವೀಪಗಳು
 CC|ko|코코스 제도
 CC|kr|*aa
-CC|ks|کوکَس کیٖلِنگ جٔزیٖرٕ
-CC|ku|*aa
+CC|ks|کوکَس (کیٖلِنگ) جٔزیٖرٕ
+CC|ku|Giravên Kokosê (Keeling)
 CC|kv|*aa
 CC|kw|*aa
 CC|ky|*kk
@@ -7254,7 +7254,7 @@ CC|lu|*aa
 CC|lv|Kokosu (Kīlinga) salas
 CC|mg|*aa
 CC|mh|*aa
-CC|mi|*aa
+CC|mi|Ngā Moutere Kokoko (Kirini)
 CC|mk|Кокосови (Килиншки) Острови
 CC|ml|കോക്കസ് (കീലിംഗ്) ദ്വീപുകൾ
 CC|mn|Кокос (Кийлинг) арлууд
@@ -7276,7 +7276,7 @@ CC|nv|*aa
 CC|ny|*aa
 CC|oc|*aa
 CC|oj|*aa
-CC|om|*aa
+CC|om|Odoloota Kokos (Keeliing)
 CC|or|କୋକୋସ୍ (କୀଲିଂ) ଦ୍ଵୀପପୁଞ୍ଜ
 CC|os|*aa
 CC|pa|ਕੋਕੋਸ (ਕੀਲਿੰਗ) ਟਾਪੂ
@@ -7291,7 +7291,7 @@ CC|ro|*mo
 CC|ru|Кокосовые о-ва
 CC|rw|*aa
 CC|sa|*aa
-CC|sc|*aa
+CC|sc|Ìsulas Cocos (Keeling)
 CC|sd|ڪوڪوس ٻيٽ
 CC|se|Cocos-sullot
 CC|sg|*aa
@@ -7312,7 +7312,7 @@ CC|ta|கோகோஸ் (கீலிங்) தீவுகள்
 CC|te|కోకోస్ (కీలింగ్) దీవులు
 CC|tg|Ҷазираҳои Кокос (Килинг)
 CC|th|หมู่เกาะโคโคส (คีลิง)
-CC|ti|ኮኮስ ኬሊንግ ደሴቶች
+CC|ti|ደሴታት ኮኮስ
 CC|tk|Kokos (Kiling) adalary
 CC|tl|*aa
 CC|tn|*aa
@@ -7331,7 +7331,7 @@ CC|vi|Quần đảo Cocos (Keeling)
 CC|vo|*aa
 CC|wa|*aa
 CC|wo|Duni Koko (Kilin)
-CC|xh|*aa
+CC|xh|ECocos (Keeling) Islands
 CC|yi|*aa
 CC|yo|Erékùsù Cocos (Keeling)
 CC|za|*aa
@@ -7341,7 +7341,7 @@ CD|aa|Congo - Kinshasa
 CD|ab|*aa
 CD|ae|*aa
 CD|af|Demokratiese Republiek van die Kongo
-CD|ak|Kongo (Zair)
+CD|ak|Kongo Kinhyaahya
 CD|am|ኮንጎ-ኪንሻሳ
 CD|an|*aa
 CD|ar|الكونغو - كينشاسا
@@ -7366,7 +7366,7 @@ CD|co|*aa
 CD|cr|*aa
 CD|cs|Kongo – Kinshasa
 CD|cu|*aa
-CD|cv|*aa
+CD|cv|Конго - Киншаса
 CD|cy|Y Congo - Kinshasa
 CD|da|Congo-Kinshasa
 CD|de|Kongo-Kinshasa
@@ -7397,7 +7397,7 @@ CD|he|קונגו - קינשאסה
 CD|hi|कांगो - किंशासा
 CD|ho|*aa
 CD|hr|*br
-CD|ht|*aa
+CD|ht|*da
 CD|hu|Kongó – Kinshasa
 CD|hy|Կոնգո - Կինշասա
 CD|hz|*aa
@@ -7442,8 +7442,8 @@ CD|lu|Ditunga wa Kongu
 CD|lv|Kongo (Kinšasa)
 CD|mg|Repoblikan’i Kongo
 CD|mh|*aa
-CD|mi|*aa
-CD|mk|Конго - Киншаса
+CD|mi|Kōngo - Kinihāha
+CD|mk|*cv
 CD|ml|കോംഗോ - കിൻഷാസ
 CD|mn|*ky
 CD|mo|*aa
@@ -7464,7 +7464,7 @@ CD|nv|*aa
 CD|ny|*aa
 CD|oc|*aa
 CD|oj|*aa
-CD|om|*aa
+CD|om|Koongoo - Kinshaasaa
 CD|or|କଙ୍ଗୋ (ଡିଆରସି)
 CD|os|*aa
 CD|pa|ਕਾਂਗੋ - ਕਿੰਸ਼ਾਸਾ
@@ -7476,7 +7476,7 @@ CD|qu|Congo (RDC)
 CD|rm|*aa
 CD|rn|Repubulika Iharanira Demokarasi ya Kongo
 CD|ro|*aa
-CD|ru|*mk
+CD|ru|*cv
 CD|rw|*aa
 CD|sa|*aa
 CD|sc|*aa
@@ -7490,7 +7490,7 @@ CD|sm|*aa
 CD|sn|*nd
 CD|so|Jamhuuriyadda Dimuquraadiga Kongo
 CD|sq|*de
-CD|sr|*mk
+CD|sr|*cv
 CD|ss|*aa
 CD|st|*aa
 CD|su|*aa
@@ -7498,16 +7498,16 @@ CD|sv|*de
 CD|sw|*ki
 CD|ta|காங்கோ - கின்ஷாசா
 CD|te|కాంగో- కిన్షాసా
-CD|tg|*aa
+CD|tg|*cv
 CD|th|คองโก - กินชาซา
-CD|ti|ኮንጎ
+CD|ti|ደሞክራስያዊት ሪፓብሊክ ኮንጎ
 CD|tk|Kongo - Kinşasa
 CD|tl|*aa
 CD|tn|*aa
 CD|to|Kongo - Kinisasa
 CD|tr|*tk
 CD|ts|*aa
-CD|tt|*aa
+CD|tt|Конго (КДР)
 CD|tw|*aa
 CD|ty|*aa
 CD|ug|كونگو - كىنشاسا
@@ -7518,8 +7518,8 @@ CD|ve|*aa
 CD|vi|*aa
 CD|vo|*aa
 CD|wa|*aa
-CD|wo|*aa
-CD|xh|*aa
+CD|wo|Kongo (R K D)
+CD|xh|ECongo -Kinshasa
 CD|yi|*ji
 CD|yo|Kóńgò – Kinshasa
 CD|za|*aa
@@ -7554,7 +7554,7 @@ CF|co|*aa
 CF|cr|*aa
 CF|cs|Středoafrická republika
 CF|cu|*aa
-CF|cv|*aa
+CF|cv|Тӗп Африка Республики
 CF|cy|Gweriniaeth Canolbarth Affrica
 CF|da|Den Centralafrikanske Republik
 CF|de|Zentralafrikanische Republik
@@ -7585,7 +7585,7 @@ CF|he|הרפובליקה המרכז-אפריקאית
 CF|hi|मध्य अफ़्रीकी गणराज्य
 CF|ho|*aa
 CF|hr|Srednjoafrička Republika
-CF|ht|*aa
+CF|ht|*fr
 CF|hu|Közép-afrikai Köztársaság
 CF|hy|Կենտրոնական Աֆրիկյան Հանրապետություն
 CF|hz|*aa
@@ -7615,7 +7615,7 @@ CF|kn|ಮಧ್ಯ ಆಫ್ರಿಕಾ ಗಣರಾಜ್ಯ
 CF|ko|중앙 아프리카 공화국
 CF|kr|*aa
 CF|ks|مرکٔزی اَفریٖکی جموٗریَت
-CF|ku|Komara Afrîkaya Navend
+CF|ku|Komara Afrîkaya Navîn
 CF|kv|*aa
 CF|kw|*aa
 CF|ky|Борбордук Африка Республикасы
@@ -7630,7 +7630,7 @@ CF|lu|Ditunga dya Afrika wa munkatshi
 CF|lv|Centrālāfrikas Republika
 CF|mg|Repoblika Ivon’Afrika
 CF|mh|*aa
-CF|mi|*aa
+CF|mi|Te Whenua Tūhake o Āwherika Waenga
 CF|mk|Централноафриканска Република
 CF|ml|സെൻട്രൽ ആഫ്രിക്കൻ റിപ്പബ്ലിക്ക്
 CF|mn|Төв Африкийн Бүгд Найрамдах Улс
@@ -7652,7 +7652,7 @@ CF|nv|*aa
 CF|ny|*aa
 CF|oc|*aa
 CF|oj|*aa
-CF|om|*aa
+CF|om|Rippaablika Afrikaa Gidduugaleessaa
 CF|or|ମଧ୍ୟ ଆଫ୍ରିକୀୟ ସାଧାରଣତନ୍ତ୍ର
 CF|os|*aa
 CF|pa|ਕੇਂਦਰੀ ਅਫ਼ਰੀਕੀ ਗਣਰਾਜ
@@ -7667,7 +7667,7 @@ CF|ro|*mo
 CF|ru|Центрально-Африканская Республика
 CF|rw|*aa
 CF|sa|*aa
-CF|sc|*aa
+CF|sc|Repùblica Tzentrafricana
 CF|sd|وچ آفريقي جمهوريه
 CF|se|Gaska-Afrihká dásseváldi
 CF|sg|Ködörösêse tî Bêafrîka
@@ -7688,7 +7688,7 @@ CF|ta|மத்திய ஆப்ரிக்கக் குடியரசு
 CF|te|సెంట్రల్ ఆఫ్రికన్ రిపబ్లిక్
 CF|tg|Ҷумҳурии Африқои Марказӣ
 CF|th|สาธารณรัฐแอฟริกากลาง
-CF|ti|ማእከላዊ አፍሪቃ ሪፖብሊክ
+CF|ti|ሪፓብሊክ ማእከላይ ኣፍሪቃ
 CF|tk|Merkezi Afrika Respublikasy
 CF|tl|*aa
 CF|tn|*aa
@@ -7707,7 +7707,7 @@ CF|vi|Cộng hòa Trung Phi
 CF|vo|*aa
 CF|wa|*aa
 CF|wo|Repiblik Sàntar Afrik
-CF|xh|*aa
+CF|xh|ECentral African Republic
 CF|yi|*ji
 CF|yo|Àrin gùngun Áfíríkà
 CF|za|*aa
@@ -7716,7 +7716,7 @@ CF|zu|i-Central African Republic
 CG|aa|Congo - Brazzaville
 CG|ab|*aa
 CG|ae|*aa
-CG|af|Kongo - Brazzaville
+CG|af|Kongo-Brazzaville
 CG|ak|Kongo
 CG|am|ኮንጎ ብራዛቪል
 CG|an|*aa
@@ -7733,7 +7733,7 @@ CG|bi|*aa
 CG|bm|*ak
 CG|bn|*as
 CG|bo|*aa
-CG|br|*af
+CG|br|Kongo - Brazzaville
 CG|bs|*ak
 CG|ca|*aa
 CG|ce|Конго - Браззавиль
@@ -7742,16 +7742,16 @@ CG|co|*aa
 CG|cr|*aa
 CG|cs|Kongo – Brazzaville
 CG|cu|*aa
-CG|cv|*aa
+CG|cv|*ce
 CG|cy|Y Congo - Brazzaville
 CG|da|Congo-Brazzaville
-CG|de|Kongo-Brazzaville
+CG|de|*af
 CG|dv|*aa
 CG|dz|ཀོང་གྷོ བྷྲ་ཛ་བིལ
 CG|ee|Kongo Brazzaville nutome
 CG|el|Κονγκό - Μπραζαβίλ
 CG|en|*aa
-CG|eo|Kongolo
+CG|eo|Kongo Brazavila
 CG|es|Congo
 CG|et|Kongo Vabariik
 CG|eu|*ak
@@ -7762,7 +7762,7 @@ CG|fj|*aa
 CG|fo|*ak
 CG|fr|*da
 CG|fy|*da
-CG|ga|an Congó
+CG|ga|Congó-Brazzaville
 CG|gd|A’ Chongo - Brazzaville
 CG|gl|República do Congo
 CG|gn|*aa
@@ -7772,18 +7772,18 @@ CG|ha|*ak
 CG|he|קונגו - ברזאויל
 CG|hi|कांगो – ब्राज़ाविल
 CG|ho|*aa
-CG|hr|*af
-CG|ht|*aa
+CG|hr|*br
+CG|ht|*da
 CG|hu|Kongó – Brazzaville
 CG|hy|Կոնգո - Բրազավիլ
 CG|hz|*aa
-CG|ia|*es
-CG|id|*af
+CG|ia|*aa
+CG|id|*br
 CG|ie|*aa
 CG|ig|*es
 CG|ii|*aa
 CG|ik|*aa
-CG|in|*af
+CG|in|*br
 CG|io|*aa
 CG|is|Kongó-Brazzaville
 CG|it|*da
@@ -7803,12 +7803,12 @@ CG|kn|ಕಾಂಗೋ - ಬ್ರಾಜಾವಿಲ್ಲೇ
 CG|ko|콩고-브라자빌
 CG|kr|*aa
 CG|ks|کونگو بٔرزاوِلی
-CG|ku|*af
+CG|ku|*br
 CG|kv|*aa
 CG|kw|*aa
 CG|ky|Конго-Браззавил
 CG|la|*aa
-CG|lb|*de
+CG|lb|*af
 CG|lg|*ak
 CG|li|*aa
 CG|ln|*ak
@@ -7818,7 +7818,7 @@ CG|lu|Kongu
 CG|lv|Kongo (Brazavila)
 CG|mg|Kôngô
 CG|mh|*aa
-CG|mi|*aa
+CG|mi|Kōngo - Pārawhe
 CG|mk|Конго - Бразавил
 CG|ml|കോംഗോ - ബ്രാസവില്ലി
 CG|mn|Конго-Браззавиль
@@ -7828,19 +7828,19 @@ CG|ms|*aa
 CG|mt|il-Kongo - Brazzaville
 CG|my|ကွန်ဂို-ဘရာဇာဗီးလ်
 CG|na|*aa
-CG|nb|*de
+CG|nb|*af
 CG|nd|Khongo
 CG|ne|कङ्गो ब्राजाभिल
 CG|ng|*aa
 CG|nl|*da
-CG|nn|*de
-CG|no|*de
+CG|nn|*af
+CG|no|*af
 CG|nr|*aa
 CG|nv|*aa
 CG|ny|*aa
 CG|oc|*aa
 CG|oj|*aa
-CG|om|*aa
+CG|om|Koongoo - Biraazaavil
 CG|or|କଙ୍ଗୋ-ବ୍ରାଜିଭିଲ୍ଲେ
 CG|os|*aa
 CG|pa|ਕਾਂਗੋ - ਬ੍ਰਾਜ਼ਾਵਿਲੇ
@@ -7855,13 +7855,13 @@ CG|ro|*aa
 CG|ru|*ce
 CG|rw|*aa
 CG|sa|*aa
-CG|sc|*aa
+CG|sc|Congo - Bratzaville
 CG|sd|ڪانگو - برازاویل
-CG|se|*de
+CG|se|*af
 CG|sg|Kongö
 CG|si|කොංගො - බ්‍රසාවිල්
 CG|sk|Konžská republika
-CG|sl|*af
+CG|sl|*br
 CG|sm|*aa
 CG|sn|*ak
 CG|so|*ak
@@ -7870,20 +7870,20 @@ CG|sr|*mk
 CG|ss|*aa
 CG|st|*aa
 CG|su|*aa
-CG|sv|*de
-CG|sw|*af
+CG|sv|*af
+CG|sw|*br
 CG|ta|காங்கோ - ப்ராஸாவில்லே
 CG|te|కాంగో- బ్రాజావిల్లి
-CG|tg|*aa
+CG|tg|Конго - Браззавил
 CG|th|คองโก - บราซซาวิล
-CG|ti|ኮንጎ ሪፓብሊክ
+CG|ti|ኮንጎ
 CG|tk|Kongo - Brazzawil
 CG|tl|*aa
 CG|tn|*aa
 CG|to|Kongo - Palasavila
 CG|tr|Kongo - Brazavil
 CG|ts|*aa
-CG|tt|*aa
+CG|tt|*ce
 CG|tw|*aa
 CG|ty|*aa
 CG|ug|كونگو - بىراززاۋىل
@@ -7894,8 +7894,8 @@ CG|ve|*aa
 CG|vi|*aa
 CG|vo|*aa
 CG|wa|*aa
-CG|wo|*aa
-CG|xh|*aa
+CG|wo|Réewum Kongo
+CG|xh|ECongo - Brazzaville
 CG|yi|*aa
 CG|yo|Kóńgò – Brazaville
 CG|za|*aa
@@ -7930,7 +7930,7 @@ CH|co|*aa
 CH|cr|*aa
 CH|cs|Švýcarsko
 CH|cu|*aa
-CH|cv|*aa
+CH|cv|*ce
 CH|cy|Y Swistir
 CH|da|Schweiz
 CH|de|*da
@@ -7961,13 +7961,13 @@ CH|he|שווייץ
 CH|hi|स्विट्ज़रलैंड
 CH|ho|*aa
 CH|hr|*bs
-CH|ht|*aa
+CH|ht|*fr
 CH|hu|Svájc
 CH|hy|Շվեյցարիա
 CH|hz|*aa
 CH|ia|Suissa
 CH|id|Swiss
-CH|ie|*aa
+CH|ie|Svissia
 CH|ig|*aa
 CH|ii|*aa
 CH|ik|*aa
@@ -8006,10 +8006,10 @@ CH|lu|Swise
 CH|lv|Šveice
 CH|mg|Soisa
 CH|mh|*aa
-CH|mi|*aa
+CH|mi|Huiterangi
 CH|mk|Швајцарија
 CH|ml|സ്വിറ്റ്സർലാൻഡ്
-CH|mn|Швейцарь
+CH|mn|Швейцар
 CH|mo|Elveția
 CH|mr|स्वित्झर्लंड
 CH|ms|*aa
@@ -8028,7 +8028,7 @@ CH|nv|*aa
 CH|ny|*aa
 CH|oc|*aa
 CH|oj|*aa
-CH|om|*aa
+CH|om|Siwizerlaand
 CH|or|ସ୍ୱିଜରଲ୍ୟାଣ୍ଡ
 CH|os|*aa
 CH|pa|ਸਵਿਟਜ਼ਰਲੈਂਡ
@@ -8043,7 +8043,7 @@ CH|ro|*mo
 CH|ru|*bg
 CH|rw|*aa
 CH|sa|*aa
-CH|sc|*aa
+CH|sc|Isvìtzera
 CH|sd|سوئزرلينڊ
 CH|se|Šveica
 CH|sg|Sûîsi
@@ -8083,7 +8083,7 @@ CH|vi|Thụy Sĩ
 CH|vo|*aa
 CH|wa|*aa
 CH|wo|Siwis
-CH|xh|*aa
+CH|xh|ESwitzerland
 CH|yi|*he
 CH|yo|switiṣilandi
 CH|za|*aa
@@ -8093,8 +8093,8 @@ CI|aa|Côte d’Ivoire
 CI|ab|*aa
 CI|ae|*aa
 CI|af|Ivoorkus
-CI|ak|La Côte d’Ivoire
-CI|am|ኮት ዲቯር
+CI|ak|Kodivuwa
+CI|am|ኮትዲቯር
 CI|an|*aa
 CI|ar|ساحل العاج
 CI|as|কোটে ডি আইভৰ
@@ -8107,7 +8107,7 @@ CI|bg|Кот д’Ивоар
 CI|bh|*aa
 CI|bi|*aa
 CI|bm|Kodiwari
-CI|bn|কোত দিভোয়ার
+CI|bn|কোট ডি‘আইভোর
 CI|bo|*aa
 CI|br|Aod an Olifant
 CI|bs|Obala Slonovače
@@ -8118,7 +8118,7 @@ CI|co|*aa
 CI|cr|*aa
 CI|cs|Pobřeží slonoviny
 CI|cu|*aa
-CI|cv|*aa
+CI|cv|Кот-д’Ивуар
 CI|cy|*aa
 CI|da|Elfenbenskysten
 CI|de|*aa
@@ -8129,7 +8129,7 @@ CI|el|Ακτή Ελεφαντοστού
 CI|en|*aa
 CI|eo|Ebur-Bordo
 CI|es|*aa
-CI|et|*aa
+CI|et|Elevandiluurannik
 CI|eu|Boli Kosta
 CI|fa|ساحل عاج
 CI|ff|Kodduwaar
@@ -8138,7 +8138,7 @@ CI|fj|*aa
 CI|fo|Fílabeinsstrondin
 CI|fr|*aa
 CI|fy|Ivoorkust
-CI|ga|an Cósta Eabhair
+CI|ga|An Cósta Eabhair
 CI|gd|*aa
 CI|gl|*aa
 CI|gn|*aa
@@ -8146,14 +8146,14 @@ CI|gu|કોટ ડીઆઇવરી
 CI|gv|*aa
 CI|ha|Aibari Kwas
 CI|he|חוף השנהב
-CI|hi|कोट डी आइवर
+CI|hi|कोत दिवुआर
 CI|ho|*aa
 CI|hr|Obala Bjelokosti
 CI|ht|*aa
 CI|hu|Elefántcsontpart
 CI|hy|Կոտ դ՚Իվուար
 CI|hz|*aa
-CI|ia|*aa
+CI|ia|Costa de Ebore
 CI|id|*aa
 CI|ie|*aa
 CI|ig|*aa
@@ -8172,17 +8172,17 @@ CI|ka|კოტ-დივუარი
 CI|kg|*aa
 CI|ki|Kodivaa
 CI|kj|*aa
-CI|kk|Кот-д’Ивуар
+CI|kk|*cv
 CI|kl|*aa
 CI|km|កូតឌីវ័រ
 CI|kn|ಕೋತ್ ದ್‘ಇವಾರ್
 CI|ko|코트디부아르
 CI|kr|*aa
-CI|ks|اَیوٕری کوسٹ
-CI|ku|Peravê Diranfîl
+CI|ks|کوٹ ڈلوائر
+CI|ku|*aa
 CI|kv|*aa
 CI|kw|*aa
-CI|ky|*kk
+CI|ky|*cv
 CI|la|*aa
 CI|lb|*aa
 CI|lg|Kote Divwa
@@ -8194,12 +8194,12 @@ CI|lu|Kotedivuale
 CI|lv|Kotdivuāra
 CI|mg|*aa
 CI|mh|*aa
-CI|mi|*aa
+CI|mi|Te Tai Rei
 CI|mk|Брегот на Слоновата Коска
 CI|ml|കോട്ട് ഡി വാർ
-CI|mn|*kk
+CI|mn|*cv
 CI|mo|*aa
-CI|mr|*aa
+CI|mr|कोत द’ईवोआर
 CI|ms|Cote d’Ivoire
 CI|mt|il-Kosta tal-Avorju
 CI|my|ကို့တ် ဒီဗွာ
@@ -8216,7 +8216,7 @@ CI|nv|*aa
 CI|ny|*aa
 CI|oc|*aa
 CI|oj|*aa
-CI|om|*aa
+CI|om|Koti divoor
 CI|or|କୋତ୍ ଡି ଭ୍ଵାର୍
 CI|os|*aa
 CI|pa|ਕੋਟ ਡੀਵੋਆਰ
@@ -8228,11 +8228,11 @@ CI|qu|*aa
 CI|rm|Costa d’Ivur
 CI|rn|Kotedivuware
 CI|ro|*aa
-CI|ru|*kk
+CI|ru|*cv
 CI|rw|*aa
 CI|sa|*aa
-CI|sc|*aa
-CI|sd|ڪوٽ ڊي وار
+CI|sc|Costa de Avòriu
+CI|sd|ڪوٽي ويرا
 CI|se|Elfenbenariddu
 CI|sg|Kôdivüära
 CI|si|කෝට් දි අයිවරි
@@ -8246,20 +8246,20 @@ CI|sr|Обала Слоноваче (Кот д’Ивоар)
 CI|ss|*aa
 CI|st|*aa
 CI|su|*aa
-CI|sv|*aa
+CI|sv|Elfenbenskusten
 CI|sw|*ms
 CI|ta|கோட் தி’வாயர்
 CI|te|కోట్ డి ఐవోర్
-CI|tg|*kk
+CI|tg|*cv
 CI|th|โกตดิวัวร์
-CI|ti|*am
+CI|ti|ኮት ዲቭዋር
 CI|tk|Kot-d’Iwuar
 CI|tl|*aa
 CI|tn|*aa
 CI|to|Matafonua ʻAivolī
 CI|tr|*aa
 CI|ts|*aa
-CI|tt|*kk
+CI|tt|*cv
 CI|tw|*aa
 CI|ty|*aa
 CI|ug|كوتې دې ئىۋوئىر
@@ -8271,7 +8271,7 @@ CI|vi|*aa
 CI|vo|*aa
 CI|wa|*aa
 CI|wo|Kodiwaar
-CI|xh|*aa
+CI|xh|ECôte d’Ivoire
 CI|yi|*ji
 CI|yo|Kóútè forà
 CI|za|*aa
@@ -8281,7 +8281,7 @@ CK|aa|Cook Islands
 CK|ab|*aa
 CK|ae|*aa
 CK|af|Cookeilande
-CK|ak|Kook Nsupɔw
+CK|ak|Kuk Nsupɔ
 CK|am|ኩክ ደሴቶች
 CK|an|*aa
 CK|ar|جزر كوك
@@ -8306,7 +8306,7 @@ CK|co|*aa
 CK|cr|*aa
 CK|cs|Cookovy ostrovy
 CK|cu|*aa
-CK|cv|*aa
+CK|cv|Кук утравӗсем
 CK|cy|Ynysoedd Cook
 CK|da|Cookøerne
 CK|de|Cookinseln
@@ -8332,12 +8332,12 @@ CK|gl|Illas Cook
 CK|gn|*aa
 CK|gu|કુક આઇલેન્ડ્સ
 CK|gv|*aa
-CK|ha|Tsibiran Kuku
+CK|ha|Tsibiran Cook
 CK|he|איי קוק
 CK|hi|कुक द्वीपसमूह
 CK|ho|*aa
 CK|hr|Cookovi Otoci
-CK|ht|*aa
+CK|ht|*fr
 CK|hu|Cook-szigetek
 CK|hy|Կուկի կղզիներ
 CK|hz|*aa
@@ -8367,7 +8367,7 @@ CK|kn|ಕುಕ್ ದ್ವೀಪಗಳು
 CK|ko|쿡 제도
 CK|kr|*aa
 CK|ks|کُک جٔزیٖرٕ
-CK|ku|Giravên Cook
+CK|ku|Giravên Cookê
 CK|kv|*aa
 CK|kw|*aa
 CK|ky|*kk
@@ -8382,7 +8382,7 @@ CK|lu|Lutanda lua Kookɛ
 CK|lv|Kuka salas
 CK|mg|Nosy Kook
 CK|mh|*aa
-CK|mi|*aa
+CK|mi|Kuki Airani
 CK|mk|Кукови Острови
 CK|ml|കുക്ക് ദ്വീപുകൾ
 CK|mn|Күүкийн арлууд
@@ -8404,7 +8404,7 @@ CK|nv|*aa
 CK|ny|*aa
 CK|oc|*aa
 CK|oj|*aa
-CK|om|*aa
+CK|om|Odoloota Kuuk
 CK|or|କୁକ୍‌ ଦ୍ୱୀପପୁଞ୍ଜ
 CK|os|*aa
 CK|pa|ਕੁੱਕ ਟਾਪੂ
@@ -8416,10 +8416,10 @@ CK|qu|*es
 CK|rm|Inslas Cook
 CK|rn|Izinga rya Kuku
 CK|ro|*mo
-CK|ru|Острова Кука
+CK|ru|о-ва Кука
 CK|rw|*aa
 CK|sa|*aa
-CK|sc|*aa
+CK|sc|Ìsulas Cook
 CK|sd|ڪوڪ ٻيٽ
 CK|se|Cook-sullot
 CK|sg|âzûâ Kûku
@@ -8459,7 +8459,7 @@ CK|vi|Quần đảo Cook
 CK|vo|*aa
 CK|wa|*aa
 CK|wo|Duni Kuuk
-CK|xh|*aa
+CK|xh|ECook Islands
 CK|yi|*ji
 CK|yo|Etíokun Kùúkù
 CK|za|*aa
@@ -8494,7 +8494,7 @@ CL|co|*aa
 CL|cr|*aa
 CL|cs|*aa
 CL|cu|*aa
-CL|cv|*aa
+CL|cv|*bg
 CL|cy|*aa
 CL|da|*aa
 CL|de|*aa
@@ -8520,12 +8520,12 @@ CL|gl|*aa
 CL|gn|*aa
 CL|gu|ચિલી
 CL|gv|*aa
-CL|ha|Cayile
+CL|ha|*aa
 CL|he|צ׳ילה
 CL|hi|चिली
 CL|ho|*aa
 CL|hr|*bs
-CL|ht|*aa
+CL|ht|*af
 CL|hu|*aa
 CL|hy|Չիլի
 CL|hz|*aa
@@ -8570,7 +8570,7 @@ CL|lu|Shili
 CL|lv|Čīle
 CL|mg|*lu
 CL|mh|*aa
-CL|mi|*aa
+CL|mi|Hiri
 CL|mk|Чиле
 CL|ml|ചിലി
 CL|mn|*bg
@@ -8592,8 +8592,8 @@ CL|nv|*aa
 CL|ny|*aa
 CL|oc|*aa
 CL|oj|*aa
-CL|om|*aa
-CL|or|ଚିଲ୍ଲୀ
+CL|om|Chiilii
+CL|or|ଚିଲି
 CL|os|*aa
 CL|pa|ਚਿਲੀ
 CL|pi|*aa
@@ -8607,7 +8607,7 @@ CL|ro|*aa
 CL|ru|*bg
 CL|rw|*aa
 CL|sa|*aa
-CL|sc|*aa
+CL|sc|Tzile
 CL|sd|چلي
 CL|se|Čiile
 CL|sg|Shilïi
@@ -8628,7 +8628,7 @@ CL|ta|சிலி
 CL|te|చిలీ
 CL|tg|*bg
 CL|th|ชิลี
-CL|ti|*am
+CL|ti|ቺሌ
 CL|tk|*az
 CL|tl|*aa
 CL|tn|*aa
@@ -8647,7 +8647,7 @@ CL|vi|*aa
 CL|vo|*aa
 CL|wa|*aa
 CL|wo|*bm
-CL|xh|*aa
+CL|xh|EChile
 CL|yi|*ji
 CL|yo|Ṣílè
 CL|za|*aa
@@ -8682,7 +8682,7 @@ CM|co|*aa
 CM|cr|*aa
 CM|cs|*az
 CM|cu|*aa
-CM|cv|*aa
+CM|cv|*be
 CM|cy|Camerŵn
 CM|da|Cameroun
 CM|de|*az
@@ -8713,7 +8713,7 @@ CM|he|קמרון
 CM|hi|कैमरून
 CM|ho|*aa
 CM|hr|*az
-CM|ht|*aa
+CM|ht|*da
 CM|hu|*az
 CM|hy|Կամերուն
 CM|hz|*aa
@@ -8758,7 +8758,7 @@ CM|lu|Kamerune
 CM|lv|Kamerūna
 CM|mg|Kamerona
 CM|mh|*aa
-CM|mi|*aa
+CM|mi|Kamarūna
 CM|mk|*be
 CM|ml|കാമറൂൺ
 CM|mn|*be
@@ -8780,7 +8780,7 @@ CM|nv|*aa
 CM|ny|*aa
 CM|oc|*aa
 CM|oj|*aa
-CM|om|*aa
+CM|om|Kaameruun
 CM|or|କାମେରୁନ୍
 CM|os|*aa
 CM|pa|ਕੈਮਰੂਨ
@@ -8795,7 +8795,7 @@ CM|ro|*ca
 CM|ru|*be
 CM|rw|*aa
 CM|sa|*aa
-CM|sc|*aa
+CM|sc|Camerùn
 CM|sd|ڪيمرون
 CM|se|*az
 CM|sg|Kamerûne
@@ -8804,7 +8804,7 @@ CM|sk|*az
 CM|sl|*az
 CM|sm|*aa
 CM|sn|*bm
-CM|so|Kaameruun
+CM|so|*om
 CM|sq|*az
 CM|sr|*be
 CM|ss|*aa
@@ -8816,7 +8816,7 @@ CM|ta|கேமரூன்
 CM|te|కామెరూన్
 CM|tg|*be
 CM|th|แคเมอรูน
-CM|ti|ካሜሮን
+CM|ti|*am
 CM|tk|*az
 CM|tl|*aa
 CM|tn|*aa
@@ -8835,7 +8835,7 @@ CM|vi|*aa
 CM|vo|*aa
 CM|wa|*aa
 CM|wo|*az
-CM|xh|*aa
+CM|xh|ECameroon
 CM|yi|*ji
 CM|yo|Kamerúúnì
 CM|za|*aa
@@ -8870,7 +8870,7 @@ CN|co|*aa
 CN|cr|*aa
 CN|cs|Čína
 CN|cu|*aa
-CN|cv|*aa
+CN|cv|*bg
 CN|cy|Tsieina
 CN|da|*bs
 CN|de|*aa
@@ -8892,7 +8892,7 @@ CN|fr|Chine
 CN|fy|*br
 CN|ga|an tSín
 CN|gd|An t-Sìn
-CN|gl|A China
+CN|gl|*aa
 CN|gn|*aa
 CN|gu|ચીન
 CN|gv|*aa
@@ -8901,7 +8901,7 @@ CN|he|סין
 CN|hi|चीन
 CN|ho|*aa
 CN|hr|*bs
-CN|ht|*aa
+CN|ht|*fr
 CN|hu|Kína
 CN|hy|Չինաստան
 CN|hz|*aa
@@ -8968,8 +8968,8 @@ CN|nv|*aa
 CN|ny|*aa
 CN|oc|*aa
 CN|oj|*aa
-CN|om|*aa
-CN|or|ଚିନ୍
+CN|om|Chaayinaa
+CN|or|ଚୀନ୍‌
 CN|os|*bg
 CN|pa|ਚੀਨ
 CN|pi|*aa
@@ -8983,7 +8983,7 @@ CN|ro|*aa
 CN|ru|*bg
 CN|rw|*aa
 CN|sa|चीन:
-CN|sc|*aa
+CN|sc|Tzina
 CN|sd|چين
 CN|se|Kiinná
 CN|sg|Shîna
@@ -9023,10 +9023,10 @@ CN|vi|Trung Quốc
 CN|vo|*aa
 CN|wa|*aa
 CN|wo|*ff
-CN|xh|*aa
+CN|xh|ETshayina
 CN|yi|*ji
 CN|yo|Ṣáínà
-CN|za|*aa
+CN|za|Cunghgoz
 CN|zh|*ja
 CN|zu|i-China
 CO|aa|Colombia
@@ -9058,7 +9058,7 @@ CO|co|*aa
 CO|cr|*aa
 CO|cs|Kolumbie
 CO|cu|*aa
-CO|cv|*aa
+CO|cv|*ce
 CO|cy|*aa
 CO|da|*aa
 CO|de|Kolumbien
@@ -9089,7 +9089,7 @@ CO|he|קולומביה
 CO|hi|कोलंबिया
 CO|ho|*aa
 CO|hr|*bs
-CO|ht|*aa
+CO|ht|*fr
 CO|hu|*fi
 CO|hy|Կոլումբիա
 CO|hz|*aa
@@ -9119,7 +9119,7 @@ CO|kn|ಕೊಲಂಬಿಯಾ
 CO|ko|콜롬비아
 CO|kr|*aa
 CO|ks|کولَمبِیا
-CO|ku|*ff
+CO|ku|Kolombîya
 CO|kv|*aa
 CO|kw|*aa
 CO|ky|*bg
@@ -9134,7 +9134,7 @@ CO|lu|*bm
 CO|lv|*bs
 CO|mg|Kôlômbia
 CO|mh|*aa
-CO|mi|*aa
+CO|mi|Koromōpia
 CO|mk|Колумбија
 CO|ml|കൊളംബിയ
 CO|mn|*ce
@@ -9156,8 +9156,8 @@ CO|nv|*aa
 CO|ny|*aa
 CO|oc|*aa
 CO|oj|*aa
-CO|om|*aa
-CO|or|କୋଲମ୍ବିଆ
+CO|om|Kolombiyaa
+CO|or|କଲମ୍ବିଆ
 CO|os|*aa
 CO|pa|ਕੋਲੰਬੀਆ
 CO|pi|*aa
@@ -9171,7 +9171,7 @@ CO|ro|*mo
 CO|ru|*bg
 CO|rw|*aa
 CO|sa|*aa
-CO|sc|*aa
+CO|sc|*ca
 CO|sd|ڪولمبيا
 CO|se|*ak
 CO|sg|Kolombïi
@@ -9192,7 +9192,7 @@ CO|ta|கொலம்பியா
 CO|te|కొలంబియా
 CO|tg|*bg
 CO|th|โคลอมเบีย
-CO|ti|*am
+CO|ti|ኮሎምብያ
 CO|tk|Kolumbiýa
 CO|tl|*aa
 CO|tn|*aa
@@ -9211,7 +9211,7 @@ CO|vi|*aa
 CO|vo|*aa
 CO|wa|*aa
 CO|wo|*bm
-CO|xh|*aa
+CO|xh|EColombia
 CO|yi|*ji
 CO|yo|Kòlómíbìa
 CO|za|*aa
@@ -9246,7 +9246,7 @@ CR|co|*aa
 CR|cr|*aa
 CR|cs|*bs
 CR|cu|*aa
-CR|cv|*aa
+CR|cv|*ce
 CR|cy|*aa
 CR|da|*aa
 CR|de|*aa
@@ -9306,7 +9306,7 @@ CR|km|កូស្តារីកា
 CR|kn|ಕೊಸ್ಟಾ ರಿಕಾ
 CR|ko|코스타리카
 CR|kr|*aa
-CR|ks|کوسٹا رِکا
+CR|ks|کوسٹا ریکا
 CR|ku|Kosta Rîka
 CR|kv|*aa
 CR|kw|*aa
@@ -9322,7 +9322,7 @@ CR|lu|*ln
 CR|lv|*bs
 CR|mg|Kosta Rikà
 CR|mh|*aa
-CR|mi|*aa
+CR|mi|Koto Rīka
 CR|mk|Костарика
 CR|ml|കോസ്റ്ററിക്ക
 CR|mn|*ce
@@ -9344,7 +9344,7 @@ CR|nv|*aa
 CR|ny|*aa
 CR|oc|*aa
 CR|oj|*aa
-CR|om|*aa
+CR|om|Kostaa Rikaa
 CR|or|କୋଷ୍ଟା ରିକା
 CR|os|*aa
 CR|pa|ਕੋਸਟਾ ਰੀਕਾ
@@ -9368,7 +9368,7 @@ CR|sk|*bs
 CR|sl|*bs
 CR|sm|*aa
 CR|sn|*bs
-CR|so|Kosta Riika
+CR|so|*aa
 CR|sq|Kosta-Rikë
 CR|sr|*mk
 CR|ss|*aa
@@ -9392,14 +9392,14 @@ CR|tw|*aa
 CR|ty|*aa
 CR|ug|كوستارىكا
 CR|uk|*ce
-CR|ur|کوسٹا ریکا
+CR|ur|*ks
 CR|uz|*tk
 CR|ve|*aa
 CR|vi|*aa
 CR|vo|*aa
 CR|wa|*aa
 CR|wo|*az
-CR|xh|*aa
+CR|xh|ECosta Rica
 CR|yi|*ji
 CR|yo|Kuusita Ríkà
 CR|za|*aa
@@ -9434,7 +9434,7 @@ CU|co|*aa
 CU|cr|*aa
 CU|cs|*af
 CU|cu|*aa
-CU|cv|*aa
+CU|cv|*be
 CU|cy|Ciwba
 CU|da|*aa
 CU|de|*af
@@ -9495,7 +9495,7 @@ CU|kn|ಕ್ಯೂಬಾ
 CU|ko|쿠바
 CU|kr|*aa
 CU|ks|کیوٗبا
-CU|ku|Kûba
+CU|ku|*af
 CU|kv|*aa
 CU|kw|*aa
 CU|ky|*be
@@ -9510,7 +9510,7 @@ CU|lu|*af
 CU|lv|*af
 CU|mg|Kiobà
 CU|mh|*aa
-CU|mi|*aa
+CU|mi|Kiupa
 CU|mk|*be
 CU|ml|ക്യൂബ
 CU|mn|*be
@@ -9532,8 +9532,8 @@ CU|nv|*aa
 CU|ny|*aa
 CU|oc|*aa
 CU|oj|*aa
-CU|om|*aa
-CU|or|କ୍ୱିବା
+CU|om|Kuubaa
+CU|or|କ‍୍ୟୁବା
 CU|os|*aa
 CU|pa|ਕਿਊਬਾ
 CU|pi|*aa
@@ -9572,7 +9572,7 @@ CU|ti|*am
 CU|tk|*af
 CU|tl|*aa
 CU|tn|*aa
-CU|to|Kiupa
+CU|to|*mi
 CU|tr|Küba
 CU|ts|*aa
 CU|tt|*be
@@ -9587,7 +9587,7 @@ CU|vi|*aa
 CU|vo|*aa
 CU|wa|*aa
 CU|wo|*af
-CU|xh|*aa
+CU|xh|ECuba
 CU|yi|*ji
 CU|yo|Kúbà
 CU|za|*aa
@@ -9598,7 +9598,7 @@ CV|ab|*aa
 CV|ae|*aa
 CV|af|Kaap Verde
 CV|ak|Kepvɛdfo Islands
-CV|am|ኬፕ ቬርዴ
+CV|am|ኬፕቨርዴ
 CV|an|*aa
 CV|ar|الرأس الأخضر
 CV|as|কেপ ভার্দে
@@ -9611,7 +9611,7 @@ CV|bg|Кабо Верде
 CV|bh|*aa
 CV|bi|*aa
 CV|bm|Capivɛrdi
-CV|bn|কেপভার্দে
+CV|bn|*as
 CV|bo|*aa
 CV|br|Kab-Glas
 CV|bs|Zelenortska Ostrva
@@ -9622,7 +9622,7 @@ CV|co|*aa
 CV|cr|*aa
 CV|cs|Kapverdy
 CV|cu|*aa
-CV|cv|*aa
+CV|cv|*ce
 CV|cy|Cabo Verde
 CV|da|Kap Verde
 CV|de|*cy
@@ -9631,7 +9631,7 @@ CV|dz|ཀེཔ་བཱཌ
 CV|ee|Kape Verde nutome
 CV|el|Πράσινο Ακρωτήριο
 CV|en|*aa
-CV|eo|Kabo-Verdo
+CV|eo|Kaboverdo
 CV|es|*cy
 CV|et|Roheneemesaared
 CV|eu|*cy
@@ -9648,16 +9648,16 @@ CV|gl|*cy
 CV|gn|*aa
 CV|gu|કૅપ વર્ડે
 CV|gv|*aa
-CV|ha|Tsibiran Kap Barde
+CV|ha|Tsibiran Cape Verde
 CV|he|כף ורדה
 CV|hi|केप वर्ड
 CV|ho|*aa
 CV|hr|Zelenortska Republika
-CV|ht|*aa
+CV|ht|*fr
 CV|hu|Zöld-foki Köztársaság
 CV|hy|Կաբո Վերդե
 CV|hz|*aa
-CV|ia|*aa
+CV|ia|Capo Verde
 CV|id|Tanjung Verde
 CV|ie|*aa
 CV|ig|*aa
@@ -9666,7 +9666,7 @@ CV|ik|*aa
 CV|in|*id
 CV|io|*aa
 CV|is|Grænhöfðaeyjar
-CV|it|Capo Verde
+CV|it|*ia
 CV|iu|*aa
 CV|iw|*he
 CV|ja|カーボベルデ
@@ -9698,8 +9698,8 @@ CV|lu|Lutanda lua Kapevele
 CV|lv|Kaboverde
 CV|mg|Nosy Cap-Vert
 CV|mh|*aa
-CV|mi|*aa
-CV|mk|Зелен ’Рт
+CV|mi|Te Kūrae Matomato
+CV|mk|*bg
 CV|ml|കേപ്പ് വേർഡ്
 CV|mn|*ce
 CV|mo|Capul Verde
@@ -9720,7 +9720,7 @@ CV|nv|*aa
 CV|ny|*aa
 CV|oc|*aa
 CV|oj|*aa
-CV|om|*aa
+CV|om|Keeppi Vaardee
 CV|or|କେପ୍ ଭର୍ଦେ
 CV|os|*aa
 CV|pa|ਕੇਪ ਵਰਡੇ
@@ -9735,7 +9735,7 @@ CV|ro|*mo
 CV|ru|*ce
 CV|rw|*aa
 CV|sa|*aa
-CV|sc|*aa
+CV|sc|Cabu birde
 CV|sd|ڪيپ وردي
 CV|se|*da
 CV|sg|Azûâ tî Kâpo-Vêre
@@ -9756,12 +9756,12 @@ CV|ta|கேப் வெர்டே
 CV|te|కేప్ వెర్డె
 CV|tg|*ce
 CV|th|เคปเวิร์ด
-CV|ti|*am
+CV|ti|ኬፕ ቨርደ
 CV|tk|Kabo-Werde
 CV|tl|*aa
 CV|tn|*aa
 CV|to|Muiʻi Vēte
-CV|tr|*aa
+CV|tr|*cy
 CV|ts|*aa
 CV|tt|*ce
 CV|tw|*aa
@@ -9775,7 +9775,7 @@ CV|vi|*aa
 CV|vo|*aa
 CV|wa|*aa
 CV|wo|Kabo Werde
-CV|xh|*aa
+CV|xh|ECape Verde
 CV|yi|*ji
 CV|yo|Etíokun Kápé féndè
 CV|za|*aa
@@ -9785,7 +9785,7 @@ CW|aa|Curaçao
 CW|ab|*aa
 CW|ae|*aa
 CW|af|*aa
-CW|ak|*aa
+CW|ak|Kurakaw
 CW|am|ኩራሳዎ
 CW|an|*aa
 CW|ar|كوراساو
@@ -9810,7 +9810,7 @@ CW|co|*aa
 CW|cr|*aa
 CW|cs|*aa
 CW|cu|*aa
-CW|cv|*aa
+CW|cv|*bg
 CW|cy|*aa
 CW|da|*aa
 CW|de|*aa
@@ -9830,7 +9830,7 @@ CW|fj|*aa
 CW|fo|*aa
 CW|fr|*aa
 CW|fy|*aa
-CW|ga|*aa
+CW|ga|Cúrasó
 CW|gd|*aa
 CW|gl|*aa
 CW|gn|*aa
@@ -9838,7 +9838,7 @@ CW|gu|ક્યુરાસાઓ
 CW|gv|*aa
 CW|ha|Ƙasar Curaçao
 CW|he|קוראסאו
-CW|hi|क्यूरासाओ
+CW|hi|कुरासाओ
 CW|ho|*aa
 CW|hr|*aa
 CW|ht|*aa
@@ -9870,7 +9870,7 @@ CW|km|កូរ៉ាកៅ
 CW|kn|ಕುರಾಕಾವ್
 CW|ko|퀴라소
 CW|kr|*aa
-CW|ks|*aa
+CW|ks|کیوراکو
 CW|ku|*aa
 CW|kv|*aa
 CW|kw|*aa
@@ -9886,7 +9886,7 @@ CW|lu|*aa
 CW|lv|Kirasao
 CW|mg|*aa
 CW|mh|*aa
-CW|mi|*aa
+CW|mi|Kurahao
 CW|mk|Курасао
 CW|ml|കുറാകാവോ
 CW|mn|*bg
@@ -9908,7 +9908,7 @@ CW|nv|*aa
 CW|ny|*aa
 CW|oc|*aa
 CW|oj|*aa
-CW|om|*aa
+CW|om|Kurakowaa
 CW|or|କୁରାକାଓ
 CW|os|*aa
 CW|pa|ਕੁਰਾਕਾਓ
@@ -9944,7 +9944,7 @@ CW|ta|குராகவ்
 CW|te|క్యూరసో
 CW|tg|*bg
 CW|th|คูราเซา
-CW|ti|ኩራካዎ
+CW|ti|ኩራሳው
 CW|tk|Kýurasao
 CW|tl|*aa
 CW|tn|*aa
@@ -9963,7 +9963,7 @@ CW|vi|*aa
 CW|vo|*aa
 CW|wa|*aa
 CW|wo|Kursawo
-CW|xh|*aa
+CW|xh|ECuraçao
 CW|yi|*ji
 CW|yo|*aa
 CW|za|*aa
@@ -9973,7 +9973,7 @@ CX|aa|Christmas Island
 CX|ab|*aa
 CX|ae|*aa
 CX|af|Kerseiland
-CX|ak|*aa
+CX|ak|Buronya Supɔ
 CX|am|ክሪስማስ ደሴት
 CX|an|*aa
 CX|ar|جزيرة كريسماس
@@ -9998,7 +9998,7 @@ CX|co|*aa
 CX|cr|*aa
 CX|cs|Vánoční ostrov
 CX|cu|*aa
-CX|cv|*aa
+CX|cv|Раштав утравӗ
 CX|cy|Ynys y Nadolig
 CX|da|Juleøen
 CX|de|Weihnachtsinsel
@@ -10028,8 +10028,8 @@ CX|ha|Tsibirin Kirsmati
 CX|he|אי חג המולד
 CX|hi|क्रिसमस द्वीप
 CX|ho|*aa
-CX|hr|Božićni otok
-CX|ht|*aa
+CX|hr|Božićni Otok
+CX|ht|*fr
 CX|hu|Karácsony-sziget
 CX|hy|Սուրբ Ծննդյան կղզի
 CX|hz|*aa
@@ -10059,7 +10059,7 @@ CX|kn|ಕ್ರಿಸ್ಮಸ್ ದ್ವೀಪ
 CX|ko|크리스마스섬
 CX|kr|*aa
 CX|ks|کرِسمَس جٔزیٖرٕ
-CX|ku|*aa
+CX|ku|Girava Christmasê
 CX|kv|*aa
 CX|kw|*aa
 CX|ky|*kk
@@ -10074,7 +10074,7 @@ CX|lu|*aa
 CX|lv|Ziemsvētku sala
 CX|mg|*aa
 CX|mh|*aa
-CX|mi|*aa
+CX|mi|Te Moutere Kirihimete
 CX|mk|Божиќен Остров
 CX|ml|ക്രിസ്മസ് ദ്വീപ്
 CX|mn|Зул сарын арал
@@ -10096,7 +10096,7 @@ CX|nv|*aa
 CX|ny|*aa
 CX|oc|*aa
 CX|oj|*aa
-CX|om|*aa
+CX|om|Odola Kirismaas
 CX|or|ଖ୍ରୀଷ୍ଟମାସ ଦ୍ୱୀପ
 CX|os|*aa
 CX|pa|ਕ੍ਰਿਸਮਿਸ ਟਾਪੂ
@@ -10111,7 +10111,7 @@ CX|ro|*mo
 CX|ru|о-в Рождества
 CX|rw|*aa
 CX|sa|*aa
-CX|sc|*aa
+CX|sc|Ìsula de sa Natividade
 CX|sd|ڪرسمس ٻيٽ
 CX|se|Juovllat-sullot
 CX|sg|*aa
@@ -10151,7 +10151,7 @@ CX|vi|Đảo Giáng Sinh
 CX|vo|*aa
 CX|wa|*aa
 CX|wo|Dunu Kirismas
-CX|xh|*aa
+CX|xh|EChristmas Island
 CX|yi|*aa
 CX|yo|Erékùsù Christmas
 CX|za|*aa
@@ -10161,7 +10161,7 @@ CY|aa|Cyprus
 CY|ab|*aa
 CY|ae|*aa
 CY|af|Siprus
-CY|ak|Saeprɔs
+CY|ak|Saeprɔso
 CY|am|ሳይፕረስ
 CY|an|*aa
 CY|ar|قبرص
@@ -10186,7 +10186,7 @@ CY|co|*aa
 CY|cr|*aa
 CY|cs|Kypr
 CY|cu|*aa
-CY|cv|*aa
+CY|cv|*ce
 CY|cy|*aa
 CY|da|Cypern
 CY|de|Zypern
@@ -10212,12 +10212,12 @@ CY|gl|*es
 CY|gn|*aa
 CY|gu|સાયપ્રસ
 CY|gv|*aa
-CY|ha|Sifurus
+CY|ha|Saifurus
 CY|he|קפריסין
 CY|hi|साइप्रस
 CY|ho|*aa
 CY|hr|Cipar
-CY|ht|*aa
+CY|ht|*fr
 CY|hu|Ciprus
 CY|hy|Կիպրոս
 CY|hz|*aa
@@ -10246,8 +10246,8 @@ CY|km|ស៊ីប
 CY|kn|ಸೈಪ್ರಸ್
 CY|ko|키프로스
 CY|kr|*aa
-CY|ks|سایفرس
-CY|ku|Kîpros
+CY|ks|سائپرس
+CY|ku|Qibris
 CY|kv|*aa
 CY|kw|*aa
 CY|ky|*ce
@@ -10262,7 +10262,7 @@ CY|lu|Shipele
 CY|lv|Kipra
 CY|mg|Sypra
 CY|mh|*aa
-CY|mi|*aa
+CY|mi|Haipara
 CY|mk|Кипар
 CY|ml|സൈപ്രസ്
 CY|mn|*ce
@@ -10284,7 +10284,7 @@ CY|nv|*aa
 CY|ny|*aa
 CY|oc|*aa
 CY|oj|*aa
-CY|om|*aa
+CY|om|Qoophiroos
 CY|or|ସାଇପ୍ରସ୍
 CY|os|*aa
 CY|pa|ਸਾਇਪ੍ਰਸ
@@ -10299,8 +10299,8 @@ CY|ro|*mo
 CY|ru|*ce
 CY|rw|*aa
 CY|sa|*aa
-CY|sc|*aa
-CY|sd|سائپرس
+CY|sc|Tzipru
+CY|sd|*ks
 CY|se|*fi
 CY|sg|Sîpri
 CY|si|සයිප්‍රසය
@@ -10320,7 +10320,7 @@ CY|ta|சைப்ரஸ்
 CY|te|సైప్రస్
 CY|tg|*ce
 CY|th|ไซปรัส
-CY|ti|*am
+CY|ti|ቆጵሮስ
 CY|tk|*az
 CY|tl|*aa
 CY|tn|*aa
@@ -10339,7 +10339,7 @@ CY|vi|Síp
 CY|vo|*aa
 CY|wa|*aa
 CY|wo|*ff
-CY|xh|*aa
+CY|xh|ECyprus
 CY|yi|*aa
 CY|yo|Kúrúsì
 CY|za|*aa
@@ -10349,7 +10349,7 @@ CZ|aa|Czechia
 CZ|ab|*aa
 CZ|ae|*aa
 CZ|af|Tsjeggië
-CZ|ak|Kyɛk Kurokɛse
+CZ|ak|Kyɛk
 CZ|am|ቼቺያ
 CZ|an|*aa
 CZ|ar|التشيك
@@ -10363,7 +10363,7 @@ CZ|bg|Чехия
 CZ|bh|*aa
 CZ|bi|*aa
 CZ|bm|Ceki republiki
-CZ|bn|চেচিয়া
+CZ|bn|চেকিয়া
 CZ|bo|*aa
 CZ|br|Tchekia
 CZ|bs|Češka
@@ -10374,7 +10374,7 @@ CZ|co|*aa
 CZ|cr|*aa
 CZ|cs|Česko
 CZ|cu|*aa
-CZ|cv|*aa
+CZ|cv|*ce
 CZ|cy|Tsiecia
 CZ|da|Tjekkiet
 CZ|de|Tschechien
@@ -10400,18 +10400,18 @@ CZ|gl|*es
 CZ|gn|*aa
 CZ|gu|ચેકીયા
 CZ|gv|*aa
-CZ|ha|Jamhuriyar Cak
+CZ|ha|*aa
 CZ|he|צ׳כיה
 CZ|hi|चेकिया
 CZ|ho|*aa
 CZ|hr|*bs
-CZ|ht|*aa
+CZ|ht|*fr
 CZ|hu|Csehország
 CZ|hy|Չեխիա
 CZ|hz|*aa
 CZ|ia|Chechia
 CZ|id|Ceko
-CZ|ie|*aa
+CZ|ie|*br
 CZ|ig|*aa
 CZ|ii|*aa
 CZ|ik|*aa
@@ -10434,7 +10434,7 @@ CZ|km|ឆែក
 CZ|kn|ಝೆಕಿಯಾ
 CZ|ko|체코
 CZ|kr|*aa
-CZ|ks|چیک جَموٗرِیَت
+CZ|ks|چیکیا
 CZ|ku|Çekya
 CZ|kv|*aa
 CZ|kw|*aa
@@ -10450,7 +10450,7 @@ CZ|lu|Ditunga dya Tsheka
 CZ|lv|Čehija
 CZ|mg|Repoblikan’i Tseky
 CZ|mh|*aa
-CZ|mi|*aa
+CZ|mi|Tiekia
 CZ|mk|Чешка
 CZ|ml|ചെക്കിയ
 CZ|mn|Чех
@@ -10472,7 +10472,7 @@ CZ|nv|*aa
 CZ|ny|*aa
 CZ|oc|*aa
 CZ|oj|*aa
-CZ|om|*aa
+CZ|om|Cheechiya
 CZ|or|ଚେଚିଆ
 CZ|os|*aa
 CZ|pa|ਚੈਕੀਆ
@@ -10487,7 +10487,7 @@ CZ|ro|*mo
 CZ|ru|*bg
 CZ|rw|*aa
 CZ|sa|*aa
-CZ|sc|*aa
+CZ|sc|Tzèchia
 CZ|sd|چيڪيا
 CZ|se|Čeahkka
 CZ|sg|Ködörösêse tî Tyêki
@@ -10508,7 +10508,7 @@ CZ|ta|செசியா
 CZ|te|చెకియా
 CZ|tg|Ҷумҳурии Чех
 CZ|th|เช็ก
-CZ|ti|ቼክ ሪፓብሊክ
+CZ|ti|ቸክያ
 CZ|tk|Çehiýa
 CZ|tl|*aa
 CZ|tn|*aa
@@ -10520,14 +10520,14 @@ CZ|tw|*aa
 CZ|ty|*aa
 CZ|ug|چېخ جۇمھۇرىيىتى
 CZ|uk|Чехія
-CZ|ur|چیکیا
+CZ|ur|*ks
 CZ|uz|Chexiya
 CZ|ve|*aa
 CZ|vi|Séc
 CZ|vo|*aa
 CZ|wa|*aa
 CZ|wo|Réewum Cek
-CZ|xh|*aa
+CZ|xh|ECzechia
 CZ|yi|*ji
 CZ|yo|Ṣẹ́ẹ́kì
 CZ|za|*aa
@@ -10562,7 +10562,7 @@ DE|co|*aa
 DE|cr|*aa
 DE|cs|Německo
 DE|cu|*aa
-DE|cv|*aa
+DE|cv|*ce
 DE|cy|Yr Almaen
 DE|da|Tyskland
 DE|de|Deutschland
@@ -10593,14 +10593,14 @@ DE|he|גרמניה
 DE|hi|जर्मनी
 DE|ho|*aa
 DE|hr|*bs
-DE|ht|*aa
+DE|ht|*fr
 DE|hu|Németország
 DE|hy|Գերմանիա
 DE|hz|*aa
 DE|ia|Germania
 DE|id|Jerman
-DE|ie|*aa
-DE|ig|Jamanị
+DE|ie|*ia
+DE|ig|*aa
 DE|ii|ꄓꇩ
 DE|ik|*aa
 DE|in|*id
@@ -10660,7 +10660,7 @@ DE|nv|*aa
 DE|ny|*aa
 DE|oc|*aa
 DE|oj|*aa
-DE|om|*aa
+DE|om|Jarmanii
 DE|or|ଜର୍ମାନୀ
 DE|os|*mn
 DE|pa|ਜਰਮਨੀ
@@ -10675,7 +10675,7 @@ DE|ro|*ia
 DE|ru|*bg
 DE|rw|*aa
 DE|sa|जर्मनीदेश:
-DE|sc|*aa
+DE|sc|Germània
 DE|sd|جرمني
 DE|se|Duiska
 DE|sg|Zâmani
@@ -10715,7 +10715,7 @@ DE|vi|Đức
 DE|vo|*aa
 DE|wa|*aa
 DE|wo|*ff
-DE|xh|*aa
+DE|xh|EJamani
 DE|yi|*ji
 DE|yo|Jámánì
 DE|za|*aa
@@ -10750,7 +10750,7 @@ DJ|co|*aa
 DJ|cr|*aa
 DJ|cs|Džibutsko
 DJ|cu|*aa
-DJ|cv|*aa
+DJ|cv|*bg
 DJ|cy|*aa
 DJ|da|*aa
 DJ|de|Dschibuti
@@ -10785,7 +10785,7 @@ DJ|ht|*aa
 DJ|hu|Dzsibuti
 DJ|hy|Ջիբութի
 DJ|hz|*aa
-DJ|ia|*aa
+DJ|ia|*eu
 DJ|id|*bm
 DJ|ie|*aa
 DJ|ig|*aa
@@ -10826,7 +10826,7 @@ DJ|lu|*eu
 DJ|lv|Džibutija
 DJ|mg|Djiboti
 DJ|mh|*aa
-DJ|mi|*aa
+DJ|mi|Tipūti
 DJ|mk|Џибути
 DJ|ml|ജിബൂത്തി
 DJ|mn|*bg
@@ -10848,10 +10848,10 @@ DJ|nv|*aa
 DJ|ny|*aa
 DJ|oc|*aa
 DJ|oj|*aa
-DJ|om|*aa
+DJ|om|Jibuutii
 DJ|or|ଜିବୋଟି
 DJ|os|*aa
-DJ|pa|ਜ਼ੀਬੂਤੀ
+DJ|pa|ਜਿਬੂਤੀ
 DJ|pi|*aa
 DJ|pl|Dżibuti
 DJ|ps|جبوتي
@@ -10863,7 +10863,7 @@ DJ|ro|*aa
 DJ|ru|*bg
 DJ|rw|*aa
 DJ|sa|*aa
-DJ|sc|*aa
+DJ|sc|*it
 DJ|sd|ڊجبيوتي
 DJ|se|*aa
 DJ|sg|Dibutùii
@@ -10884,7 +10884,7 @@ DJ|ta|ஜிபௌட்டி
 DJ|te|జిబౌటి
 DJ|tg|Ҷибути
 DJ|th|จิบูตี
-DJ|ti|*am
+DJ|ti|ጅቡቲ
 DJ|tk|*bm
 DJ|tl|*aa
 DJ|tn|*aa
@@ -10903,7 +10903,7 @@ DJ|vi|*aa
 DJ|vo|*aa
 DJ|wa|*aa
 DJ|wo|*bm
-DJ|xh|*aa
+DJ|xh|EDjibouti
 DJ|yi|*ji
 DJ|yo|Díbọ́ótì
 DJ|za|*aa
@@ -10938,7 +10938,7 @@ DK|co|*aa
 DK|cr|*aa
 DK|cs|Dánsko
 DK|cu|*aa
-DK|cv|*aa
+DK|cv|*ce
 DK|cy|Denmarc
 DK|da|*br
 DK|de|Dänemark
@@ -10969,13 +10969,13 @@ DK|he|דנמרק
 DK|hi|डेनमार्क
 DK|ho|*aa
 DK|hr|*bs
-DK|ht|*aa
+DK|ht|*fr
 DK|hu|Dánia
 DK|hy|Դանիա
 DK|hz|*aa
 DK|ia|*br
 DK|id|*aa
-DK|ie|*aa
+DK|ie|Dania
 DK|ig|*aa
 DK|ii|*aa
 DK|ik|*aa
@@ -11014,7 +11014,7 @@ DK|lu|Danemalaku
 DK|lv|Dānija
 DK|mg|Danmarka
 DK|mh|*aa
-DK|mi|*aa
+DK|mi|Tenemāka
 DK|mk|Данска
 DK|ml|ഡെൻമാർക്ക്
 DK|mn|*ce
@@ -11036,12 +11036,12 @@ DK|nv|*aa
 DK|ny|*aa
 DK|oc|*aa
 DK|oj|*aa
-DK|om|*aa
+DK|om|Deenmaark
 DK|or|ଡେନମାର୍କ
 DK|os|*aa
 DK|pa|ਡੈਨਮਾਰਕ
 DK|pi|*aa
-DK|pl|Dania
+DK|pl|*ie
 DK|ps|ډنمارک
 DK|pt|*ca
 DK|qu|*ca
@@ -11051,7 +11051,7 @@ DK|ro|*mo
 DK|ru|*bg
 DK|rw|*aa
 DK|sa|*aa
-DK|sc|*aa
+DK|sc|*it
 DK|sd|ڊينمارڪ
 DK|se|Dánmárku
 DK|sg|Danemêrke
@@ -11072,7 +11072,7 @@ DK|ta|டென்மார்க்
 DK|te|డెన్మార్క్
 DK|tg|*bg
 DK|th|เดนมาร์ก
-DK|ti|*am
+DK|ti|ደንማርክ
 DK|tk|Daniýa
 DK|tl|*aa
 DK|tn|*aa
@@ -11091,7 +11091,7 @@ DK|vi|Đan Mạch
 DK|vo|*aa
 DK|wa|*aa
 DK|wo|Danmàrk
-DK|xh|*aa
+DK|xh|EDenmark
 DK|yi|*ji
 DK|yo|Dẹ́mákì
 DK|za|*aa
@@ -11126,7 +11126,7 @@ DM|co|*aa
 DM|cr|*aa
 DM|cs|*az
 DM|cu|*aa
-DM|cv|*aa
+DM|cv|*bg
 DM|cy|*aa
 DM|da|*aa
 DM|de|*aa
@@ -11157,14 +11157,14 @@ DM|he|דומיניקה
 DM|hi|डोमिनिका
 DM|ho|*aa
 DM|hr|*az
-DM|ht|*aa
+DM|ht|*fr
 DM|hu|*az
 DM|hy|Դոմինիկա
 DM|hz|*aa
 DM|ia|*aa
 DM|id|*az
 DM|ie|*aa
-DM|ig|*az
+DM|ig|*aa
 DM|ii|*aa
 DM|ik|*aa
 DM|in|*az
@@ -11202,7 +11202,7 @@ DM|lu|Duminiku
 DM|lv|*az
 DM|mg|*az
 DM|mh|*aa
-DM|mi|*aa
+DM|mi|Tominika
 DM|mk|*bg
 DM|ml|ഡൊമിനിക്ക
 DM|mn|*bg
@@ -11224,7 +11224,7 @@ DM|nv|*aa
 DM|ny|*aa
 DM|oc|*aa
 DM|oj|*aa
-DM|om|*aa
+DM|om|Dominiikaa
 DM|or|ଡୋମିନିକା
 DM|os|*aa
 DM|pa|ਡੋਮੀਨਿਕਾ
@@ -11264,7 +11264,7 @@ DM|ti|*am
 DM|tk|*az
 DM|tl|*aa
 DM|tn|*aa
-DM|to|Tominika
+DM|to|*mi
 DM|tr|*az
 DM|ts|*aa
 DM|tt|*bg
@@ -11279,7 +11279,7 @@ DM|vi|*aa
 DM|vo|*aa
 DM|wa|*aa
 DM|wo|Dominik
-DM|xh|*aa
+DM|xh|EDominica
 DM|yi|*ji
 DM|yo|Dòmíníkà
 DM|za|*aa
@@ -11289,7 +11289,7 @@ DO|aa|Dominican Republic
 DO|ab|*aa
 DO|ae|*aa
 DO|af|Dominikaanse Republiek
-DO|ak|Dɔmeneka Kurokɛse
+DO|ak|Dɔmeneka Man
 DO|am|ዶመኒካን ሪፑብሊክ
 DO|an|*aa
 DO|ar|جمهورية الدومينيكان
@@ -11314,7 +11314,7 @@ DO|co|*aa
 DO|cr|*aa
 DO|cs|Dominikánská republika
 DO|cu|*aa
-DO|cv|*aa
+DO|cv|Доминикан Республики
 DO|cy|Gweriniaeth Dominica
 DO|da|Den Dominikanske Republik
 DO|de|Dominikanische Republik
@@ -11345,7 +11345,7 @@ DO|he|הרפובליקה הדומיניקנית
 DO|hi|डोमिनिकन गणराज्य
 DO|ho|*aa
 DO|hr|*bs
-DO|ht|*aa
+DO|ht|*fr
 DO|hu|Dominikai Köztársaság
 DO|hy|Դոմինիկյան Հանրապետություն
 DO|hz|*aa
@@ -11375,7 +11375,7 @@ DO|kn|ಡೊಮೆನಿಕನ್ ರಿಪಬ್ಲಿಕ್
 DO|ko|도미니카 공화국
 DO|kr|*aa
 DO|ks|ڈومِنِکَن جموٗرِیَت
-DO|ku|Komara Domînîk
+DO|ku|Komara Domînîkê
 DO|kv|*aa
 DO|kw|*aa
 DO|ky|Доминика Республикасы
@@ -11390,7 +11390,7 @@ DO|lu|Ditunga wa Duminiku
 DO|lv|Dominikāna
 DO|mg|Repoblika Dominikanina
 DO|mh|*aa
-DO|mi|*aa
+DO|mi|Te Whenua Tūhake o Tominika
 DO|mk|Доминиканска Република
 DO|ml|ഡൊമിനിക്കൻ റിപ്പബ്ലിക്ക്
 DO|mn|Бүгд Найрамдах Доминикан Улс
@@ -11412,7 +11412,7 @@ DO|nv|*aa
 DO|ny|*aa
 DO|oc|*aa
 DO|oj|*aa
-DO|om|*aa
+DO|om|Dominikaa Rippaabilik
 DO|or|ଡୋମିନିକାନ୍‌ ସାଧାରଣତନ୍ତ୍ର
 DO|os|*aa
 DO|pa|ਡੋਮੀਨਿਕਾਈ ਗਣਰਾਜ
@@ -11427,7 +11427,7 @@ DO|ro|*mo
 DO|ru|Доминиканская Республика
 DO|rw|*aa
 DO|sa|*aa
-DO|sc|*aa
+DO|sc|Repùblica Dominicana
 DO|sd|ڊومينيڪن جمهوريه
 DO|se|Dominikána dásseváldi
 DO|sg|Ködörösêse tî Dominîka
@@ -11448,7 +11448,7 @@ DO|ta|டொமினிகன் குடியரசு
 DO|te|డొమినికన్ రిపబ్లిక్
 DO|tg|Ҷумҳурии Доминикан
 DO|th|สาธารณรัฐโดมินิกัน
-DO|ti|ዶመኒካ ሪፓብሊክ
+DO|ti|ዶሚኒካዊት ሪፓብሊክ
 DO|tk|Dominikan Respublikasy
 DO|tl|*aa
 DO|tn|*aa
@@ -11467,7 +11467,7 @@ DO|vi|Cộng hòa Dominica
 DO|vo|*aa
 DO|wa|*aa
 DO|wo|Repiblik Dominiken
-DO|xh|*aa
+DO|xh|EDominican Republic
 DO|yi|*ji
 DO|yo|Dòmíníkánì
 DO|za|*aa
@@ -11502,7 +11502,7 @@ DZ|co|*aa
 DZ|cr|*aa
 DZ|cs|Alžírsko
 DZ|cu|*aa
-DZ|cv|*aa
+DZ|cv|*bg
 DZ|cy|*aa
 DZ|da|Algeriet
 DZ|de|Algerien
@@ -11522,7 +11522,7 @@ DZ|fj|*aa
 DZ|fo|*aa
 DZ|fr|Algérie
 DZ|fy|Algerije
-DZ|ga|an Ailgéir
+DZ|ga|An Ailgéir
 DZ|gd|Aildiria
 DZ|gl|Alxeria
 DZ|gn|*aa
@@ -11533,7 +11533,7 @@ DZ|he|אלג׳יריה
 DZ|hi|अल्जीरिया
 DZ|ho|*aa
 DZ|hr|*bs
-DZ|ht|*aa
+DZ|ht|*fr
 DZ|hu|Algéria
 DZ|hy|Ալժիր
 DZ|hz|*aa
@@ -11563,7 +11563,7 @@ DZ|kn|ಅಲ್ಜೀರಿಯ
 DZ|ko|알제리
 DZ|kr|*aa
 DZ|ks|اؠلجیرِیا
-DZ|ku|Cezayir
+DZ|ku|Cezayîr
 DZ|kv|*aa
 DZ|kw|*aa
 DZ|ky|*bg
@@ -11578,7 +11578,7 @@ DZ|lu|Alijeri
 DZ|lv|Alžīrija
 DZ|mg|Alzeria
 DZ|mh|*aa
-DZ|mi|*aa
+DZ|mi|Aratiria
 DZ|mk|*bg
 DZ|ml|അൾജീരിയ
 DZ|mn|*bg
@@ -11600,7 +11600,7 @@ DZ|nv|*aa
 DZ|ny|*aa
 DZ|oc|*aa
 DZ|oj|*aa
-DZ|om|*aa
+DZ|om|Aljeeriyaa
 DZ|or|ଆଲଜେରିଆ
 DZ|os|*aa
 DZ|pa|ਅਲਜੀਰੀਆ
@@ -11636,12 +11636,12 @@ DZ|ta|அல்ஜீரியா
 DZ|te|అల్జీరియా
 DZ|tg|Алҷазоир
 DZ|th|แอลจีเรีย
-DZ|ti|ኣልጀሪያ
+DZ|ti|ኣልጀርያ
 DZ|tk|*bs
 DZ|tl|*aa
 DZ|tn|*aa
 DZ|to|ʻAlisilia
-DZ|tr|*ku
+DZ|tr|Cezayir
 DZ|ts|*aa
 DZ|tt|*bg
 DZ|tw|*aa
@@ -11655,7 +11655,7 @@ DZ|vi|*aa
 DZ|vo|*aa
 DZ|wa|*aa
 DZ|wo|Alseri
-DZ|xh|*aa
+DZ|xh|E-Algeria
 DZ|yi|*aa
 DZ|yo|Àlùgèríánì
 DZ|za|*aa
@@ -11665,7 +11665,7 @@ EC|aa|Ecuador
 EC|ab|*aa
 EC|ae|*aa
 EC|af|*aa
-EC|ak|Ikuwadɔ
+EC|ak|Yikuwedɔ
 EC|am|ኢኳዶር
 EC|an|*aa
 EC|ar|الإكوادور
@@ -11690,7 +11690,7 @@ EC|co|*aa
 EC|cr|*aa
 EC|cs|Ekvádor
 EC|cu|*aa
-EC|cv|*aa
+EC|cv|*be
 EC|cy|*aa
 EC|da|*aa
 EC|de|*aa
@@ -11721,7 +11721,7 @@ EC|he|אקוודור
 EC|hi|इक्वाडोर
 EC|ho|*aa
 EC|hr|*az
-EC|ht|*aa
+EC|ht|*fr
 EC|hu|*aa
 EC|hy|Էկվադոր
 EC|hz|*aa
@@ -11751,7 +11751,7 @@ EC|kn|ಈಕ್ವೆಡಾರ್
 EC|ko|에콰도르
 EC|kr|*aa
 EC|ks|اِکواڑور
-EC|ku|*eu
+EC|ku|*ha
 EC|kv|*aa
 EC|kw|*aa
 EC|ky|*be
@@ -11766,7 +11766,7 @@ EC|lu|Ekwatele
 EC|lv|Ekvadora
 EC|mg|Ekoatera
 EC|mh|*aa
-EC|mi|*aa
+EC|mi|Ekuatoa
 EC|mk|*bg
 EC|ml|ഇക്വഡോർ
 EC|mn|*be
@@ -11788,8 +11788,8 @@ EC|nv|*aa
 EC|ny|*aa
 EC|oc|*aa
 EC|oj|*aa
-EC|om|*aa
-EC|or|ଇକ୍ୱାଡୋର୍
+EC|om|Ekuwaador
+EC|or|ଇକ୍ୱେଡର୍‌
 EC|os|*aa
 EC|pa|ਇਕਵੇਡੋਰ
 EC|pi|*aa
@@ -11803,7 +11803,7 @@ EC|ro|*aa
 EC|ru|*be
 EC|rw|*aa
 EC|sa|*aa
-EC|sc|*aa
+EC|sc|Ècuador
 EC|sd|ايڪواڊور
 EC|se|*aa
 EC|sg|Ekuatëre
@@ -11824,7 +11824,7 @@ EC|ta|ஈக்வடார்
 EC|te|ఈక్వడార్
 EC|tg|*be
 EC|th|เอกวาดอร์
-EC|ti|*am
+EC|ti|ኤኳዶር
 EC|tk|*ha
 EC|tl|*aa
 EC|tn|*aa
@@ -11843,7 +11843,7 @@ EC|vi|*aa
 EC|vo|*aa
 EC|wa|*aa
 EC|wo|Ekwaatër
-EC|xh|*aa
+EC|xh|EEcuador
 EC|yi|*ji
 EC|yo|Ekuádò
 EC|za|*aa
@@ -11878,7 +11878,7 @@ EE|co|*aa
 EE|cr|*aa
 EE|cs|Estonsko
 EE|cu|*aa
-EE|cv|*aa
+EE|cv|*ce
 EE|cy|*aa
 EE|da|*af
 EE|de|*af
@@ -11909,7 +11909,7 @@ EE|he|אסטוניה
 EE|hi|एस्टोनिया
 EE|ho|*aa
 EE|hr|*bs
-EE|ht|*aa
+EE|ht|*fr
 EE|hu|Észtország
 EE|hy|Էստոնիա
 EE|hz|*aa
@@ -11954,7 +11954,7 @@ EE|lu|*ln
 EE|lv|Igaunija
 EE|mg|*aa
 EE|mh|*aa
-EE|mi|*aa
+EE|mi|Etōnia
 EE|mk|Естонија
 EE|ml|എസ്റ്റോണിയ‍
 EE|mn|*ce
@@ -11976,7 +11976,7 @@ EE|nv|*aa
 EE|ny|*aa
 EE|oc|*aa
 EE|oj|*aa
-EE|om|*aa
+EE|om|Istooniyaa
 EE|or|ଏସ୍ତୋନିଆ
 EE|os|*aa
 EE|pa|ਇਸਟੋਨੀਆ
@@ -11991,7 +11991,7 @@ EE|ro|*aa
 EE|ru|*kk
 EE|rw|*aa
 EE|sa|*aa
-EE|sc|*aa
+EE|sc|*ca
 EE|sd|ايسٽونيا
 EE|se|Estlánda
 EE|sg|Estonïi
@@ -12012,7 +12012,7 @@ EE|ta|எஸ்டோனியா
 EE|te|ఎస్టోనియా
 EE|tg|*kk
 EE|th|เอสโตเนีย
-EE|ti|*am
+EE|ti|ኤስቶንያ
 EE|tk|Estoniýa
 EE|tl|*aa
 EE|tn|*aa
@@ -12031,7 +12031,7 @@ EE|vi|*aa
 EE|vo|*aa
 EE|wa|*aa
 EE|wo|*ff
-EE|xh|*aa
+EE|xh|E-Estonia
 EE|yi|*ji
 EE|yo|Esitonia
 EE|za|*aa
@@ -12041,7 +12041,7 @@ EG|aa|Egypt
 EG|ab|*aa
 EG|ae|*aa
 EG|af|Egipte
-EG|ak|Nisrim
+EG|ak|Misrim
 EG|am|ግብጽ
 EG|an|*aa
 EG|ar|مصر
@@ -12066,7 +12066,7 @@ EG|co|*aa
 EG|cr|*aa
 EG|cs|*aa
 EG|cu|*aa
-EG|cv|*aa
+EG|cv|*bg
 EG|cy|Yr Aifft
 EG|da|Egypten
 EG|de|Ägypten
@@ -12075,10 +12075,10 @@ EG|dz|ཨི་ཇིབཊ
 EG|ee|Egypte nutome
 EG|el|Αίγυπτος
 EG|en|*aa
-EG|eo|Egipto
-EG|es|*eo
+EG|eo|Egiptujo
+EG|es|Egipto
 EG|et|Egiptus
-EG|eu|*eo
+EG|eu|*es
 EG|fa|*ar
 EG|ff|Ejipt
 EG|fi|Egypti
@@ -12086,8 +12086,8 @@ EG|fj|*aa
 EG|fo|Egyptaland
 EG|fr|Égypte
 EG|fy|Egypte
-EG|ga|an Éigipt
-EG|gd|An Èiphit
+EG|ga|An Éigipt
+EG|gd|An Èipheit
 EG|gl|Exipto
 EG|gn|*aa
 EG|gu|ઇજિપ્ત
@@ -12097,7 +12097,7 @@ EG|he|מצרים
 EG|hi|मिस्र
 EG|ho|*aa
 EG|hr|*bs
-EG|ht|*aa
+EG|ht|*fr
 EG|hu|Egyiptom
 EG|hy|Եգիպտոս
 EG|hz|*aa
@@ -12126,7 +12126,7 @@ EG|km|អេហ្ស៊ីប
 EG|kn|ಈಜಿಪ್ಟ್
 EG|ko|이집트
 EG|kr|*aa
-EG|ks|مِسٔر
+EG|ks|*ar
 EG|ku|*az
 EG|kv|*aa
 EG|kw|*aa
@@ -12142,7 +12142,7 @@ EG|lu|Mushidi
 EG|lv|Ēģipte
 EG|mg|Ejypta
 EG|mh|*aa
-EG|mi|*aa
+EG|mi|Īhipa
 EG|mk|*bg
 EG|ml|ഈജിപ്ത്
 EG|mn|*bg
@@ -12164,7 +12164,7 @@ EG|nv|*aa
 EG|ny|*aa
 EG|oc|*aa
 EG|oj|*aa
-EG|om|*aa
+EG|om|Missir
 EG|or|ଇଜିପ୍ଟ
 EG|os|*aa
 EG|pa|ਮਿਸਰ
@@ -12172,14 +12172,14 @@ EG|pi|*aa
 EG|pl|*br
 EG|ps|*ar
 EG|pt|Egito
-EG|qu|*eo
+EG|qu|*es
 EG|rm|Egipta
 EG|rn|*lg
 EG|ro|*br
 EG|ru|*bg
 EG|rw|*aa
 EG|sa|*aa
-EG|sc|*aa
+EG|sc|Egitu
 EG|sd|*ar
 EG|se|Egypta
 EG|sg|Kâmitâ
@@ -12200,7 +12200,7 @@ EG|ta|எகிப்து
 EG|te|ఈజిప్ట్
 EG|tg|Миср
 EG|th|อียิปต์
-EG|ti|*am
+EG|ti|ግብጺ
 EG|tk|Müsür
 EG|tl|*aa
 EG|tn|*aa
@@ -12219,7 +12219,7 @@ EG|vi|Ai Cập
 EG|vo|*aa
 EG|wa|*aa
 EG|wo|Esipt
-EG|xh|*aa
+EG|xh|IYiputa
 EG|yi|*ji
 EG|yo|Égípítì
 EG|za|*aa
@@ -12229,7 +12229,7 @@ EH|aa|Western Sahara
 EH|ab|*aa
 EH|ae|*aa
 EH|af|Wes-Sahara
-EH|ak|*aa
+EH|ak|Sahara Atɔeɛ
 EH|am|ምዕራባዊ ሳህራ
 EH|an|*aa
 EH|ar|الصحراء الغربية
@@ -12254,7 +12254,7 @@ EH|co|*aa
 EH|cr|*aa
 EH|cs|Západní Sahara
 EH|cu|*aa
-EH|cv|*aa
+EH|cv|Анӑҫ Сахара
 EH|cy|Gorllewin Sahara
 EH|da|Vestsahara
 EH|de|Westsahara
@@ -12274,9 +12274,9 @@ EH|fj|*aa
 EH|fo|Vestursahara
 EH|fr|Sahara occidental
 EH|fy|Westelijke Sahara
-EH|ga|an Sahára Thiar
+EH|ga|An Sahára Thiar
 EH|gd|Sathara an Iar
-EH|gl|O Sáhara Occidental
+EH|gl|*es
 EH|gn|*aa
 EH|gu|પશ્ચિમી સહારા
 EH|gv|*aa
@@ -12285,7 +12285,7 @@ EH|he|סהרה המערבית
 EH|hi|पश्चिमी सहारा
 EH|ho|*aa
 EH|hr|*bs
-EH|ht|*aa
+EH|ht|*fr
 EH|hu|Nyugat-Szahara
 EH|hy|Արևմտյան Սահարա
 EH|hz|*aa
@@ -12298,7 +12298,7 @@ EH|ik|*aa
 EH|in|*id
 EH|io|*aa
 EH|is|Vestur-Sahara
-EH|it|Sahara occidentale
+EH|it|Sahara Occidentale
 EH|iu|*aa
 EH|iw|*he
 EH|ja|西サハラ
@@ -12330,7 +12330,7 @@ EH|lu|*aa
 EH|lv|Rietumsahāra
 EH|mg|*aa
 EH|mh|*aa
-EH|mi|*aa
+EH|mi|Hahāra ki te Tonga
 EH|mk|*bg
 EH|ml|പശ്ചിമ സഹാറ
 EH|mn|Баруун Сахар
@@ -12352,7 +12352,7 @@ EH|nv|*aa
 EH|ny|*aa
 EH|oc|*aa
 EH|oj|*aa
-EH|om|*aa
+EH|om|Sahaaraa Dhihaa
 EH|or|ପଶ୍ଚିମ ସାହାରା
 EH|os|*aa
 EH|pa|ਪੱਛਮੀ ਸਹਾਰਾ
@@ -12367,7 +12367,7 @@ EH|ro|*mo
 EH|ru|Западная Сахара
 EH|rw|*aa
 EH|sa|*aa
-EH|sc|*aa
+EH|sc|Sahara otzidentale
 EH|sd|اولهه صحارا
 EH|se|Oarje-Sahára
 EH|sg|*aa
@@ -12386,16 +12386,16 @@ EH|sv|Västsahara
 EH|sw|Sahara Magharibi
 EH|ta|மேற்கு சஹாரா
 EH|te|పడమటి సహారా
-EH|tg|*aa
+EH|tg|Сахараи Ғарбӣ
 EH|th|ซาฮาราตะวันตก
-EH|ti|*am
+EH|ti|ምዕራባዊ ሰሃራ
 EH|tk|Günbatar Sahara
 EH|tl|Kanlurang Sahara
 EH|tn|*aa
 EH|to|Sahala fakahihifo
 EH|tr|Batı Sahra
 EH|ts|*aa
-EH|tt|*aa
+EH|tt|Көнбатыш Сахара
 EH|tw|*aa
 EH|ty|*aa
 EH|ug|غەربىي ساخارا
@@ -12406,8 +12406,8 @@ EH|ve|*aa
 EH|vi|Tây Sahara
 EH|vo|*aa
 EH|wa|*aa
-EH|wo|*aa
-EH|xh|*aa
+EH|wo|Sahara bu sowwu
+EH|xh|EWestern Sahara
 EH|yi|*aa
 EH|yo|Ìwọ̀òòrùn Sàhárà
 EH|za|*aa
@@ -12442,7 +12442,7 @@ ER|co|*aa
 ER|cr|*aa
 ER|cs|*aa
 ER|cu|*aa
-ER|cv|*aa
+ER|cv|*ce
 ER|cy|*aa
 ER|da|*aa
 ER|de|*aa
@@ -12473,7 +12473,7 @@ ER|he|אריתריאה
 ER|hi|इरिट्रिया
 ER|ho|*aa
 ER|hr|*bs
-ER|ht|*aa
+ER|ht|*fr
 ER|hu|*aa
 ER|hy|Էրիթրեա
 ER|hz|*aa
@@ -12503,7 +12503,7 @@ ER|kn|ಎರಿಟ್ರಿಯಾ
 ER|ko|에리트리아
 ER|kr|*aa
 ER|ks|اِرٕٹِیا
-ER|ku|Erîtrea
+ER|ku|Erître
 ER|kv|*aa
 ER|kw|*aa
 ER|ky|*kk
@@ -12518,7 +12518,7 @@ ER|lu|Elitele
 ER|lv|*bs
 ER|mg|*aa
 ER|mh|*aa
-ER|mi|*aa
+ER|mi|Eritēria
 ER|mk|Еритреја
 ER|ml|എറിത്രിയ
 ER|mn|*ce
@@ -12540,7 +12540,7 @@ ER|nv|*aa
 ER|ny|*aa
 ER|oc|*aa
 ER|oj|*aa
-ER|om|*aa
+ER|om|Eertiraa
 ER|or|ଇରିଟ୍ରିୟା
 ER|os|*aa
 ER|pa|ਇਰੀਟ੍ਰਿਆ
@@ -12595,7 +12595,7 @@ ER|vi|*aa
 ER|vo|*aa
 ER|wa|*aa
 ER|wo|*bm
-ER|xh|*aa
+ER|xh|E-Eritrea
 ER|yi|*ji
 ER|yo|Eritira
 ER|za|*aa
@@ -12630,7 +12630,7 @@ ES|co|*aa
 ES|cr|*aa
 ES|cs|Španělsko
 ES|cu|*aa
-ES|cv|*aa
+ES|cv|*ce
 ES|cy|Sbaen
 ES|da|Spanien
 ES|de|*da
@@ -12661,13 +12661,13 @@ ES|he|ספרד
 ES|hi|स्पेन
 ES|ho|*aa
 ES|hr|Španjolska
-ES|ht|*aa
+ES|ht|*fr
 ES|hu|Spanyolország
 ES|hy|Իսպանիա
 ES|hz|*aa
 ES|ia|Espania
 ES|id|Spanyol
-ES|ie|*aa
+ES|ie|Hispania
 ES|ig|*aa
 ES|ii|*aa
 ES|ik|*aa
@@ -12682,7 +12682,7 @@ ES|ji|שפּאַניע
 ES|jv|Sepanyol
 ES|ka|ესპანეთი
 ES|kg|*aa
-ES|ki|Hispania
+ES|ki|*ie
 ES|kj|*aa
 ES|kk|*bg
 ES|kl|*aa
@@ -12706,7 +12706,7 @@ ES|lu|Nsipani
 ES|lv|Spānija
 ES|mg|Espaina
 ES|mh|*aa
-ES|mi|*aa
+ES|mi|Peina
 ES|mk|Шпанија
 ES|ml|സ്‌പെയിൻ
 ES|mn|*ce
@@ -12726,16 +12726,16 @@ ES|no|*fo
 ES|nr|*aa
 ES|nv|*aa
 ES|ny|*aa
-ES|oc|*aa
+ES|oc|Espanha
 ES|oj|*aa
-ES|om|*aa
+ES|om|Ispeen
 ES|or|ସ୍ପେନ୍
 ES|os|*aa
 ES|pa|ਸਪੇਨ
 ES|pi|*aa
 ES|pl|Hiszpania
 ES|ps|هسپانیه
-ES|pt|Espanha
+ES|pt|*oc
 ES|qu|*es
 ES|rm|*it
 ES|rn|Hisipaniya
@@ -12743,7 +12743,7 @@ ES|ro|*fo
 ES|ru|*bg
 ES|rw|*aa
 ES|sa|*aa
-ES|sc|*aa
+ES|sc|Ispagna
 ES|sd|اسپين
 ES|se|Spánia
 ES|sg|Espânye
@@ -12764,7 +12764,7 @@ ES|ta|ஸ்பெயின்
 ES|te|స్పెయిన్
 ES|tg|*bg
 ES|th|สเปน
-ES|ti|*am
+ES|ti|ስጳኛ
 ES|tk|Ispaniýa
 ES|tl|*aa
 ES|tn|*aa
@@ -12783,9 +12783,9 @@ ES|vi|Tây Ban Nha
 ES|vo|*aa
 ES|wa|*aa
 ES|wo|Españ
-ES|xh|*aa
+ES|xh|ESpain
 ES|yi|*ji
-ES|yo|Sipani
+ES|yo|Sípéìnì
 ES|za|*aa
 ES|zh|西班牙
 ES|zu|i-Spain
@@ -12818,7 +12818,7 @@ ET|co|*aa
 ET|cr|*aa
 ET|cs|Etiopie
 ET|cu|*aa
-ET|cv|*aa
+ET|cv|*ce
 ET|cy|*aa
 ET|da|Etiopien
 ET|de|Äthiopien
@@ -12849,13 +12849,13 @@ ET|he|אתיופיה
 ET|hi|इथियोपिया
 ET|ho|*aa
 ET|hr|*bs
-ET|ht|*aa
+ET|ht|*fr
 ET|hu|Etiópia
 ET|hy|Եթովպիա
 ET|hz|*aa
 ET|ia|*aa
 ET|id|*br
-ET|ie|*aa
+ET|ie|*br
 ET|ig|*aa
 ET|ii|*aa
 ET|ik|*aa
@@ -12879,7 +12879,7 @@ ET|kn|ಇಥಿಯೋಪಿಯಾ
 ET|ko|에티오피아
 ET|kr|*aa
 ET|ks|اِتھوپِیا
-ET|ku|Etiyopya
+ET|ku|Etîyopya
 ET|kv|*aa
 ET|kw|*aa
 ET|ky|*kk
@@ -12894,7 +12894,7 @@ ET|lu|Etshiopi
 ET|lv|*bs
 ET|mg|*aa
 ET|mh|*aa
-ET|mi|*aa
+ET|mi|*br
 ET|mk|Етиопија
 ET|ml|എത്യോപ്യ
 ET|mn|Этиоп
@@ -12931,7 +12931,7 @@ ET|ro|*br
 ET|ru|*kk
 ET|rw|*aa
 ET|sa|*aa
-ET|sc|*aa
+ET|sc|*ca
 ET|sd|ايٿوپيا
 ET|se|*br
 ET|sg|Etiopïi
@@ -12957,7 +12957,7 @@ ET|tk|Efiopiýa
 ET|tl|*aa
 ET|tn|*aa
 ET|to|ʻĪtiōpia
-ET|tr|*ku
+ET|tr|Etiyopya
 ET|ts|*aa
 ET|tt|*kk
 ET|tw|*aa
@@ -12971,7 +12971,7 @@ ET|vi|*aa
 ET|vo|*aa
 ET|wa|*aa
 ET|wo|Ecopi
-ET|xh|*aa
+ET|xh|E-Ethiopia
 ET|yi|*ji
 ET|yo|Etopia
 ET|za|*aa
@@ -13006,7 +13006,7 @@ FI|co|*aa
 FI|cr|*aa
 FI|cs|Finsko
 FI|cu|*aa
-FI|cv|*aa
+FI|cv|*ce
 FI|cy|Y Ffindir
 FI|da|*aa
 FI|de|Finnland
@@ -13037,7 +13037,7 @@ FI|he|פינלנד
 FI|hi|फ़िनलैंड
 FI|ho|*aa
 FI|hr|*bs
-FI|ht|*aa
+FI|ht|*fr
 FI|hu|Finnország
 FI|hy|Ֆինլանդիա
 FI|hz|*aa
@@ -13066,7 +13066,7 @@ FI|km|ហ្វាំងឡង់
 FI|kn|ಫಿನ್‌ಲ್ಯಾಂಡ್
 FI|ko|핀란드
 FI|kr|*aa
-FI|ks|فِنلینڑ
+FI|ks|فِن لینڈ
 FI|ku|Fînlenda
 FI|kv|*aa
 FI|kw|*aa
@@ -13082,10 +13082,10 @@ FI|lu|Filande
 FI|lv|Somija
 FI|mg|Finlandy
 FI|mh|*aa
-FI|mi|*aa
+FI|mi|Whinarana
 FI|mk|Финска
 FI|ml|ഫിൻലാൻഡ്
-FI|mn|Финлянд
+FI|mn|Финланд
 FI|mo|Finlanda
 FI|mr|फिनलंड
 FI|ms|*aa
@@ -13104,7 +13104,7 @@ FI|nv|*aa
 FI|ny|*aa
 FI|oc|*aa
 FI|oj|*aa
-FI|om|*aa
+FI|om|Fiinlaand
 FI|or|ଫିନଲ୍ୟାଣ୍ଡ
 FI|os|*aa
 FI|pa|ਫਿਨਲੈਂਡ
@@ -13119,7 +13119,7 @@ FI|ro|*mo
 FI|ru|*kk
 FI|rw|*aa
 FI|sa|*aa
-FI|sc|*aa
+FI|sc|*ca
 FI|sd|فن لينڊ
 FI|se|Suopma
 FI|sg|Fëlânde
@@ -13159,7 +13159,7 @@ FI|vi|Phần Lan
 FI|vo|*aa
 FI|wa|*aa
 FI|wo|Finlànd
-FI|xh|*aa
+FI|xh|EFinland
 FI|yi|*ji
 FI|yo|Filandi
 FI|za|*aa
@@ -13194,7 +13194,7 @@ FJ|co|*aa
 FJ|cr|*aa
 FJ|cs|*bs
 FJ|cu|*aa
-FJ|cv|*aa
+FJ|cv|*bg
 FJ|cy|*aa
 FJ|da|*aa
 FJ|de|Fidschi
@@ -13225,13 +13225,13 @@ FJ|he|פיג׳י
 FJ|hi|फ़िजी
 FJ|ho|*aa
 FJ|hr|*bs
-FJ|ht|*aa
+FJ|ht|*af
 FJ|hu|Fidzsi
 FJ|hy|Ֆիջի
 FJ|hz|*aa
 FJ|ia|*aa
 FJ|id|*aa
-FJ|ie|*aa
+FJ|ie|*af
 FJ|ig|*aa
 FJ|ii|*aa
 FJ|ik|*aa
@@ -13270,7 +13270,7 @@ FJ|lu|Fuji
 FJ|lv|*bs
 FJ|mg|*af
 FJ|mh|*aa
-FJ|mi|*aa
+FJ|mi|Whītī
 FJ|mk|Фиџи
 FJ|ml|ഫിജി
 FJ|mn|Фижи
@@ -13292,7 +13292,7 @@ FJ|nv|*aa
 FJ|ny|*aa
 FJ|oc|*aa
 FJ|oj|*aa
-FJ|om|*aa
+FJ|om|Fiijii
 FJ|or|ଫିଜି
 FJ|os|*aa
 FJ|pa|ਫ਼ਿਜੀ
@@ -13347,9 +13347,9 @@ FJ|vi|*aa
 FJ|vo|*aa
 FJ|wa|*aa
 FJ|wo|*ff
-FJ|xh|*aa
+FJ|xh|EFiji
 FJ|yi|*ji
-FJ|yo|*aa
+FJ|yo|Fíjì
 FJ|za|*aa
 FJ|zh|斐济
 FJ|zu|i-Fiji
@@ -13357,7 +13357,7 @@ FK|aa|Falkland Islands
 FK|ab|*aa
 FK|ae|*aa
 FK|af|Falklandeilande
-FK|ak|Fɔlkman Aeland
+FK|ak|Fɔkman Aeland
 FK|am|የፎክላንድ ደሴቶች
 FK|an|*aa
 FK|ar|جزر فوكلاند
@@ -13375,14 +13375,14 @@ FK|bn|ফকল্যান্ড দ্বীপপুঞ্জ
 FK|bo|*aa
 FK|br|Inizi Falkland
 FK|bs|Folklandska ostrva
-FK|ca|Illes Malvines
+FK|ca|Illes Falkland
 FK|ce|Фолклендан гӀайренаш
 FK|ch|*aa
 FK|co|*aa
 FK|cr|*aa
 FK|cs|Falklandské ostrovy
 FK|cu|*aa
-FK|cv|*aa
+FK|cv|Фолкленд утравӗсем
 FK|cy|Ynysoedd y Falkland/Malvinas
 FK|da|Falklandsøerne
 FK|de|Falklandinseln
@@ -13412,15 +13412,15 @@ FK|ha|Tsibiran Falkilan
 FK|he|איי פוקלנד
 FK|hi|फ़ॉकलैंड द्वीपसमूह
 FK|ho|*aa
-FK|hr|Falklandski otoci
-FK|ht|*aa
+FK|hr|Falklandski Otoci
+FK|ht|*fr
 FK|hu|Falkland-szigetek
 FK|hy|Ֆոլքլենդյան կղզիներ
 FK|hz|*aa
-FK|ia|*aa
+FK|ia|Insulas Falkland
 FK|id|Kepulauan Falkland
 FK|ie|*aa
-FK|ig|Agwaetiti Falkland
+FK|ig|*aa
 FK|ii|*aa
 FK|ik|*aa
 FK|in|*id
@@ -13443,7 +13443,7 @@ FK|kn|ಫಾಕ್‌ಲ್ಯಾಂಡ್ ದ್ವೀಪಗಳು
 FK|ko|포클랜드 제도
 FK|kr|*aa
 FK|ks|فٕلاکلینڑ جٔزیٖرٕ
-FK|ku|Giravên Malvîn
+FK|ku|Giravên Falklandê
 FK|kv|*aa
 FK|kw|*aa
 FK|ky|*kk
@@ -13458,7 +13458,7 @@ FK|lu|Lutanda lua Maluni
 FK|lv|Folklenda salas
 FK|mg|Nosy Falkand
 FK|mh|*aa
-FK|mi|*aa
+FK|mi|Motu Whākarangi
 FK|mk|Фолкландски Острови
 FK|ml|ഫാക്ക്‌ലാന്റ് ദ്വീപുകൾ
 FK|mn|Фолклендийн арлууд
@@ -13480,7 +13480,7 @@ FK|nv|*aa
 FK|ny|*aa
 FK|oc|*aa
 FK|oj|*aa
-FK|om|*aa
+FK|om|Odoloota Faalklaand
 FK|or|ଫକ୍‌ଲ୍ୟାଣ୍ଡ ଦ୍ଵୀପପୁଞ୍ଜ
 FK|os|*aa
 FK|pa|ਫ਼ਾਕਲੈਂਡ ਟਾਪੂ
@@ -13495,7 +13495,7 @@ FK|ro|*mo
 FK|ru|Фолклендские о-ва
 FK|rw|*aa
 FK|sa|*aa
-FK|sc|*aa
+FK|sc|Ìsulas Falkland
 FK|sd|فاڪ لينڊ ٻيٽ
 FK|se|Falklandsullot
 FK|sg|Âzûâ tî Mälüîni
@@ -13535,7 +13535,7 @@ FK|vi|Quần đảo Falkland
 FK|vo|*aa
 FK|wa|*aa
 FK|wo|Duni Falkland
-FK|xh|*aa
+FK|xh|EFalkland Islands
 FK|yi|*ji
 FK|yo|Etikun Fakalandi
 FK|za|*aa
@@ -13546,7 +13546,7 @@ FM|ab|*aa
 FM|ae|*aa
 FM|af|Mikronesië
 FM|ak|Maekronehyia
-FM|am|ሚክሮኔዢያ
+FM|am|ማይክሮኔዢያ
 FM|an|*aa
 FM|ar|ميكرونيزيا
 FM|as|মাইক্ৰোনেচিয়া
@@ -13570,7 +13570,7 @@ FM|co|*aa
 FM|cr|*aa
 FM|cs|Mikronésie
 FM|cu|*aa
-FM|cv|*aa
+FM|cv|Микронези
 FM|cy|*aa
 FM|da|Mikronesien
 FM|de|*da
@@ -13601,7 +13601,7 @@ FM|he|מיקרונזיה
 FM|hi|माइक्रोनेशिया
 FM|ho|*aa
 FM|hr|*bs
-FM|ht|*aa
+FM|ht|*fr
 FM|hu|Mikronézia
 FM|hy|Միկրոնեզիա
 FM|hz|*aa
@@ -13630,7 +13630,7 @@ FM|km|មីក្រូណេស៊ី
 FM|kn|ಮೈಕ್ರೋನೇಶಿಯಾ
 FM|ko|미크로네시아
 FM|kr|*aa
-FM|ks|*aa
+FM|ks|مائیکرونیشیا
 FM|ku|Mîkronezya
 FM|kv|*aa
 FM|kw|*aa
@@ -13646,14 +13646,14 @@ FM|lu|*ln
 FM|lv|Mikronēzija
 FM|mg|Mikrônezia
 FM|mh|*aa
-FM|mi|*aa
+FM|mi|Mekanēhia
 FM|mk|Микронезија
 FM|ml|മൈക്രോനേഷ്യ
-FM|mn|Микронези
+FM|mn|*cv
 FM|mo|Micronezia
 FM|mr|मायक्रोनेशिया
 FM|ms|*aa
-FM|mt|Mikroneżja
+FM|mt|il-Mikroneżja
 FM|my|မိုင်ခရိုနီရှား
 FM|na|*aa
 FM|nb|Mikronesiaføderasjonen
@@ -13668,7 +13668,7 @@ FM|nv|*aa
 FM|ny|*aa
 FM|oc|*aa
 FM|oj|*aa
-FM|om|*aa
+FM|om|Maayikirooneeshiyaa
 FM|or|ମାଇକ୍ରୋନେସିଆ
 FM|os|*aa
 FM|pa|ਮਾਇਕ੍ਰੋਨੇਸ਼ੀਆ
@@ -13683,7 +13683,7 @@ FM|ro|*mo
 FM|ru|Федеративные Штаты Микронезии
 FM|rw|*aa
 FM|sa|*aa
-FM|sc|*aa
+FM|sc|*ca
 FM|sd|مائڪرونيشيا
 FM|se|*eu
 FM|sg|Mikronezïi
@@ -13704,7 +13704,7 @@ FM|ta|மைக்ரோனேஷியா
 FM|te|మైక్రోనేషియా
 FM|tg|Штатҳои Федеративии Микронезия
 FM|th|ไมโครนีเซีย
-FM|ti|*am
+FM|ti|ማይክሮነዥያ
 FM|tk|Mikroneziýa
 FM|tl|*aa
 FM|tn|*aa
@@ -13723,7 +13723,7 @@ FM|vi|*aa
 FM|vo|*aa
 FM|wa|*aa
 FM|wo|Mikoronesi
-FM|xh|*aa
+FM|xh|EMicronesia
 FM|yi|*ji
 FM|yo|Makoronesia
 FM|za|*aa
@@ -13733,7 +13733,7 @@ FO|aa|Faroe Islands
 FO|ab|*aa
 FO|ae|*aa
 FO|af|Faroëreilande
-FO|ak|*aa
+FO|ak|Faro Aeland
 FO|am|የፋሮ ደሴቶች
 FO|an|*aa
 FO|ar|جزر فارو
@@ -13747,7 +13747,7 @@ FO|bg|Фарьорски острови
 FO|bh|*aa
 FO|bi|*aa
 FO|bm|*aa
-FO|bn|ফ্যারও দ্বীপপুঞ্জ
+FO|bn|ফ্যারো দ্বীপপুঞ্জ
 FO|bo|*aa
 FO|br|Inizi Faero
 FO|bs|Farska ostrva
@@ -13758,7 +13758,7 @@ FO|co|*aa
 FO|cr|*aa
 FO|cs|Faerské ostrovy
 FO|cu|*aa
-FO|cv|*aa
+FO|cv|Фарер утравӗсем
 FO|cy|Ynysoedd Ffaro
 FO|da|Færøerne
 FO|de|Färöer
@@ -13788,15 +13788,15 @@ FO|ha|Tsibirai na Faroe
 FO|he|איי פארו
 FO|hi|फ़ेरो द्वीपसमूह
 FO|ho|*aa
-FO|hr|Farski otoci
-FO|ht|*aa
+FO|hr|Ovčji Otoci
+FO|ht|*fr
 FO|hu|Feröer szigetek
 FO|hy|Ֆարերյան կղզիներ
 FO|hz|*aa
 FO|ia|Insulas Feroe
 FO|id|Kepulauan Faroe
 FO|ie|*aa
-FO|ig|Agwaetiti Faroe
+FO|ig|*aa
 FO|ii|*aa
 FO|ik|*aa
 FO|in|*id
@@ -13818,8 +13818,8 @@ FO|km|កោះ​ហ្វារ៉ូ
 FO|kn|ಫರೋ ದ್ವೀಪಗಳು
 FO|ko|페로 제도
 FO|kr|*aa
-FO|ks|*aa
-FO|ku|Giravên Feroe
+FO|ks|فارو جزیرہ
+FO|ku|Giravên Faroeyê
 FO|kv|*aa
 FO|kw|*aa
 FO|ky|*kk
@@ -13834,7 +13834,7 @@ FO|lu|*aa
 FO|lv|Fēru salas
 FO|mg|*aa
 FO|mh|*aa
-FO|mi|*aa
+FO|mi|Motu Wharau
 FO|mk|Фарски Острови
 FO|ml|ഫറോ ദ്വീപുകൾ
 FO|mn|Фарерын арлууд
@@ -13856,7 +13856,7 @@ FO|nv|*aa
 FO|ny|*aa
 FO|oc|*aa
 FO|oj|*aa
-FO|om|*aa
+FO|om|Odoloota Fafo’ee
 FO|or|ଫାରୋଇ ଦ୍ୱୀପପୁଞ୍ଜ
 FO|os|*aa
 FO|pa|ਫੈਰੋ ਟਾਪੂ
@@ -13871,7 +13871,7 @@ FO|ro|*mo
 FO|ru|Фарерские о-ва
 FO|rw|*aa
 FO|sa|*aa
-FO|sc|*aa
+FO|sc|Ìsulas Føroyar
 FO|sd|فارو ٻيٽ
 FO|se|Fearsullot
 FO|sg|*aa
@@ -13892,7 +13892,7 @@ FO|ta|ஃபாரோ தீவுகள்
 FO|te|ఫారో దీవులు
 FO|tg|Ҷазираҳои Фарер
 FO|th|หมู่เกาะแฟโร
-FO|ti|ደሴታት ፋራኦ
+FO|ti|ደሴታት ፋሮ
 FO|tk|Farer adalary
 FO|tl|*aa
 FO|tn|*aa
@@ -13911,7 +13911,7 @@ FO|vi|Quần đảo Faroe
 FO|vo|*aa
 FO|wa|*aa
 FO|wo|Duni Faro
-FO|xh|*aa
+FO|xh|EFaroe Islands
 FO|yi|*ji
 FO|yo|Àwọn Erékùsù ti Faroe
 FO|za|*aa
@@ -13921,7 +13921,7 @@ FR|aa|France
 FR|ab|*aa
 FR|ae|*aa
 FR|af|Frankryk
-FR|ak|Frɛnkyeman
+FR|ak|Franse
 FR|am|ፈረንሳይ
 FR|an|*aa
 FR|ar|فرنسا
@@ -13946,7 +13946,7 @@ FR|co|*aa
 FR|cr|*aa
 FR|cs|Francie
 FR|cu|*aa
-FR|cv|*aa
+FR|cv|*ce
 FR|cy|Ffrainc
 FR|da|Frankrig
 FR|de|Frankreich
@@ -13983,7 +13983,7 @@ FR|hy|Ֆրանսիա
 FR|hz|*aa
 FR|ia|*es
 FR|id|Prancis
-FR|ie|*aa
+FR|ie|*es
 FR|ig|*aa
 FR|ii|ꃔꇩ
 FR|ik|*aa
@@ -14042,9 +14042,9 @@ FR|no|*nb
 FR|nr|*aa
 FR|nv|*aa
 FR|ny|*aa
-FR|oc|*aa
+FR|oc|*ca
 FR|oj|*aa
-FR|om|*aa
+FR|om|Faransaay
 FR|or|ଫ୍ରାନ୍ସ
 FR|os|*mn
 FR|pa|ਫ਼ਰਾਂਸ
@@ -14059,7 +14059,7 @@ FR|ro|*mo
 FR|ru|*bg
 FR|rw|*aa
 FR|sa|फ़्रांस:
-FR|sc|*aa
+FR|sc|Frantza
 FR|sd|*ks
 FR|se|Frankriika
 FR|sg|Farânzi
@@ -14080,7 +14080,7 @@ FR|ta|பிரான்ஸ்
 FR|te|ఫ్రాన్స్‌
 FR|tg|Фаронса
 FR|th|ฝรั่งเศส
-FR|ti|*am
+FR|ti|ፈረንሳ
 FR|tk|Fransiýa
 FR|tl|*aa
 FR|tn|*aa
@@ -14099,7 +14099,7 @@ FR|vi|Pháp
 FR|vo|*aa
 FR|wa|*aa
 FR|wo|Faraans
-FR|xh|*aa
+FR|xh|EFrance
 FR|yi|*ji
 FR|yo|Faranse
 FR|za|*aa
@@ -14134,7 +14134,7 @@ GA|co|*aa
 GA|cr|*aa
 GA|cs|*aa
 GA|cu|*aa
-GA|cv|*aa
+GA|cv|*be
 GA|cy|*aa
 GA|da|*aa
 GA|de|Gabun
@@ -14210,7 +14210,7 @@ GA|lu|Ngabu
 GA|lv|Gabona
 GA|mg|*aa
 GA|mh|*aa
-GA|mi|*aa
+GA|mi|Kāpona
 GA|mk|*be
 GA|ml|ഗാബൺ
 GA|mn|*be
@@ -14232,7 +14232,7 @@ GA|nv|*aa
 GA|ny|*aa
 GA|oc|*aa
 GA|oj|*aa
-GA|om|*aa
+GA|om|Gaaboon
 GA|or|ଗାବୋନ୍
 GA|os|*aa
 GA|pa|ਗਬੋਨ
@@ -14247,7 +14247,7 @@ GA|ro|*aa
 GA|ru|*be
 GA|rw|*aa
 GA|sa|*aa
-GA|sc|*aa
+GA|sc|Gabòn
 GA|sd|گبون
 GA|se|*aa
 GA|sg|Gaböon
@@ -14256,7 +14256,7 @@ GA|sk|*aa
 GA|sl|*aa
 GA|sm|*aa
 GA|sn|*aa
-GA|so|Gaaboon
+GA|so|*om
 GA|sq|*aa
 GA|sr|*be
 GA|ss|*aa
@@ -14287,7 +14287,7 @@ GA|vi|*aa
 GA|vo|*aa
 GA|wa|*aa
 GA|wo|Gaboŋ
-GA|xh|*aa
+GA|xh|EGabon
 GA|yi|*ji
 GA|yo|*aa
 GA|za|*aa
@@ -14297,7 +14297,7 @@ GB|aa|United Kingdom
 GB|ab|*aa
 GB|ae|*aa
 GB|af|Verenigde Koninkryk
-GB|ak|Ahendiman Nkabom
+GB|ak|UK
 GB|am|ዩናይትድ ኪንግደም
 GB|an|*aa
 GB|ar|المملكة المتحدة
@@ -14322,7 +14322,7 @@ GB|co|*aa
 GB|cr|*aa
 GB|cs|Spojené království
 GB|cu|*aa
-GB|cv|*aa
+GB|cv|Аслӑ Британи
 GB|cy|Y Deyrnas Unedig
 GB|da|Storbritannien
 GB|de|Vereinigtes Königreich
@@ -14344,7 +14344,7 @@ GB|fr|Royaume-Uni
 GB|fy|Verenigd Koninkrijk
 GB|ga|an Ríocht Aontaithe
 GB|gd|An Rìoghachd Aonaichte
-GB|gl|O Reino Unido
+GB|gl|*es
 GB|gn|*aa
 GB|gu|યુનાઇટેડ કિંગડમ
 GB|gv|Rywvaneth Unys
@@ -14353,13 +14353,13 @@ GB|he|בריטניה
 GB|hi|यूनाइटेड किंगडम
 GB|ho|*aa
 GB|hr|*bs
-GB|ht|*aa
+GB|ht|*fr
 GB|hu|Egyesült Királyság
 GB|hy|Միացյալ Թագավորություն
 GB|hz|*aa
 GB|ia|Regno Unite
 GB|id|Inggris Raya
-GB|ie|*aa
+GB|ie|Unit Reyia
 GB|ig|*aa
 GB|ii|ꑱꇩ
 GB|ik|*aa
@@ -14382,8 +14382,8 @@ GB|km|ចក្រភព​អង់គ្លេស
 GB|kn|ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್
 GB|ko|영국
 GB|kr|*aa
-GB|ks|یُنایٹِڑ کِنگڈَم
-GB|ku|Keyaniya Yekbûyî
+GB|ks|متحدہ مملِکت
+GB|ku|Qiralîyeta Yekbûyî
 GB|kv|*aa
 GB|kw|*gv
 GB|ky|Улуу Британия
@@ -14398,7 +14398,7 @@ GB|lu|Angeletele
 GB|lv|Apvienotā Karaliste
 GB|mg|Angletera
 GB|mh|*aa
-GB|mi|Hononga o Piritene
+GB|mi|Te Hononga o Piritene
 GB|mk|Обединето Кралство
 GB|ml|യുണൈറ്റഡ് കിംഗ്ഡം
 GB|mn|Их Британи
@@ -14435,7 +14435,7 @@ GB|ro|*mo
 GB|ru|Великобритания
 GB|rw|*aa
 GB|sa|संयुक्त राष्ट्र:
-GB|sc|*aa
+GB|sc|Regnu Unidu
 GB|sd|برطانيہ
 GB|se|Stuorra-Británnia
 GB|sg|Ködörögbïä--Ôko
@@ -14456,7 +14456,7 @@ GB|ta|யுனைடெட் கிங்டம்
 GB|te|యునైటెడ్ కింగ్‌డమ్
 GB|tg|Шоҳигарии Муттаҳида
 GB|th|สหราชอาณาจักร
-GB|ti|እንግሊዝ
+GB|ti|ብሪጣንያ
 GB|tk|Birleşen Patyşalyk
 GB|tl|*aa
 GB|tn|*aa
@@ -14475,7 +14475,7 @@ GB|vi|Vương quốc Anh
 GB|vo|*aa
 GB|wa|*aa
 GB|wo|Ruwaayom Ini
-GB|xh|*aa
+GB|xh|E-United Kingdom
 GB|yi|*ji
 GB|yo|Gẹ̀ẹ́sì
 GB|za|*aa
@@ -14510,7 +14510,7 @@ GD|co|*aa
 GD|cr|*aa
 GD|cs|*aa
 GD|cu|*aa
-GD|cv|*aa
+GD|cv|*bg
 GD|cy|*aa
 GD|da|*aa
 GD|de|*aa
@@ -14541,7 +14541,7 @@ GD|he|גרנדה
 GD|hi|ग्रेनाडा
 GD|ho|*aa
 GD|hr|*aa
-GD|ht|*aa
+GD|ht|*fr
 GD|hu|*aa
 GD|hy|Գրենադա
 GD|hz|*aa
@@ -14570,7 +14570,7 @@ GD|km|ហ្គ្រើណាដ
 GD|kn|ಗ್ರೆನೆಡಾ
 GD|ko|그레나다
 GD|kr|*aa
-GD|ks|گرنیڑا
+GD|ks|گرینیڈا
 GD|ku|*aa
 GD|kv|*aa
 GD|kw|*aa
@@ -14586,7 +14586,7 @@ GD|lu|Ngelenade
 GD|lv|Grenāda
 GD|mg|Grenady
 GD|mh|*aa
-GD|mi|*aa
+GD|mi|Kerenāta
 GD|mk|*bg
 GD|ml|ഗ്രനേഡ
 GD|mn|*bg
@@ -14608,7 +14608,7 @@ GD|nv|*aa
 GD|ny|*aa
 GD|oc|*aa
 GD|oj|*aa
-GD|om|*aa
+GD|om|Girinaada
 GD|or|ଗ୍ରେନାଡା
 GD|os|*aa
 GD|pa|ਗ੍ਰੇਨਾਡਾ
@@ -14624,7 +14624,7 @@ GD|ru|*bg
 GD|rw|*aa
 GD|sa|*aa
 GD|sc|*aa
-GD|sd|گرينڊا
+GD|sd|گريناڊا
 GD|se|*aa
 GD|sg|Grenâda
 GD|si|ග්‍රැනඩාව
@@ -14644,7 +14644,7 @@ GD|ta|கிரனெடா
 GD|te|గ్రెనడా
 GD|tg|*bg
 GD|th|เกรเนดา
-GD|ti|*am
+GD|ti|ግረናዳ
 GD|tk|*aa
 GD|tl|*aa
 GD|tn|*aa
@@ -14663,7 +14663,7 @@ GD|vi|*aa
 GD|vo|*aa
 GD|wa|*aa
 GD|wo|Garanad
-GD|xh|*aa
+GD|xh|EGrenada
 GD|yi|*ji
 GD|yo|Genada
 GD|za|*aa
@@ -14698,7 +14698,7 @@ GE|co|*aa
 GE|cr|*aa
 GE|cs|Gruzie
 GE|cu|*aa
-GE|cv|*aa
+GE|cv|Грузи
 GE|cy|*aa
 GE|da|Georgien
 GE|de|*da
@@ -14724,12 +14724,12 @@ GE|gl|Xeorxia
 GE|gn|*aa
 GE|gu|જ્યોર્જિયા
 GE|gv|*aa
-GE|ha|Jiwarjiya
+GE|ha|Jojiya
 GE|he|גאורגיה
 GE|hi|जॉर्जिया
 GE|ho|*aa
 GE|hr|*bs
-GE|ht|*aa
+GE|ht|*fr
 GE|hu|Grúzia
 GE|hy|Վրաստան
 GE|hz|*aa
@@ -14774,7 +14774,7 @@ GE|lu|Joriji
 GE|lv|*bs
 GE|mg|Zeorzia
 GE|mh|*aa
-GE|mi|*aa
+GE|mi|Hōria
 GE|mk|Грузија
 GE|ml|ജോർജ്ജിയ
 GE|mn|Гүрж
@@ -14796,7 +14796,7 @@ GE|nv|*aa
 GE|ny|*aa
 GE|oc|*aa
 GE|oj|*aa
-GE|om|*aa
+GE|om|Joorjiyaa
 GE|or|ଜର୍ଜିଆ
 GE|os|Гуырдзыстон
 GE|pa|ਜਾਰਜੀਆ
@@ -14811,7 +14811,7 @@ GE|ro|*aa
 GE|ru|*bg
 GE|rw|*aa
 GE|sa|*aa
-GE|sc|*aa
+GE|sc|*ca
 GE|sd|جارجيا
 GE|se|*aa
 GE|sg|Zorzïi
@@ -14832,7 +14832,7 @@ GE|ta|ஜார்ஜியா
 GE|te|జార్జియా
 GE|tg|Гурҷистон
 GE|th|จอร์เจีย
-GE|ti|*am
+GE|ti|ጆርጅያ
 GE|tk|Gruziýa
 GE|tl|*aa
 GE|tn|*aa
@@ -14851,7 +14851,7 @@ GE|vi|*aa
 GE|vo|*aa
 GE|wa|*aa
 GE|wo|Seworsi
-GE|xh|*aa
+GE|xh|EGeorgia
 GE|yi|*ji
 GE|yo|Gọgia
 GE|za|*aa
@@ -14886,7 +14886,7 @@ GF|co|*aa
 GF|cr|*aa
 GF|cs|Francouzská Guyana
 GF|cu|*aa
-GF|cv|*aa
+GF|cv|Франци Гвиана
 GF|cy|Guyane Ffrengig
 GF|da|Fransk Guyana
 GF|de|Französisch-Guayana
@@ -14917,20 +14917,20 @@ GF|he|גיאנה הצרפתית
 GF|hi|फ़्रेंच गुयाना
 GF|ho|*aa
 GF|hr|Francuska Gijana
-GF|ht|*aa
+GF|ht|*fr
 GF|hu|Francia Guyana
 GF|hy|Ֆրանսիական Գվիանա
 GF|hz|*aa
 GF|ia|Guyana francese
 GF|id|Guyana Prancis
 GF|ie|*aa
-GF|ig|Frenchi Guiana
+GF|ig|*aa
 GF|ii|*aa
 GF|ik|*aa
 GF|in|*id
 GF|io|*aa
 GF|is|Franska Gvæjana
-GF|it|*ia
+GF|it|Guyana Francese
 GF|iu|*aa
 GF|iw|*he
 GF|ja|仏領ギアナ
@@ -14950,7 +14950,7 @@ GF|ks|فرانسِسی گِانا
 GF|ku|Guyanaya Fransî
 GF|kv|*aa
 GF|kw|*aa
-GF|ky|Француздук Гвиана
+GF|ky|Франция Гвианасы
 GF|la|*aa
 GF|lb|Guayane
 GF|lg|Guyana enfalansa
@@ -14962,7 +14962,7 @@ GF|lu|Giyane wa Nfalanse
 GF|lv|Francijas Gviāna
 GF|mg|Guyana frantsay
 GF|mh|*aa
-GF|mi|*aa
+GF|mi|Kiāna Wīwī
 GF|mk|Француска Гвајана
 GF|ml|ഫ്രഞ്ച് ഗയാന
 GF|mn|Францын Гвиана
@@ -14984,7 +14984,7 @@ GF|nv|*aa
 GF|ny|*aa
 GF|oc|*aa
 GF|oj|*aa
-GF|om|*aa
+GF|om|Faransaay Guyiinaa
 GF|or|ଫ୍ରେଞ୍ଚ ଗୁଇନା
 GF|os|*aa
 GF|pa|ਫਰੈਂਚ ਗੁਇਆਨਾ
@@ -14999,7 +14999,7 @@ GF|ro|*mo
 GF|ru|Французская Гвиана
 GF|rw|*aa
 GF|sa|*aa
-GF|sc|*aa
+GF|sc|Guiana frantzesa
 GF|sd|فرانسيسي گيانا
 GF|se|Frankriikka Guayana
 GF|sg|Güyâni tî farânzi
@@ -15020,7 +15020,7 @@ GF|ta|பிரெஞ்சு கயானா
 GF|te|ఫ్రెంచ్ గియానా
 GF|tg|Гвианаи Фаронса
 GF|th|เฟรนช์เกียนา
-GF|ti|ናይ ፈረንሳይ ጉይና
+GF|ti|ፈረንሳዊት ጊያና
 GF|tk|Fransuz Gwianasy
 GF|tl|*aa
 GF|tn|*aa
@@ -15039,7 +15039,7 @@ GF|vi|Guiana thuộc Pháp
 GF|vo|*aa
 GF|wa|*aa
 GF|wo|Guyaan Farañse
-GF|xh|*aa
+GF|xh|EFrench Guiana
 GF|yi|*ji
 GF|yo|Firenṣi Guana
 GF|za|*aa
@@ -15049,7 +15049,7 @@ GG|aa|Guernsey
 GG|ab|*aa
 GG|ae|*aa
 GG|af|*aa
-GG|ak|*aa
+GG|ak|Guɛnse
 GG|am|ጉርነሲ
 GG|an|*aa
 GG|ar|غيرنزي
@@ -15063,7 +15063,7 @@ GG|bg|Гърнзи
 GG|bh|*aa
 GG|bi|*aa
 GG|bm|*aa
-GG|bn|গুয়ার্নসি
+GG|bn|গার্নসি
 GG|bo|*aa
 GG|br|Gwernenez
 GG|bs|*aa
@@ -15074,7 +15074,7 @@ GG|co|*aa
 GG|cr|*aa
 GG|cs|*aa
 GG|cu|*aa
-GG|cv|*aa
+GG|cv|*ce
 GG|cy|Ynys y Garn
 GG|da|*aa
 GG|de|*aa
@@ -15105,7 +15105,7 @@ GG|he|גרנזי
 GG|hi|गर्नसी
 GG|ho|*aa
 GG|hr|*aa
-GG|ht|*aa
+GG|ht|*es
 GG|hu|*aa
 GG|hy|Գերնսի
 GG|hz|*aa
@@ -15134,7 +15134,7 @@ GG|km|ហ្គេនស៊ី
 GG|kn|ಗುರ್ನ್‌ಸೆ
 GG|ko|건지
 GG|kr|*aa
-GG|ks|گیوَنَرسے
+GG|ks|گورنسے
 GG|ku|*aa
 GG|kv|*aa
 GG|kw|*aa
@@ -15150,7 +15150,7 @@ GG|lu|*aa
 GG|lv|Gērnsija
 GG|mg|*aa
 GG|mh|*aa
-GG|mi|*aa
+GG|mi|Kōnihi
 GG|mk|Гернзи
 GG|ml|ഗേൺസി
 GG|mn|*ce
@@ -15172,7 +15172,7 @@ GG|nv|*aa
 GG|ny|*aa
 GG|oc|*aa
 GG|oj|*aa
-GG|om|*aa
+GG|om|Guwernisey
 GG|or|ଗୁଏରନେସି
 GG|os|*aa
 GG|pa|ਗਰਨਜੀ
@@ -15208,7 +15208,7 @@ GG|ta|கெர்ன்சி
 GG|te|గర్న్‌సీ
 GG|tg|*ce
 GG|th|เกิร์นซีย์
-GG|ti|ገርንሲ
+GG|ti|ገርንዚ
 GG|tk|*az
 GG|tl|*aa
 GG|tn|*aa
@@ -15227,7 +15227,7 @@ GG|vi|*aa
 GG|vo|*aa
 GG|wa|*aa
 GG|wo|Gernase
-GG|xh|*aa
+GG|xh|EGuernsey
 GG|yi|*ji
 GG|yo|*aa
 GG|za|*aa
@@ -15262,7 +15262,7 @@ GH|co|*aa
 GH|cr|*aa
 GH|cs|*aa
 GH|cu|*aa
-GH|cv|*aa
+GH|cv|*be
 GH|cy|*aa
 GH|da|*aa
 GH|de|*aa
@@ -15338,7 +15338,7 @@ GH|lu|*ki
 GH|lv|*bm
 GH|mg|*aa
 GH|mh|*aa
-GH|mi|*aa
+GH|mi|Kāna
 GH|mk|*be
 GH|ml|ഘാന
 GH|mn|*be
@@ -15360,7 +15360,7 @@ GH|nv|*aa
 GH|ny|*aa
 GH|oc|*aa
 GH|oj|*aa
-GH|om|*aa
+GH|om|Gaanaa
 GH|or|ଘାନା
 GH|os|*aa
 GH|pa|ਘਾਨਾ
@@ -15415,7 +15415,7 @@ GH|vi|*aa
 GH|vo|*aa
 GH|wa|*aa
 GH|wo|*bm
-GH|xh|*aa
+GH|xh|EGhana
 GH|yi|*ji
 GH|yo|*bm
 GH|za|*aa
@@ -15450,7 +15450,7 @@ GI|co|*aa
 GI|cr|*aa
 GI|cs|*aa
 GI|cu|*aa
-GI|cv|*aa
+GI|cv|*bg
 GI|cy|*aa
 GI|da|*aa
 GI|de|*aa
@@ -15511,7 +15511,7 @@ GI|kn|ಗಿಬ್ರಾಲ್ಟರ್
 GI|ko|지브롤터
 GI|kr|*aa
 GI|ks|جِبرالٹَر
-GI|ku|Cîbraltar
+GI|ku|Cebelîtariq
 GI|kv|*aa
 GI|kw|*aa
 GI|ky|*bg
@@ -15526,7 +15526,7 @@ GI|lu|Jibeletale
 GI|lv|Gibraltārs
 GI|mg|Zibraltara
 GI|mh|*aa
-GI|mi|*aa
+GI|mi|Kāmaka
 GI|mk|*bg
 GI|ml|ജിബ്രാൾട്ടർ
 GI|mn|*bg
@@ -15548,7 +15548,7 @@ GI|nv|*aa
 GI|ny|*aa
 GI|oc|*aa
 GI|oj|*aa
-GI|om|*aa
+GI|om|Gibraaltar
 GI|or|ଜିବ୍ରାଲ୍ଟର୍
 GI|os|*aa
 GI|pa|ਜਿਬਰਾਲਟਰ
@@ -15563,7 +15563,7 @@ GI|ro|*aa
 GI|ru|*bg
 GI|rw|*aa
 GI|sa|*aa
-GI|sc|*aa
+GI|sc|*it
 GI|sd|جبرالٽر
 GI|se|*aa
 GI|sg|Zibraltära, Zibaratära
@@ -15584,7 +15584,7 @@ GI|ta|ஜிப்ரால்டர்
 GI|te|జిబ్రాల్టర్
 GI|tg|*bg
 GI|th|ยิบรอลตาร์
-GI|ti|ጊብራልታር
+GI|ti|ጂብራልታር
 GI|tk|*aa
 GI|tl|*aa
 GI|tn|*aa
@@ -15603,7 +15603,7 @@ GI|vi|*aa
 GI|vo|*aa
 GI|wa|*aa
 GI|wo|Sibraltaar
-GI|xh|*aa
+GI|xh|EGibraltar
 GI|yi|*ji
 GI|yo|Gibaratara
 GI|za|*aa
@@ -15638,7 +15638,7 @@ GL|co|*aa
 GL|cr|*aa
 GL|cs|Grónsko
 GL|cu|*aa
-GL|cv|*aa
+GL|cv|*ce
 GL|cy|Yr Ynys Las
 GL|da|Grønland
 GL|de|Grönland
@@ -15669,7 +15669,7 @@ GL|he|גרינלנד
 GL|hi|ग्रीनलैंड
 GL|ho|*aa
 GL|hr|*bs
-GL|ht|*aa
+GL|ht|*af
 GL|hu|*de
 GL|hy|Գրենլանդիա
 GL|hz|*aa
@@ -15698,8 +15698,8 @@ GL|km|ហ្គ្រោអង់ឡង់
 GL|kn|ಗ್ರೀನ್‌ಲ್ಯಾಂಡ್
 GL|ko|그린란드
 GL|kr|*aa
-GL|ks|گریٖنلینڑ
-GL|ku|Grînlenda
+GL|ks|گرین لینڈ
+GL|ku|Grînlanda
 GL|kv|*aa
 GL|kw|*aa
 GL|ky|*bg
@@ -15714,9 +15714,9 @@ GL|lu|Ngowelande
 GL|lv|Grenlande
 GL|mg|*af
 GL|mh|*aa
-GL|mi|*aa
+GL|mi|Whenuakāriki
 GL|mk|Гренланд
-GL|ml|ഗ്രീൻലാൻറ്
+GL|ml|ഗ്രീൻലൻഡ്
 GL|mn|*mk
 GL|mo|Groenlanda
 GL|mr|ग्रीनलंड
@@ -15736,7 +15736,7 @@ GL|nv|*aa
 GL|ny|*aa
 GL|oc|*aa
 GL|oj|*aa
-GL|om|*aa
+GL|om|Giriinlaand
 GL|or|ଗ୍ରୀନଲ୍ୟାଣ୍ଡ
 GL|os|*aa
 GL|pa|ਗ੍ਰੀਨਲੈਂਡ
@@ -15751,7 +15751,7 @@ GL|ro|*mo
 GL|ru|*bg
 GL|rw|*aa
 GL|sa|*aa
-GL|sc|*aa
+GL|sc|*ca
 GL|sd|گرين لينڊ
 GL|se|*kl
 GL|sg|Gorolânde
@@ -15784,14 +15784,14 @@ GL|tw|*aa
 GL|ty|*aa
 GL|ug|گىرېنلاندىيە
 GL|uk|Гренландія
-GL|ur|گرین لینڈ
+GL|ur|*ks
 GL|uz|Grenlandiya
 GL|ve|*aa
 GL|vi|*aa
 GL|vo|*aa
 GL|wa|*aa
 GL|wo|Girinlànd
-GL|xh|*aa
+GL|xh|EGreenland
 GL|yi|*ji
 GL|yo|Gerelandi
 GL|za|*aa
@@ -15826,7 +15826,7 @@ GM|co|*aa
 GM|cr|*aa
 GM|cs|Gambie
 GM|cu|*aa
-GM|cv|*aa
+GM|cv|*ce
 GM|cy|*aa
 GM|da|*aa
 GM|de|*aa
@@ -15846,7 +15846,7 @@ GM|fj|*aa
 GM|fo|*aa
 GM|fr|*cs
 GM|fy|*aa
-GM|ga|an Ghaimbia
+GM|ga|An Ghaimbia
 GM|gd|A’ Ghaimbia
 GM|gl|*aa
 GM|gn|*aa
@@ -15857,7 +15857,7 @@ GM|he|גמביה
 GM|hi|गाम्बिया
 GM|ho|*aa
 GM|hr|*bs
-GM|ht|*aa
+GM|ht|*cs
 GM|hu|*aa
 GM|hy|Գամբիա
 GM|hz|*aa
@@ -15887,7 +15887,7 @@ GM|kn|ಗ್ಯಾಂಬಿಯಾ
 GM|ko|감비아
 GM|kr|*aa
 GM|ks|گَمبِیا
-GM|ku|*ha
+GM|ku|Gambîya
 GM|kv|*aa
 GM|kw|*aa
 GM|ky|*bg
@@ -15902,7 +15902,7 @@ GM|lu|*ln
 GM|lv|*bs
 GM|mg|*aa
 GM|mh|*aa
-GM|mi|*aa
+GM|mi|Kamopia
 GM|mk|Гамбија
 GM|ml|ഗാംബിയ
 GM|mn|*ce
@@ -15924,7 +15924,7 @@ GM|nv|*aa
 GM|ny|*aa
 GM|oc|*aa
 GM|oj|*aa
-GM|om|*aa
+GM|om|Gaambiyaa
 GM|or|ଗାମ୍ବିଆ
 GM|os|*aa
 GM|pa|ਗੈਂਬੀਆ
@@ -15939,7 +15939,7 @@ GM|ro|*aa
 GM|ru|*bg
 GM|rw|*aa
 GM|sa|*aa
-GM|sc|*aa
+GM|sc|*ca
 GM|sd|گيمبيا
 GM|se|Gámbia
 GM|sg|Gambïi
@@ -15960,7 +15960,7 @@ GM|ta|காம்பியா
 GM|te|గాంబియా
 GM|tg|*bg
 GM|th|แกมเบีย
-GM|ti|*am
+GM|ti|ጋምብያ
 GM|tk|Gambiýa
 GM|tl|*aa
 GM|tn|*aa
@@ -15979,7 +15979,7 @@ GM|vi|*aa
 GM|vo|*aa
 GM|wa|*aa
 GM|wo|Gàmbi
-GM|xh|*aa
+GM|xh|EGambia
 GM|yi|*ji
 GM|yo|*aa
 GM|za|*aa
@@ -16014,7 +16014,7 @@ GN|co|*aa
 GN|cr|*aa
 GN|cs|*aa
 GN|cu|*aa
-GN|cv|*aa
+GN|cv|*ce
 GN|cy|*ak
 GN|da|*aa
 GN|de|*aa
@@ -16034,7 +16034,7 @@ GN|fj|*aa
 GN|fo|*aa
 GN|fr|Guinée
 GN|fy|*af
-GN|ga|an Ghuine
+GN|ga|An Ghuine
 GN|gd|*ak
 GN|gl|*aa
 GN|gn|*aa
@@ -16045,7 +16045,7 @@ GN|he|גינאה
 GN|hi|गिनी
 GN|ho|*aa
 GN|hr|*bs
-GN|ht|*aa
+GN|ht|*fr
 GN|hu|*aa
 GN|hy|Գվինեա
 GN|hz|*aa
@@ -16090,7 +16090,7 @@ GN|lu|Ngine
 GN|lv|*bs
 GN|mg|*br
 GN|mh|*aa
-GN|mi|*aa
+GN|mi|Kini
 GN|mk|Гвинеја
 GN|ml|ഗിനിയ
 GN|mn|*ce
@@ -16112,7 +16112,7 @@ GN|nv|*aa
 GN|ny|*aa
 GN|oc|*aa
 GN|oj|*aa
-GN|om|*aa
+GN|om|Giinii
 GN|or|ଗୁଇନିଆ
 GN|os|*aa
 GN|pa|ਗਿਨੀ
@@ -16152,7 +16152,7 @@ GN|ti|*am
 GN|tk|Gwineýa
 GN|tl|*aa
 GN|tn|*aa
-GN|to|Kini
+GN|to|*mi
 GN|tr|*bm
 GN|ts|*aa
 GN|tt|*bg
@@ -16167,7 +16167,7 @@ GN|vi|*aa
 GN|vo|*aa
 GN|wa|*aa
 GN|wo|*bm
-GN|xh|*aa
+GN|xh|EGuinea
 GN|yi|*ji
 GN|yo|Gene
 GN|za|*aa
@@ -16202,7 +16202,7 @@ GP|co|*aa
 GP|cr|*aa
 GP|cs|*aa
 GP|cu|*aa
-GP|cv|*aa
+GP|cv|*bg
 GP|cy|*aa
 GP|da|*aa
 GP|de|*aa
@@ -16262,7 +16262,7 @@ GP|km|ហ្គោដឺឡុប
 GP|kn|ಗುಡೆಲೋಪ್
 GP|ko|과들루프
 GP|kr|*aa
-GP|ks|گَواڑیلوپ
+GP|ks|گواڈلوپ
 GP|ku|*aa
 GP|kv|*aa
 GP|kw|*aa
@@ -16278,7 +16278,7 @@ GP|lu|Ngwadelupe
 GP|lv|*lt
 GP|mg|Goadelopy
 GP|mh|*aa
-GP|mi|*aa
+GP|mi|Kuatarupa
 GP|mk|Гвадалупе
 GP|ml|ഗ്വാഡലൂപ്പ്
 GP|mn|Гваделуп
@@ -16300,7 +16300,7 @@ GP|nv|*aa
 GP|ny|*aa
 GP|oc|*aa
 GP|oj|*aa
-GP|om|*aa
+GP|om|Gowadelowape
 GP|or|ଗୁଆଡେଲୋପ୍
 GP|os|*aa
 GP|pa|ਗੁਆਡੇਲੋਪ
@@ -16315,7 +16315,7 @@ GP|ro|*mo
 GP|ru|*bg
 GP|rw|*aa
 GP|sa|*aa
-GP|sc|*aa
+GP|sc|*it
 GP|sd|گواڊیلوپ
 GP|se|*aa
 GP|sg|Guadelûpu
@@ -16336,7 +16336,7 @@ GP|ta|க்வாதேலோப்
 GP|te|గ్వాడెలోప్
 GP|tg|*bg
 GP|th|กวาเดอลูป
-GP|ti|*am
+GP|ti|ጓደሉፕ
 GP|tk|*pl
 GP|tl|*aa
 GP|tn|*aa
@@ -16355,7 +16355,7 @@ GP|vi|*aa
 GP|vo|*aa
 GP|wa|*aa
 GP|wo|Guwaadelup
-GP|xh|*aa
+GP|xh|EGuadeloupe
 GP|yi|*ji
 GP|yo|Gadelope
 GP|za|*aa
@@ -16390,7 +16390,7 @@ GQ|co|*aa
 GQ|cr|*aa
 GQ|cs|Rovníková Guinea
 GQ|cu|*aa
-GQ|cv|*aa
+GQ|cv|Экваториаллӑ Гвиней
 GQ|cy|Gini Gyhydeddol
 GQ|da|Ækvatorialguinea
 GQ|de|Äquatorialguinea
@@ -16416,12 +16416,12 @@ GQ|gl|*es
 GQ|gn|*aa
 GQ|gu|ઇક્વેટોરિયલ ગિની
 GQ|gv|*aa
-GQ|ha|Gini Ta Ikwaita
+GQ|ha|Ikwatoriyal Gini
 GQ|he|גינאה המשוונית
 GQ|hi|इक्वेटोरियल गिनी
 GQ|ho|*aa
 GQ|hr|Ekvatorska Gvineja
-GQ|ht|*aa
+GQ|ht|*fr
 GQ|hu|Egyenlítői-Guinea
 GQ|hy|Հասարակածային Գվինեա
 GQ|hz|*aa
@@ -16451,7 +16451,7 @@ GQ|kn|ಈಕ್ವೆಟೋರಿಯಲ್ ಗಿನಿ
 GQ|ko|적도 기니
 GQ|kr|*aa
 GQ|ks|اِکوِٹورِیَل گِنی
-GQ|ku|Gîneya Rojbendî
+GQ|ku|Gîneya Ekwadorê
 GQ|kv|*aa
 GQ|kw|*aa
 GQ|ky|Экватордук Гвинея
@@ -16466,7 +16466,7 @@ GQ|lu|Gine Ekwatele
 GQ|lv|Ekvatoriālā Gvineja
 GQ|mg|Guinea Ekoatera
 GQ|mh|*aa
-GQ|mi|*aa
+GQ|mi|Kini Ekuatoria
 GQ|mk|Екваторска Гвинеја
 GQ|ml|ഇക്വറ്റോറിയൽ ഗിനിയ
 GQ|mn|Экваторын Гвиней
@@ -16488,8 +16488,8 @@ GQ|nv|*aa
 GQ|ny|*aa
 GQ|oc|*aa
 GQ|oj|*aa
-GQ|om|*aa
-GQ|or|ଇକ୍ବାଟେରିଆଲ୍ ଗୁଇନିଆ
+GQ|om|Ikkuwaatooriyaal Giinii
+GQ|or|ଇକ୍ବାଟୋରିଆଲ୍ ଗୁଇନିଆ
 GQ|os|*aa
 GQ|pa|ਭੂ-ਖੰਡੀ ਗਿਨੀ
 GQ|pi|*aa
@@ -16503,7 +16503,7 @@ GQ|ro|*mo
 GQ|ru|Экваториальная Гвинея
 GQ|rw|*aa
 GQ|sa|*aa
-GQ|sc|*aa
+GQ|sc|Guinea Ecuadoriale
 GQ|sd|ايڪوٽوريل گائينا
 GQ|se|Ekvatoriála Guinea
 GQ|sg|Ginëe tî Ekuatëre
@@ -16524,7 +16524,7 @@ GQ|ta|ஈக்வடோரியல் கினியா
 GQ|te|ఈక్వటోరియల్ గినియా
 GQ|tg|Гвинеяи Экваторӣ
 GQ|th|อิเควทอเรียลกินี
-GQ|ti|*am
+GQ|ti|ኢኳቶርያል ጊኒ
 GQ|tk|Ekwatorial Gwineýa
 GQ|tl|*aa
 GQ|tn|*aa
@@ -16543,7 +16543,7 @@ GQ|vi|Guinea Xích Đạo
 GQ|vo|*aa
 GQ|wa|*aa
 GQ|wo|Gine Ekuwatoriyal
-GQ|xh|*aa
+GQ|xh|E-Equatorial Guinea
 GQ|yi|*ji
 GQ|yo|Ekutoria Gini
 GQ|za|*aa
@@ -16578,7 +16578,7 @@ GR|co|*aa
 GR|cr|*aa
 GR|cs|Řecko
 GR|cu|*aa
-GR|cv|*aa
+GR|cv|*ce
 GR|cy|Gwlad Groeg
 GR|da|Grækenland
 GR|de|Griechenland
@@ -16609,13 +16609,13 @@ GR|he|יוון
 GR|hi|यूनान
 GR|ho|*aa
 GR|hr|*bs
-GR|ht|*aa
+GR|ht|*fr
 GR|hu|Görögország
 GR|hy|Հունաստան
 GR|hz|*aa
 GR|ia|*es
 GR|id|Yunani
-GR|ie|*aa
+GR|ie|*es
 GR|ig|*aa
 GR|ii|*aa
 GR|ik|*aa
@@ -16639,7 +16639,7 @@ GR|kn|ಗ್ರೀಸ್
 GR|ko|그리스
 GR|kr|*aa
 GR|ks|گریٖس
-GR|ku|Yewnanistan
+GR|ku|Yûnanistan
 GR|kv|*aa
 GR|kw|*aa
 GR|ky|Греция
@@ -16654,7 +16654,7 @@ GR|lu|Ngeleka
 GR|lv|Grieķija
 GR|mg|Gresy
 GR|mh|*aa
-GR|mi|*aa
+GR|mi|Kirihi
 GR|mk|Грција
 GR|ml|ഗ്രീസ്
 GR|mn|Грек
@@ -16676,7 +16676,7 @@ GR|nv|*aa
 GR|ny|*aa
 GR|oc|*aa
 GR|oj|*aa
-GR|om|*aa
+GR|om|Giriik
 GR|or|ଗ୍ରୀସ୍
 GR|os|*aa
 GR|pa|ਗ੍ਰੀਸ
@@ -16691,7 +16691,7 @@ GR|ro|*es
 GR|ru|*ky
 GR|rw|*aa
 GR|sa|*aa
-GR|sc|*aa
+GR|sc|Grètzia
 GR|sd|يونان
 GR|se|Greika
 GR|sg|Gerêsi
@@ -16712,7 +16712,7 @@ GR|ta|கிரீஸ்
 GR|te|గ్రీస్
 GR|tg|Юнон
 GR|th|กรีซ
-GR|ti|*am
+GR|ti|ግሪኽ
 GR|tk|Gresiýa
 GR|tl|*aa
 GR|tn|*aa
@@ -16731,9 +16731,9 @@ GR|vi|Hy Lạp
 GR|vo|*aa
 GR|wa|*aa
 GR|wo|*ff
-GR|xh|*aa
+GR|xh|EGreece
 GR|yi|*ji
-GR|yo|Geriisi
+GR|yo|Gíríìsì
 GR|za|*aa
 GR|zh|希腊
 GR|zu|i-Greece
@@ -16741,7 +16741,7 @@ GS|aa|South Georgia & South Sandwich Islands
 GS|ab|*aa
 GS|ae|*aa
 GS|af|Suid-Georgië en die Suidelike Sandwicheilande
-GS|ak|*aa
+GS|ak|Gyɔɔgyia Anaafoɔ ne Sandwich Aeland Anaafoɔ
 GS|am|ደቡብ ጆርጂያ እና የደቡብ ሳንድዊች ደሴቶች
 GS|an|*aa
 GS|ar|جورجيا الجنوبية وجزر ساندويتش الجنوبية
@@ -16766,7 +16766,7 @@ GS|co|*aa
 GS|cr|*aa
 GS|cs|Jižní Georgie a Jižní Sandwichovy ostrovy
 GS|cu|*aa
-GS|cv|*aa
+GS|cv|Кӑнтӑр Георги тата Сандвичев утравӗсем
 GS|cy|De Georgia ac Ynysoedd Sandwich y De
 GS|da|South Georgia og De Sydlige Sandwichøer
 GS|de|Südgeorgien und die Südlichen Sandwichinseln
@@ -16786,7 +16786,7 @@ GS|fj|*aa
 GS|fo|Suðurgeorgia og Suðursandwichoyggjar
 GS|fr|Géorgie du Sud-et-les Îles Sandwich du Sud
 GS|fy|Sûd-Georgia en Sûdlike Sandwicheilannen
-GS|ga|an tSeoirsia Theas agus Oileáin Sandwich Theas
+GS|ga|An tSeoirsia Theas agus Oileáin Sandwich Theas
 GS|gd|Seòirsea a Deas is na h-Eileanan Sandwich a Deas
 GS|gl|Illas Xeorxia do Sur e Sandwich do Sur
 GS|gn|*aa
@@ -16796,21 +16796,21 @@ GS|ha|Kudancin Geogia da Kudancin Tsibirin Sandiwic
 GS|he|ג׳ורג׳יה הדרומית ואיי סנדוויץ׳ הדרומיים
 GS|hi|दक्षिण जॉर्जिया और दक्षिण सैंडविच द्वीपसमूह
 GS|ho|*aa
-GS|hr|Južna Georgija i Južni Sendvički Otoci
-GS|ht|*aa
+GS|hr|Južna Georgia i Otoci Južni Sandwich
+GS|ht|*fr
 GS|hu|Déli-Georgia és Déli-Sandwich-szigetek
 GS|hy|Հարավային Ջորջիա և Հարավային Սենդվիչյան կղզիներ
 GS|hz|*aa
-GS|ia|*aa
+GS|ia|Georgia del Sud e Insulas Sandwich Austral
 GS|id|Georgia Selatan & Kep. Sandwich Selatan
 GS|ie|*aa
-GS|ig|South Georgia na Agwaetiti South Sandwich
+GS|ig|*aa
 GS|ii|*aa
 GS|ik|*aa
 GS|in|*id
 GS|io|*aa
 GS|is|Suður-Georgía og Suður-Sandvíkureyjar
-GS|it|Georgia del Sud e Sandwich australi
+GS|it|Georgia del Sud e Sandwich Australi
 GS|iu|*aa
 GS|iw|*he
 GS|ja|サウスジョージア・サウスサンドウィッチ諸島
@@ -16827,7 +16827,7 @@ GS|kn|ದಕ್ಷಿಣ ಜಾರ್ಜಿಯಾ ಮತ್ತು ದಕ್ಷ�
 GS|ko|사우스조지아 사우스샌드위치 제도
 GS|kr|*aa
 GS|ks|جنوٗبی جارجِیا تہٕ جنوٗبی سینڑوٕچ جٔزیٖرٕ
-GS|ku|*aa
+GS|ku|Giravên Georgîyaya Başûr û Sandwicha Başûr
 GS|kv|*aa
 GS|kw|*aa
 GS|ky|Түштүк Жоржия жана Түштүк Сэндвич аралдары
@@ -16842,7 +16842,7 @@ GS|lu|*aa
 GS|lv|Dienviddžordžija un Dienvidsendviču salas
 GS|mg|*aa
 GS|mh|*aa
-GS|mi|*aa
+GS|mi|Hōria ki te Tonga me ngā Motu Hanawiti ki te Tonga
 GS|mk|Јужна Џорџија и Јужни Сендвички Острови
 GS|ml|ദക്ഷിണ ജോർജ്ജിയയും ദക്ഷിണ സാൻഡ്‌വിച്ച് ദ്വീപുകളും
 GS|mn|Өмнөд Жоржиа ба Өмнөд Сэндвичийн арлууд
@@ -16864,7 +16864,7 @@ GS|nv|*aa
 GS|ny|*aa
 GS|oc|*aa
 GS|oj|*aa
-GS|om|*aa
+GS|om|Joorjikaa Kibba fi Odoloota Saanduwiich Kibbaa
 GS|or|ଦକ୍ଷିଣ ଜର୍ଜିଆ ଏବଂ ଦକ୍ଷିଣ ସାଣ୍ଡୱିଚ୍ ଦ୍ୱୀପପୁଞ୍ଜ
 GS|os|*aa
 GS|pa|ਦੱਖਣੀ ਜਾਰਜੀਆ ਅਤੇ ਦੱਖਣੀ ਸੈਂਡਵਿਚ ਟਾਪੂ
@@ -16879,7 +16879,7 @@ GS|ro|*mo
 GS|ru|Южная Георгия и Южные Сандвичевы о-ва
 GS|rw|*aa
 GS|sa|*aa
-GS|sc|*aa
+GS|sc|Geòrgia de su Sud e Ìsulas Sandwich Australes
 GS|sd|ڏکڻ جارجيا ۽ ڏکڻ سينڊوچ ٻيٽ
 GS|se|Lulli Georgia ja Lulli Sandwich-sullot
 GS|sg|*aa
@@ -16900,7 +16900,7 @@ GS|ta|தெற்கு ஜார்ஜியா மற்றும் தெ�
 GS|te|దక్షిణ జార్జియా మరియు దక్షిణ శాండ్విచ్ దీవులు
 GS|tg|Ҷорҷияи Ҷанубӣ ва Ҷазираҳои Сандвич
 GS|th|เกาะเซาท์จอร์เจียและหมู่เกาะเซาท์แซนด์วิช
-GS|ti|ደሴታት ደቡብ ጆርጂያን ደቡድ ሳንድዊችን
+GS|ti|ደሴታት ደቡብ ጆርጅያን ደቡብ ሳንድዊችን
 GS|tk|Günorta Georgiýa we Günorta Sendwiç adasy
 GS|tl|*aa
 GS|tn|*aa
@@ -16919,7 +16919,7 @@ GS|vi|Nam Georgia & Quần đảo Nam Sandwich
 GS|vo|*aa
 GS|wa|*aa
 GS|wo|Seworsi di Sid ak Duni Sàndwiis di Sid
-GS|xh|*aa
+GS|xh|ESouth Georgia & South Sandwich Islands
 GS|yi|*aa
 GS|yo|Gúúsù Georgia àti Gúúsù Àwọn Erékùsù Sandwich
 GS|za|*aa
@@ -16954,7 +16954,7 @@ GT|co|*aa
 GT|cr|*aa
 GT|cs|*aa
 GT|cu|*aa
-GT|cv|*aa
+GT|cv|*bg
 GT|cy|*aa
 GT|da|*aa
 GT|de|*aa
@@ -17014,7 +17014,7 @@ GT|km|ក្វាតេម៉ាឡា
 GT|kn|ಗ್ವಾಟೆಮಾಲಾ
 GT|ko|과테말라
 GT|kr|*aa
-GT|ks|گوتیدالا
+GT|ks|گواٹمالا
 GT|ku|*aa
 GT|kv|*aa
 GT|kw|*aa
@@ -17030,7 +17030,7 @@ GT|lu|Ngwatemala
 GT|lv|*bs
 GT|mg|Goatemalà
 GT|mh|*aa
-GT|mi|*aa
+GT|mi|Kuatamāra
 GT|mk|*bg
 GT|ml|ഗ്വാട്ടിമാല
 GT|mn|Гватемал
@@ -17052,7 +17052,7 @@ GT|nv|*aa
 GT|ny|*aa
 GT|oc|*aa
 GT|oj|*aa
-GT|om|*aa
+GT|om|Guwaatimaalaa
 GT|or|ଗୁଏତମାଲା
 GT|os|*aa
 GT|pa|ਗੁਆਟੇਮਾਲਾ
@@ -17088,7 +17088,7 @@ GT|ta|கவுதமாலா
 GT|te|గ్వాటిమాలా
 GT|tg|*bg
 GT|th|กัวเตมาลา
-GT|ti|*am
+GT|ti|ጓቲማላ
 GT|tk|*bm
 GT|tl|*aa
 GT|tn|*aa
@@ -17107,9 +17107,9 @@ GT|vi|*aa
 GT|vo|*aa
 GT|wa|*aa
 GT|wo|*ak
-GT|xh|*aa
+GT|xh|EGuatemala
 GT|yi|*ji
-GT|yo|*aa
+GT|yo|Guatemálà
 GT|za|*aa
 GT|zh|危地马拉
 GT|zu|i-Guatemala
@@ -17142,7 +17142,7 @@ GU|co|*aa
 GU|cr|*aa
 GU|cs|*aa
 GU|cu|*aa
-GU|cv|*aa
+GU|cv|*be
 GU|cy|*aa
 GU|da|*aa
 GU|de|*aa
@@ -17168,7 +17168,7 @@ GU|gl|*aa
 GU|gn|*aa
 GU|gu|ગ્વામ
 GU|gv|*aa
-GU|ha|*bm
+GU|ha|*aa
 GU|he|גואם
 GU|hi|गुआम
 GU|ho|*aa
@@ -17218,7 +17218,7 @@ GU|lu|Ngwame
 GU|lv|Guama
 GU|mg|*aa
 GU|mh|*aa
-GU|mi|*aa
+GU|mi|Kuama
 GU|mk|*be
 GU|ml|ഗ്വാം
 GU|mn|*be
@@ -17240,7 +17240,7 @@ GU|nv|*aa
 GU|ny|*aa
 GU|oc|*aa
 GU|oj|*aa
-GU|om|*aa
+GU|om|Guwama
 GU|or|ଗୁଆମ୍
 GU|os|*aa
 GU|pa|ਗੁਆਮ
@@ -17255,7 +17255,7 @@ GU|ro|*aa
 GU|ru|*be
 GU|rw|*aa
 GU|sa|*aa
-GU|sc|*aa
+GU|sc|Guàm
 GU|sd|*fa
 GU|se|*aa
 GU|sg|Guâm
@@ -17276,7 +17276,7 @@ GU|ta|குவாம்
 GU|te|గ్వామ్
 GU|tg|*be
 GU|th|กวม
-GU|ti|*am
+GU|ti|ጓም
 GU|tk|*aa
 GU|tl|*aa
 GU|tn|*aa
@@ -17295,7 +17295,7 @@ GU|vi|*aa
 GU|vo|*aa
 GU|wa|*aa
 GU|wo|*ff
-GU|xh|*aa
+GU|xh|EGuam
 GU|yi|*ji
 GU|yo|Guamu
 GU|za|*aa
@@ -17306,7 +17306,7 @@ GW|ab|*aa
 GW|ae|*aa
 GW|af|Guinee-Bissau
 GW|ak|Gini Bisaw
-GW|am|ጊኒ ቢሳኦ
+GW|am|ጊኒ-ቢሳው
 GW|an|*aa
 GW|ar|غينيا بيساو
 GW|as|গিনি-বিছাও
@@ -17330,7 +17330,7 @@ GW|co|*aa
 GW|cr|*aa
 GW|cs|*aa
 GW|cu|*aa
-GW|cv|*aa
+GW|cv|*ce
 GW|cy|Guiné-Bissau
 GW|da|*aa
 GW|de|*aa
@@ -17352,7 +17352,7 @@ GW|fr|Guinée-Bissau
 GW|fy|*af
 GW|ga|Guine Bissau
 GW|gd|Gini-Bioso
-GW|gl|A Guinea Bissau
+GW|gl|*ca
 GW|gn|*aa
 GW|gu|ગિની-બિસાઉ
 GW|gv|*aa
@@ -17361,7 +17361,7 @@ GW|he|גינאה-ביסאו
 GW|hi|गिनी-बिसाउ
 GW|ho|*aa
 GW|hr|Gvineja Bisau
-GW|ht|*aa
+GW|ht|*fr
 GW|hu|Bissau-Guinea
 GW|hy|Գվինեա-Բիսաու
 GW|hz|*aa
@@ -17406,8 +17406,8 @@ GW|lu|Nginebisau
 GW|lv|Gvineja-Bisava
 GW|mg|Giné-Bisao
 GW|mh|*aa
-GW|mi|*aa
-GW|mk|Гвинеја-Бисау
+GW|mi|Kini-Pihao
+GW|mk|Гвинеја Бисао
 GW|ml|ഗിനിയ-ബിസൗ
 GW|mn|*ce
 GW|mo|Guineea-Bissau
@@ -17428,7 +17428,7 @@ GW|nv|*aa
 GW|ny|*aa
 GW|oc|*aa
 GW|oj|*aa
-GW|om|*aa
+GW|om|Giinii-Bisaawoo
 GW|or|ଗୁଇନିଆ-ବିସାଉ
 GW|os|*aa
 GW|pa|ਗਿਨੀ-ਬਿਸਾਉ
@@ -17464,7 +17464,7 @@ GW|ta|கினியா-பிஸ்ஸாவ்
 GW|te|గినియా-బిస్సావ్
 GW|tg|*bg
 GW|th|กินี-บิสเซา
-GW|ti|ቢሳዎ
+GW|ti|*am
 GW|tk|Gwineýa-Bisau
 GW|tl|*aa
 GW|tn|*aa
@@ -17483,7 +17483,7 @@ GW|vi|*aa
 GW|vo|*aa
 GW|wa|*aa
 GW|wo|Gine-Bisaawóo
-GW|xh|*aa
+GW|xh|EGuinea-Bissau
 GW|yi|*ji
 GW|yo|Gene-Busau
 GW|za|*aa
@@ -17518,7 +17518,7 @@ GY|co|*aa
 GY|cr|*aa
 GY|cs|*aa
 GY|cu|*aa
-GY|cv|*aa
+GY|cv|*ce
 GY|cy|*aa
 GY|da|*aa
 GY|de|*aa
@@ -17538,7 +17538,7 @@ GY|fj|*aa
 GY|fo|Gujana
 GY|fr|*aa
 GY|fy|*aa
-GY|ga|an Ghuáin
+GY|ga|An Ghuáin
 GY|gd|Guidheàna
 GY|gl|Güiana
 GY|gn|*aa
@@ -17594,7 +17594,7 @@ GY|lu|Ngiyane
 GY|lv|Gajāna
 GY|mg|*aa
 GY|mh|*aa
-GY|mi|*aa
+GY|mi|Kaiana
 GY|mk|Гвајана
 GY|ml|ഗയാന
 GY|mn|*ce
@@ -17616,7 +17616,7 @@ GY|nv|*aa
 GY|ny|*aa
 GY|oc|*aa
 GY|oj|*aa
-GY|om|*aa
+GY|om|Guyaanaa
 GY|or|ଗୁଇନା
 GY|os|*aa
 GY|pa|ਗੁਯਾਨਾ
@@ -17671,7 +17671,7 @@ GY|vi|*aa
 GY|vo|*aa
 GY|wa|*aa
 GY|wo|*ff
-GY|xh|*aa
+GY|xh|EGuyana
 GY|yi|*ji
 GY|yo|*aa
 GY|za|*aa
@@ -17681,7 +17681,7 @@ HK|aa|Hong Kong SAR China
 HK|ab|*aa
 HK|ae|*aa
 HK|af|Hongkong SAS China
-HK|ak|*aa
+HK|ak|Hɔnkɔn Kyaena
 HK|am|ሆንግ ኮንግ ልዩ የአስተዳደር ክልል ቻይና
 HK|an|*aa
 HK|ar|هونغ كونغ الصينية (منطقة إدارية خاصة)
@@ -17706,7 +17706,7 @@ HK|co|*aa
 HK|cr|*aa
 HK|cs|Hongkong – ZAO Číny
 HK|cu|*aa
-HK|cv|*aa
+HK|cv|Гонконг (САР)
 HK|cy|Hong Kong SAR Tsieina
 HK|da|SAR Hongkong
 HK|de|Sonderverwaltungsregion Hongkong
@@ -17726,7 +17726,7 @@ HK|fj|*aa
 HK|fo|Hong Kong SAR Kina
 HK|fr|R.A.S. chinoise de Hong Kong
 HK|fy|Hongkong SAR van Sina
-HK|ga|S.R.R. na Síne Hong Cong
+HK|ga|Sainréigiún Riaracháin Hong Cong, Daonphoblacht na Síne
 HK|gd|Hong Kong SAR na Sìne
 HK|gl|Hong Kong RAE da China
 HK|gn|*aa
@@ -17737,11 +17737,11 @@ HK|he|הונג קונג (אזור מנהלי מיוחד של סין)
 HK|hi|हाँग काँग (चीन विशेष प्रशासनिक क्षेत्र)
 HK|ho|*aa
 HK|hr|PUP Hong Kong Kina
-HK|ht|*aa
+HK|ht|*fr
 HK|hu|Hongkong KKT
 HK|hy|Հոնկոնգի ՀՎՇ
 HK|hz|*aa
-HK|ia|*aa
+HK|ia|Hongkong, R.A.S. de China
 HK|id|Hong Kong DAK Tiongkok
 HK|ie|*aa
 HK|ig|*aa
@@ -17763,11 +17763,11 @@ HK|kj|*aa
 HK|kk|Сянган АӘА
 HK|kl|*aa
 HK|km|ហុងកុង តំបន់រដ្ឋបាលពិសេសចិន
-HK|kn|ಹಾಂಗ್ ಕಾಂಗ್ SAR ಚೈನಾ
+HK|kn|ಹಾಂಗ್ ಕಾಂಗ್ ಎಸ್ಎಆರ್ ಚೈನಾ
 HK|ko|홍콩(중국 특별행정구)
 HK|kr|*aa
 HK|ks|ہانگ کانگ ایس اے آر چیٖن
-HK|ku|*aa
+HK|ku|Hong Konga HîT ya Çînê
 HK|kv|*aa
 HK|kw|*aa
 HK|ky|Гонконг Кытай ААА
@@ -17782,10 +17782,10 @@ HK|lu|*aa
 HK|lv|Ķīnas īpašās pārvaldes apgabals Honkonga
 HK|mg|*aa
 HK|mh|*aa
-HK|mi|*aa
+HK|mi|Hongipua Haina
 HK|mk|Хонгконг САР Кина
 HK|ml|ഹോങ്കോങ് (SAR) ചൈന
-HK|mn|БНХАУ-ын Тусгай захиргааны бүс Хонг Конг
+HK|mn|БНХАУ-ын Тусгай захиргааны бүс Хонг-Конг
 HK|mo|R.A.S. Hong Kong, China
 HK|mr|हाँगकाँग एसएआर चीन
 HK|ms|*aa
@@ -17802,9 +17802,9 @@ HK|no|*nb
 HK|nr|*aa
 HK|nv|*aa
 HK|ny|*aa
-HK|oc|*aa
+HK|oc|Hong Kong
 HK|oj|*aa
-HK|om|*aa
+HK|om|Hoong Koong SAR Chaayinaa
 HK|or|ହଂ କଂ ଏସଏଆର୍‌ ଚାଇନା
 HK|os|*aa
 HK|pa|ਹਾਂਗ ਕਾਂਗ ਐਸਏਆਰ ਚੀਨ
@@ -17816,10 +17816,10 @@ HK|qu|Hong Kong RAE China
 HK|rm|Regiun d’administraziun speziala da Hongkong, China
 HK|rn|*aa
 HK|ro|*mo
-HK|ru|Гонконг (САР)
+HK|ru|*cv
 HK|rw|*aa
 HK|sa|*aa
-HK|sc|*aa
+HK|sc|RAS tzinesa de Hong Kong
 HK|sd|هانگ ڪانگ SAR
 HK|se|Hongkong
 HK|sg|*aa
@@ -17828,7 +17828,7 @@ HK|sk|Hongkong – OAO Číny
 HK|sl|Posebno upravno območje Ljudske republike Kitajske Hongkong
 HK|sm|*aa
 HK|sn|*aa
-HK|so|Hong Kong
+HK|so|*oc
 HK|sq|RPA i Hong-Kongut
 HK|sr|САР Хонгконг (Кина)
 HK|ss|*aa
@@ -17840,7 +17840,7 @@ HK|ta|ஹாங்காங் எஸ்ஏஆர் சீனா
 HK|te|హాంకాంగ్ ఎస్ఏఆర్ చైనా
 HK|tg|Ҳонконг (МММ)
 HK|th|เขตปกครองพิเศษฮ่องกงแห่งสาธารณรัฐประชาชนจีน
-HK|ti|ፍሉይ ምምሕዳር ዞባ ሆንግ ኮንግ
+HK|ti|ፍሉይ ምምሕዳራዊ ዞባ ሆንግ ኮንግ (ቻይና)
 HK|tk|Gonkong AAS Hytaý
 HK|tl|*aa
 HK|tn|*aa
@@ -17858,8 +17858,8 @@ HK|ve|*aa
 HK|vi|Đặc khu Hành chính Hồng Kông, Trung Quốc
 HK|vo|*aa
 HK|wa|*aa
-HK|wo|*aa
-HK|xh|*aa
+HK|wo|Ooŋ Koŋ
+HK|xh|EHong Kong SAR China
 HK|yi|*aa
 HK|yo|Agbègbè Ìṣàkóso Ìṣúná Hong Kong Tí Ṣánà Ń Darí
 HK|za|*aa
@@ -17869,8 +17869,8 @@ HM|aa|Heard & McDonald Islands
 HM|ab|*aa
 HM|ae|*aa
 HM|af|Heardeiland en McDonaldeilande
-HM|ak|*aa
-HM|am|ኽርድ ደሴቶችና ማክዶናልድ ደሴቶች
+HM|ak|Heard ne McDonald Supɔ
+HM|am|ኽርድ ኣና ማክዶናልድ ደሴቶች
 HM|an|*aa
 HM|ar|جزيرة هيرد وجزر ماكدونالد
 HM|as|হাৰ্ড দ্বীপ আৰু মেকডোনাল্ড দ্বীপপুঞ্জ
@@ -17887,14 +17887,14 @@ HM|bn|হার্ড এবং ম্যাকডোনাল্ড দ্ব�
 HM|bo|*aa
 HM|br|Inizi Heard ha McDonald
 HM|bs|Ostrvo Heard i arhipelag McDonald
-HM|ca|Illa Heard i Illes McDonald
+HM|ca|Illes Heard i McDonald
 HM|ce|Херд гӀайре а, Макдональд гӀайренаш а
 HM|ch|*aa
 HM|co|*aa
 HM|cr|*aa
 HM|cs|Heardův ostrov a McDonaldovy ostrovy
 HM|cu|*aa
-HM|cv|*aa
+HM|cv|Херд тата Макдональд утравӗ
 HM|cy|Ynys Heard ac Ynysoedd McDonald
 HM|da|Heard Island og McDonald Islands
 HM|de|Heard und McDonaldinseln
@@ -17915,7 +17915,7 @@ HM|fo|Heard og McDonaldoyggjar
 HM|fr|Îles Heard-et-MacDonald
 HM|fy|Heard- en McDonaldeilannen
 HM|ga|Oileán Heard agus Oileáin McDonald
-HM|gd|Eilean Heard is MhicDhòmhnaill
+HM|gd|Eilean Heard is Eileanan MhicDhòmhnaill
 HM|gl|Illa Heard e Illas McDonald
 HM|gn|*aa
 HM|gu|હર્ડ અને મેકડોનાલ્ડ આઇલેન્ડ્સ
@@ -17925,11 +17925,11 @@ HM|he|איי הרד ומקדונלד
 HM|hi|हर्ड द्वीप और मैकडोनॉल्ड द्वीपसमूह
 HM|ho|*aa
 HM|hr|Otoci Heard i McDonald
-HM|ht|*aa
+HM|ht|*fr
 HM|hu|Heard-sziget és McDonald-szigetek
 HM|hy|Հերդ կղզի և ՄակԴոնալդի կղզիներ
 HM|hz|*aa
-HM|ia|*aa
+HM|ia|Insulas Heard e McDonald
 HM|id|Pulau Heard dan Kepulauan McDonald
 HM|ie|*aa
 HM|ig|Agwaetiti Heard na Agwaetiti McDonald
@@ -17954,8 +17954,8 @@ HM|km|កោះ​ហឺដនិង​ម៉ាក់ដូណាល់
 HM|kn|ಹರ್ಡ್ ಮತ್ತು ಮ್ಯಾಕ್‌ಡೋನಾಲ್ಡ್ ದ್ವೀಪಗಳು
 HM|ko|허드 맥도널드 제도
 HM|kr|*aa
-HM|ks|ہَرٕڑ جٔزیٖرٕ تہٕ مؠکڈونالڑٕ جٔزیٖرٕ
-HM|ku|*aa
+HM|ks|ہَرٕڑ تہٕ مؠکڈونالڑٕ جٔزیٖرٕ
+HM|ku|Giravên Heard û MacDonaldê
 HM|kv|*aa
 HM|kw|*aa
 HM|ky|Херд жана Макдональд аралдары
@@ -17970,9 +17970,9 @@ HM|lu|*aa
 HM|lv|Hērda sala un Makdonalda salas
 HM|mg|*aa
 HM|mh|*aa
-HM|mi|*aa
+HM|mi|Ngā Moutere Heriti me Makitānara
 HM|mk|Остров Херд и Острови Мекдоналд
-HM|ml|ഹിയേർഡും മക്‌ഡൊണാൾഡ് ദ്വീപുകളും
+HM|ml|ഹേർഡ്, മക്ഡോണൾഡ് ദ്വീപുകൾ
 HM|mn|Херд ба Макдональдийн арлууд
 HM|mo|Insula Heard și Insulele McDonald
 HM|mr|हर्ड आणि मॅक्डोनाल्ड बेटे
@@ -17992,7 +17992,7 @@ HM|nv|*aa
 HM|ny|*aa
 HM|oc|*aa
 HM|oj|*aa
-HM|om|*aa
+HM|om|Odoloota Herdii fi MaakDoonaald
 HM|or|ହାର୍ଡ୍‌ ଏବଂ ମ୍ୟାକଡୋନାଲ୍ଡ ଦ୍ୱୀପପୁଞ୍ଜ
 HM|os|*aa
 HM|pa|ਹਰਡ ਤੇ ਮੈਕਡੋਨਾਲਡ ਟਾਪੂ
@@ -18007,7 +18007,7 @@ HM|ro|*mo
 HM|ru|о-ва Херд и Макдональд
 HM|rw|*aa
 HM|sa|*aa
-HM|sc|*aa
+HM|sc|Ìsulas Heard e McDonald
 HM|sd|هرڊ ۽ مڪڊونلڊ ٻيٽ
 HM|se|Heard- ja McDonald-sullot
 HM|sg|*aa
@@ -18028,7 +18028,7 @@ HM|ta|ஹேர்ட் மற்றும் மெக்டொனால்ட
 HM|te|హెర్డ్ దీవి మరియు మెక్‌డొనాల్డ్ దీవులు
 HM|tg|Ҷазираи Ҳерд ва Ҷазираҳои Макдоналд
 HM|th|เกาะเฮิร์ดและหมู่เกาะแมกดอนัลด์
-HM|ti|ደሴታት ሀርድን ማክዶናልድን
+HM|ti|ደሴታት ሄርድን ማክዶናልድን
 HM|tk|Herd we Makdonald adalary
 HM|tl|*aa
 HM|tn|*aa
@@ -18047,7 +18047,7 @@ HM|vi|Quần đảo Heard và McDonald
 HM|vo|*aa
 HM|wa|*aa
 HM|wo|Duni Hërd ak Duni MakDonald
-HM|xh|*aa
+HM|xh|EHeard & McDonald Islands
 HM|yi|*aa
 HM|yo|Erékùsù Heard àti Erékùsù McDonald
 HM|za|*aa
@@ -18082,7 +18082,7 @@ HN|co|*aa
 HN|cr|*aa
 HN|cs|*aa
 HN|cu|*aa
-HN|cv|*aa
+HN|cv|*ce
 HN|cy|*aa
 HN|da|*aa
 HN|de|*aa
@@ -18108,7 +18108,7 @@ HN|gl|*aa
 HN|gn|*aa
 HN|gu|હોન્ડુરસ
 HN|gv|*aa
-HN|ha|*aa
+HN|ha|Yankin Honduras
 HN|he|הונדורס
 HN|hi|होंडूरास
 HN|ho|*aa
@@ -18142,7 +18142,7 @@ HN|km|ហុងឌូរ៉ាស
 HN|kn|ಹೊಂಡುರಾಸ್
 HN|ko|온두라스
 HN|kr|*aa
-HN|ks|ہانڈوٗرِس
+HN|ks|ہونڈورس
 HN|ku|Hondûras
 HN|kv|*aa
 HN|kw|*aa
@@ -18158,7 +18158,7 @@ HN|lu|Ondurase
 HN|lv|Hondurasa
 HN|mg|Hondiorasy
 HN|mh|*aa
-HN|mi|*aa
+HN|mi|Honotura
 HN|mk|*bg
 HN|ml|ഹോണ്ടുറാസ്
 HN|mn|*ce
@@ -18180,7 +18180,7 @@ HN|nv|*aa
 HN|ny|*aa
 HN|oc|*aa
 HN|oj|*aa
-HN|om|*aa
+HN|om|Hondurus
 HN|or|ହୋଣ୍ଡୁରାସ୍‌
 HN|os|*aa
 HN|pa|ਹੋਂਡੁਰਸ
@@ -18235,7 +18235,7 @@ HN|vi|*aa
 HN|vo|*aa
 HN|wa|*aa
 HN|wo|Onduraas
-HN|xh|*aa
+HN|xh|EHonduras
 HN|yi|*ji
 HN|yo|*ki
 HN|za|*aa
@@ -18270,7 +18270,7 @@ HR|co|*aa
 HR|cr|*aa
 HR|cs|Chorvatsko
 HR|cu|*aa
-HR|cv|*aa
+HR|cv|*ce
 HR|cy|*aa
 HR|da|Kroatien
 HR|de|*da
@@ -18301,7 +18301,7 @@ HR|he|קרואטיה
 HR|hi|क्रोएशिया
 HR|ho|*aa
 HR|hr|*bs
-HR|ht|*aa
+HR|ht|*fr
 HR|hu|Horvátország
 HR|hy|Խորվաթիա
 HR|hz|*aa
@@ -18331,7 +18331,7 @@ HR|kn|ಕ್ರೊಯೇಷಿಯಾ
 HR|ko|크로아티아
 HR|kr|*aa
 HR|ks|کروشِیا
-HR|ku|Kroatya
+HR|ku|Xirwatistan
 HR|kv|*aa
 HR|kw|*aa
 HR|ky|*kk
@@ -18346,7 +18346,7 @@ HR|lu|*ln
 HR|lv|Horvātija
 HR|mg|*id
 HR|mh|*aa
-HR|mi|*aa
+HR|mi|Koroātia
 HR|mk|Хрватска
 HR|ml|ക്രൊയേഷ്യ
 HR|mn|Хорват
@@ -18368,7 +18368,7 @@ HR|nv|*aa
 HR|ny|*aa
 HR|oc|*aa
 HR|oj|*aa
-HR|om|*aa
+HR|om|Kirooshiyaa
 HR|or|କ୍ରୋଏସିଆ
 HR|os|*aa
 HR|pa|ਕਰੋਏਸ਼ੀਆ
@@ -18383,7 +18383,7 @@ HR|ro|*mo
 HR|ru|*kk
 HR|rw|*aa
 HR|sa|*aa
-HR|sc|*aa
+HR|sc|Croàtzia
 HR|sd|ڪروئيشيا
 HR|se|Kroátia
 HR|sg|Kroasïi
@@ -18423,7 +18423,7 @@ HR|vi|*aa
 HR|vo|*aa
 HR|wa|*aa
 HR|wo|Korowasi
-HR|xh|*aa
+HR|xh|ECroatia
 HR|yi|*ji
 HR|yo|Kòróátíà
 HR|za|*aa
@@ -18458,7 +18458,7 @@ HT|co|*aa
 HT|cr|*aa
 HT|cs|*aa
 HT|cu|*aa
-HT|cv|*aa
+HT|cv|*ce
 HT|cy|*aa
 HT|da|*aa
 HT|de|*aa
@@ -18489,14 +18489,14 @@ HT|he|האיטי
 HT|hi|हैती
 HT|ho|*aa
 HT|hr|*aa
-HT|ht|*aa
+HT|ht|*af
 HT|hu|*aa
 HT|hy|Հայիթի
 HT|hz|*aa
 HT|ia|*aa
 HT|id|*aa
 HT|ie|*aa
-HT|ig|Hati
+HT|ig|*aa
 HT|ii|*aa
 HT|ik|*aa
 HT|in|*aa
@@ -18518,7 +18518,7 @@ HT|km|ហៃទី
 HT|kn|ಹೈಟಿ
 HT|ko|아이티
 HT|kr|*aa
-HT|ks|ہایتی
+HT|ks|ہیتی
 HT|ku|Haîtî
 HT|kv|*aa
 HT|kw|*aa
@@ -18556,7 +18556,7 @@ HT|nv|*aa
 HT|ny|*aa
 HT|oc|*aa
 HT|oj|*aa
-HT|om|*aa
+HT|om|Haayitii
 HT|or|ହାଇତି
 HT|os|*aa
 HT|pa|ਹੈਤੀ
@@ -18589,10 +18589,10 @@ HT|su|*aa
 HT|sv|*aa
 HT|sw|*aa
 HT|ta|ஹைட்டி
-HT|te|హైటి
+HT|te|హైతీ
 HT|tg|*ce
 HT|th|เฮติ
-HT|ti|*am
+HT|ti|ሃይቲ
 HT|tk|Gaiti
 HT|tl|*aa
 HT|tn|*aa
@@ -18611,7 +18611,7 @@ HT|vi|*aa
 HT|vo|*aa
 HT|wa|*aa
 HT|wo|Ayti
-HT|xh|*aa
+HT|xh|EHaiti
 HT|yi|*ji
 HT|yo|Haati
 HT|za|*aa
@@ -18646,7 +18646,7 @@ HU|co|*aa
 HU|cr|*aa
 HU|cs|Maďarsko
 HU|cu|*aa
-HU|cv|*aa
+HU|cv|*ce
 HU|cy|Hwngari
 HU|da|Ungarn
 HU|de|*da
@@ -18677,13 +18677,13 @@ HU|he|הונגריה
 HU|hi|हंगरी
 HU|ho|*aa
 HU|hr|*bs
-HU|ht|*aa
+HU|ht|*fr
 HU|hu|Magyarország
 HU|hy|Հունգարիա
 HU|hz|*aa
 HU|ia|*br
 HU|id|*br
-HU|ie|*aa
+HU|ie|*br
 HU|ig|*aa
 HU|ii|*aa
 HU|ik|*aa
@@ -18722,7 +18722,7 @@ HU|lu|*ln
 HU|lv|Ungārija
 HU|mg|*ca
 HU|mh|*aa
-HU|mi|*aa
+HU|mi|Hanekari
 HU|mk|Унгарија
 HU|ml|ഹംഗറി
 HU|mn|Унгар
@@ -18744,7 +18744,7 @@ HU|nv|*aa
 HU|ny|*aa
 HU|oc|*aa
 HU|oj|*aa
-HU|om|*aa
+HU|om|Hangaarii
 HU|or|ହଙ୍ଗେରୀ
 HU|os|*aa
 HU|pa|ਹੰਗਰੀ
@@ -18759,7 +18759,7 @@ HU|ro|*mo
 HU|ru|*kk
 HU|rw|*aa
 HU|sa|*aa
-HU|sc|*aa
+HU|sc|*it
 HU|sd|هنگري
 HU|se|Ungár
 HU|sg|Hongirùii
@@ -18780,7 +18780,7 @@ HU|ta|ஹங்கேரி
 HU|te|హంగేరీ
 HU|tg|Маҷористон
 HU|th|ฮังการี
-HU|ti|*am
+HU|ti|ሃንጋሪ
 HU|tk|Wengriýa
 HU|tl|*aa
 HU|tn|*aa
@@ -18799,7 +18799,7 @@ HU|vi|*aa
 HU|vo|*aa
 HU|wa|*aa
 HU|wo|Ongari
-HU|xh|*aa
+HU|xh|EHungary
 HU|yi|*ji
 HU|yo|*ha
 HU|za|*aa
@@ -18834,7 +18834,7 @@ ID|co|*aa
 ID|cr|*aa
 ID|cs|Indonésie
 ID|cu|*aa
-ID|cv|*aa
+ID|cv|*ce
 ID|cy|*aa
 ID|da|Indonesien
 ID|de|*da
@@ -18865,7 +18865,7 @@ ID|he|אינדונזיה
 ID|hi|इंडोनेशिया
 ID|ho|*aa
 ID|hr|*bs
-ID|ht|*aa
+ID|ht|*cs
 ID|hu|Indonézia
 ID|hy|Ինդոնեզիա
 ID|hz|*aa
@@ -18894,8 +18894,8 @@ ID|km|ឥណ្ឌូណេស៊ី
 ID|kn|ಇಂಡೋನೇಶಿಯಾ
 ID|ko|인도네시아
 ID|kr|*aa
-ID|ks|اِنڑونیشِیا
-ID|ku|Îndonezya
+ID|ks|انڈونیشیا
+ID|ku|Endonezya
 ID|kv|*aa
 ID|kw|*aa
 ID|ky|*bg
@@ -18910,7 +18910,7 @@ ID|lu|*ln
 ID|lv|Indonēzija
 ID|mg|*br
 ID|mh|*aa
-ID|mi|*aa
+ID|mi|Initonīhia
 ID|mk|Индонезија
 ID|ml|ഇന്തോനേഷ്യ
 ID|mn|Индонез
@@ -18932,7 +18932,7 @@ ID|nv|*aa
 ID|ny|*aa
 ID|oc|*aa
 ID|oj|*aa
-ID|om|*aa
+ID|om|Indooneeshiyaa
 ID|or|ଇଣ୍ଡୋନେସିଆ
 ID|os|*aa
 ID|pa|ਇੰਡੋਨੇਸ਼ੀਆ
@@ -18947,7 +18947,7 @@ ID|ro|*br
 ID|ru|*bg
 ID|rw|*aa
 ID|sa|*aa
-ID|sc|*aa
+ID|sc|*ca
 ID|sd|انڊونيشيا
 ID|se|*aa
 ID|sg|Ênndonezïi
@@ -18968,28 +18968,28 @@ ID|ta|இந்தோனேசியா
 ID|te|ఇండోనేషియా
 ID|tg|*bg
 ID|th|อินโดนีเซีย
-ID|ti|*am
+ID|ti|ኢንዶነዥያ
 ID|tk|Indoneziýa
 ID|tl|*aa
 ID|tn|*aa
 ID|to|ʻInitonēsia
-ID|tr|Endonezya
+ID|tr|*ku
 ID|ts|*aa
 ID|tt|*bg
 ID|tw|*aa
 ID|ty|*aa
 ID|ug|ھىندونېزىيە
 ID|uk|Індонезія
-ID|ur|انڈونیشیا
+ID|ur|*ks
 ID|uz|*rn
 ID|ve|*aa
 ID|vi|*aa
 ID|vo|*aa
 ID|wa|*aa
 ID|wo|Indonesi
-ID|xh|*aa
+ID|xh|E-Indonesia
 ID|yi|*ji
-ID|yo|*aa
+ID|yo|Indonéṣíà
 ID|za|*aa
 ID|zh|印度尼西亚
 ID|zu|i-Indonesia
@@ -19022,7 +19022,7 @@ IE|co|*aa
 IE|cr|*aa
 IE|cs|Irsko
 IE|cu|*aa
-IE|cv|*aa
+IE|cv|*ce
 IE|cy|Iwerddon
 IE|da|Irland
 IE|de|*da
@@ -19053,13 +19053,13 @@ IE|he|אירלנד
 IE|hi|आयरलैंड
 IE|ho|*aa
 IE|hr|*bs
-IE|ht|*aa
+IE|ht|*fr
 IE|hu|Írország
 IE|hy|Իռլանդիա
 IE|hz|*aa
 IE|ia|*ca
 IE|id|Irlandia
-IE|ie|*aa
+IE|ie|*da
 IE|ig|*aa
 IE|ii|*aa
 IE|ik|*aa
@@ -19083,7 +19083,7 @@ IE|kn|ಐರ್ಲೆಂಡ್
 IE|ko|아일랜드
 IE|kr|*aa
 IE|ks|اَیَرلینڑ
-IE|ku|Îrlenda
+IE|ku|Îrlanda
 IE|kv|*aa
 IE|kw|*aa
 IE|ky|*bg
@@ -19098,7 +19098,7 @@ IE|lu|Irelande
 IE|lv|Īrija
 IE|mg|Irlandy
 IE|mh|*aa
-IE|mi|*aa
+IE|mi|Airani
 IE|mk|Ирска
 IE|ml|അയർലൻഡ്
 IE|mn|Ирланд
@@ -19120,7 +19120,7 @@ IE|nv|*aa
 IE|ny|*aa
 IE|oc|*aa
 IE|oj|*aa
-IE|om|*aa
+IE|om|Ayeerlaand
 IE|or|ଆୟରଲ୍ୟାଣ୍ଡ
 IE|os|*aa
 IE|pa|ਆਇਰਲੈਂਡ
@@ -19135,7 +19135,7 @@ IE|ro|*ca
 IE|ru|*bg
 IE|rw|*aa
 IE|sa|*aa
-IE|sc|*aa
+IE|sc|*ca
 IE|sd|آئرلينڊ
 IE|se|Irlánda
 IE|sg|Irlânde
@@ -19156,7 +19156,7 @@ IE|ta|அயர்லாந்து
 IE|te|ఐర్లాండ్
 IE|tg|*bg
 IE|th|ไอร์แลนด์
-IE|ti|*am
+IE|ti|ኣየርላንድ
 IE|tk|Irlandiýa
 IE|tl|*aa
 IE|tn|*aa
@@ -19175,7 +19175,7 @@ IE|vi|*aa
 IE|vo|*aa
 IE|wa|*aa
 IE|wo|Irlànd
-IE|xh|*aa
+IE|xh|E-Ireland
 IE|yi|*ji
 IE|yo|Ailandi
 IE|za|*aa
@@ -19185,7 +19185,7 @@ IL|aa|Israel
 IL|ab|*aa
 IL|ae|*aa
 IL|af|*aa
-IL|ak|*aa
+IL|ak|Israe
 IL|am|እስራኤል
 IL|an|*aa
 IL|ar|إسرائيل
@@ -19210,7 +19210,7 @@ IL|co|*aa
 IL|cr|*aa
 IL|cs|*bs
 IL|cu|*aa
-IL|cv|*aa
+IL|cv|*ce
 IL|cy|*aa
 IL|da|*aa
 IL|de|*aa
@@ -19241,7 +19241,7 @@ IL|he|ישראל
 IL|hi|इज़राइल
 IL|ho|*aa
 IL|hr|*bs
-IL|ht|*aa
+IL|ht|*fr
 IL|hu|*bs
 IL|hy|Իսրայել
 IL|hz|*aa
@@ -19270,8 +19270,8 @@ IL|km|អ៊ីស្រាអែល
 IL|kn|ಇಸ್ರೇಲ್
 IL|ko|이스라엘
 IL|kr|*aa
-IL|ks|اِسرایٖل
-IL|ku|Îsraêl
+IL|ks|اسرا ییل
+IL|ku|Îsraîl
 IL|kv|*aa
 IL|kw|*aa
 IL|ky|*ce
@@ -19286,10 +19286,10 @@ IL|lu|Isirayele
 IL|lv|Izraēla
 IL|mg|Israely
 IL|mh|*aa
-IL|mi|*aa
+IL|mi|Iharaira
 IL|mk|*bg
 IL|ml|ഇസ്രായേൽ
-IL|mn|*ce
+IL|mn|Израил
 IL|mo|*aa
 IL|mr|इस्त्राइल
 IL|ms|*aa
@@ -19308,7 +19308,7 @@ IL|nv|*aa
 IL|ny|*aa
 IL|oc|*aa
 IL|oj|*aa
-IL|om|*aa
+IL|om|Israa’eel
 IL|or|ଇସ୍ରାଏଲ୍
 IL|os|*aa
 IL|pa|ਇਜ਼ਰਾਈਲ
@@ -19323,7 +19323,7 @@ IL|ro|*aa
 IL|ru|*ce
 IL|rw|*aa
 IL|sa|*aa
-IL|sc|*aa
+IL|sc|*it
 IL|sd|اسرائيل
 IL|se|*aa
 IL|sg|Israëli
@@ -19363,7 +19363,7 @@ IL|vi|*aa
 IL|vo|*aa
 IL|wa|*aa
 IL|wo|Israyel
-IL|xh|*aa
+IL|xh|E-Israel
 IL|yi|*he
 IL|yo|Iserẹli
 IL|za|*aa
@@ -19398,7 +19398,7 @@ IM|co|*aa
 IM|cr|*aa
 IM|cs|Ostrov Man
 IM|cu|*aa
-IM|cv|*aa
+IM|cv|Мэн утравӗ
 IM|cy|Ynys Manaw
 IM|da|*aa
 IM|de|*aa
@@ -19424,12 +19424,12 @@ IM|gl|*ca
 IM|gn|*aa
 IM|gu|આઇલ ઑફ મેન
 IM|gv|Ellan Vannin
-IM|ha|Isle na Mutum
+IM|ha|*aa
 IM|he|האי מאן
 IM|hi|आइल ऑफ़ मैन
 IM|ho|*aa
 IM|hr|Otok Man
-IM|ht|*aa
+IM|ht|*fr
 IM|hu|Man-sziget
 IM|hy|Մեն կղզի
 IM|hz|*aa
@@ -19459,7 +19459,7 @@ IM|kn|ಐಲ್ ಆಫ್ ಮ್ಯಾನ್
 IM|ko|맨섬
 IM|kr|*aa
 IM|ks|آیِل آف مین
-IM|ku|Girava Man
+IM|ku|Girava Manê
 IM|kv|*aa
 IM|kw|*aa
 IM|ky|*kk
@@ -19474,7 +19474,7 @@ IM|lu|*aa
 IM|lv|Menas sala
 IM|mg|*aa
 IM|mh|*aa
-IM|mi|*aa
+IM|mi|Te Moutere Mana
 IM|mk|Остров Ман
 IM|ml|ഐൽ ഓഫ് മാൻ
 IM|mn|Мэн Арал
@@ -19496,7 +19496,7 @@ IM|nv|*aa
 IM|ny|*aa
 IM|oc|*aa
 IM|oj|*aa
-IM|om|*aa
+IM|om|Islee oof Maan
 IM|or|ଆଇଲ୍‌ ଅଫ୍‌ ମ୍ୟାନ୍‌
 IM|os|*aa
 IM|pa|ਆਇਲ ਆਫ ਮੈਨ
@@ -19511,7 +19511,7 @@ IM|ro|*mo
 IM|ru|о-в Мэн
 IM|rw|*aa
 IM|sa|*aa
-IM|sc|*aa
+IM|sc|Ìsula de Man
 IM|sd|انسانن جو ٻيٽ
 IM|se|Mann-sullot
 IM|sg|*aa
@@ -19532,7 +19532,7 @@ IM|ta|ஐல் ஆஃப் மேன்
 IM|te|ఐల్ ఆఫ్ మాన్
 IM|tg|Ҷазираи Мэн
 IM|th|เกาะแมน
-IM|ti|*am
+IM|ti|ኣይል ኦፍ ማን
 IM|tk|Men adasy
 IM|tl|*aa
 IM|tn|*aa
@@ -19551,9 +19551,9 @@ IM|vi|Đảo Man
 IM|vo|*aa
 IM|wa|*aa
 IM|wo|Dunu Maan
-IM|xh|*aa
+IM|xh|E-Isle of Man
 IM|yi|*aa
-IM|yo|*aa
+IM|yo|Erékùṣù ilẹ̀ Man
 IM|za|*aa
 IM|zh|马恩岛
 IM|zu|i-Isle of Man
@@ -19586,7 +19586,7 @@ IN|co|*aa
 IN|cr|*aa
 IN|cs|Indie
 IN|cu|*aa
-IN|cv|*aa
+IN|cv|Инди
 IN|cy|*aa
 IN|da|Indien
 IN|de|*da
@@ -19608,7 +19608,7 @@ IN|fr|Inde
 IN|fy|*aa
 IN|ga|an India
 IN|gd|Na h-Innseachan
-IN|gl|A India
+IN|gl|*aa
 IN|gn|*aa
 IN|gu|ભારત
 IN|gv|*aa
@@ -19617,7 +19617,7 @@ IN|he|הודו
 IN|hi|भारत
 IN|ho|*aa
 IN|hr|*bs
-IN|ht|*aa
+IN|ht|*fr
 IN|hu|*aa
 IN|hy|Հնդկաստան
 IN|hz|*aa
@@ -19684,9 +19684,9 @@ IN|nv|*aa
 IN|ny|*aa
 IN|oc|*aa
 IN|oj|*aa
-IN|om|*aa
+IN|om|Hindii
 IN|or|ଭାରତ
-IN|os|Инди
+IN|os|*cv
 IN|pa|ਭਾਰਤ
 IN|pi|*aa
 IN|pl|*cs
@@ -19699,7 +19699,7 @@ IN|ro|*aa
 IN|ru|*bg
 IN|rw|*aa
 IN|sa|भारतः
-IN|sc|*aa
+IN|sc|Ìndia
 IN|sd|ڀارت
 IN|se|*aa
 IN|sg|Ênnde
@@ -19739,9 +19739,9 @@ IN|vi|Ấn Độ
 IN|vo|*aa
 IN|wa|*aa
 IN|wo|End
-IN|xh|*aa
+IN|xh|E-Indiya
 IN|yi|*ji
-IN|yo|*aa
+IN|yo|Íńdíà
 IN|za|*aa
 IN|zh|印度
 IN|zu|i-India
@@ -19749,7 +19749,7 @@ IO|aa|British Indian Ocean Territory
 IO|ab|*aa
 IO|ae|*aa
 IO|af|Brits-Indiese Oseaangebied
-IO|ak|Britenfo Hɔn Man Wɔ India Po No Mu
+IO|ak|Britenfo Man Wɔ India Po No Mu
 IO|am|የብሪታኒያ ህንድ ውቂያኖስ ግዛት
 IO|an|*aa
 IO|ar|الإقليم البريطاني في المحيط الهندي
@@ -19762,13 +19762,13 @@ IO|be|Брытанская тэрыторыя ў Індыйскім акіяне
 IO|bg|Британска територия в Индийския океан
 IO|bh|*aa
 IO|bi|*aa
-IO|bm|Angilɛ ka ɛndu dugukolo
+IO|bm|*aa
 IO|bn|ব্রিটিশ ভারত মহাসাগরীয় অঞ্চল
 IO|bo|*aa
-IO|br|Tiriad breizhveurat Meurvor Indez
+IO|br|*aa
 IO|bs|Britanska Teritorija u Indijskom Okeanu
 IO|ca|Territori Britànic de l’Oceà Índic
-IO|ce|Британин латта Индин океанехь
+IO|ce|*aa
 IO|ch|*aa
 IO|co|*aa
 IO|cr|*aa
@@ -19779,21 +19779,21 @@ IO|cy|Tiriogaeth Brydeinig Cefnfor India
 IO|da|Det Britiske Territorium i Det Indiske Ocean
 IO|de|Britisches Territorium im Indischen Ozean
 IO|dv|*aa
-IO|dz|བྲི་ཊིཤ་རྒྱ་གར་གྱི་རྒྱ་མཚོ་ས་ཁོངས
-IO|ee|Britaintɔwo ƒe india ƒudome nutome
+IO|dz|*aa
+IO|ee|*aa
 IO|el|Βρετανικά Εδάφη Ινδικού Ωκεανού
 IO|en|*aa
-IO|eo|Brita Hindoceana Teritorio
+IO|eo|*aa
 IO|es|Territorio Británico del Océano Índico
 IO|et|Briti India ookeani ala
 IO|eu|Indiako Ozeanoko lurralde britainiarra
 IO|fa|قلمرو بریتانیا در اقیانوس هند
-IO|ff|Keeriindi britaani to maayo enndo
+IO|ff|*aa
 IO|fi|Brittiläinen Intian valtameren alue
 IO|fj|*aa
 IO|fo|Stóra Bretlands Indiahavoyggjar
 IO|fr|Territoire britannique de l’océan Indien
-IO|fy|Britse Gebieden yn de Indyske Oseaan
+IO|fy|*aa
 IO|ga|Críoch Aigéan Indiach na Breataine
 IO|gd|Ranntair Breatannach Cuan nan Innseachan
 IO|gl|Territorio Británico do Océano Índico
@@ -19804,10 +19804,10 @@ IO|ha|Yankin Birtaniya Na Tekun Indiya
 IO|he|הטריטוריה הבריטית באוקיינוס ההודי
 IO|hi|ब्रिटिश हिंद महासागरीय क्षेत्र
 IO|ho|*aa
-IO|hr|Britanski Indijskooceanski teritorij
-IO|ht|*aa
+IO|hr|Britanski Indijskooceanski Teritorij
+IO|ht|*fr
 IO|hu|Brit Indiai-óceáni Terület
-IO|hy|Բրիտանական Տարածք Հնդկական Օվկիանոսում
+IO|hy|Բրիտանական տարածք Հնդկական Օվկիանոսում
 IO|hz|*aa
 IO|ia|Territorio oceanic britanno-indian
 IO|id|Wilayah Inggris di Samudra Hindia
@@ -19818,46 +19818,46 @@ IO|ik|*aa
 IO|in|*id
 IO|io|*aa
 IO|is|Bresku Indlandshafseyjar
-IO|it|Territorio britannico dell’Oceano Indiano
+IO|it|Territorio Britannico dell’Oceano Indiano
 IO|iu|*aa
 IO|iw|*he
 IO|ja|英領インド洋地域
 IO|ji|*aa
-IO|jv|Wilayah Inggris nang Segoro Hindia
+IO|jv|Wilayah Inggris ing Segara Hindia
 IO|ka|ბრიტანეთის ტერიტორია ინდოეთის ოკეანეში
 IO|kg|*aa
-IO|ki|Eneo la Uingereza katika Bahari Hindi
+IO|ki|*aa
 IO|kj|*aa
 IO|kk|Үнді мұхитындағы Британ аймағы
 IO|kl|*aa
 IO|km|ដែនដី​អង់គ្លេស​នៅ​មហា​សមុទ្រ​ឥណ្ឌា
 IO|kn|ಬ್ರಿಟೀಷ್ ಹಿಂದೂ ಮಹಾಸಾಗರದ ಪ್ರದೇಶ
-IO|ko|영국령 인도양 식민지
+IO|ko|영국령 인도양 지역
 IO|kr|*aa
-IO|ks|برطانوی بحرِ ہِندۍ علاقہٕ
-IO|ku|*aa
+IO|ks|*aa
+IO|ku|Herêma Okyanûsa Hindî ya Brîtanyayê
 IO|kv|*aa
 IO|kw|*aa
 IO|ky|Инди океанындагы Британ территориясы
 IO|la|*aa
-IO|lb|Britescht Territorium am Indeschen Ozean
-IO|lg|Bizinga by’eCago
+IO|lb|*aa
+IO|lg|*aa
 IO|li|*aa
-IO|ln|Mabelé ya Angɛlɛtɛ́lɛ na mbú ya Indiya
-IO|lo|ເຂດແດນອັງກິດໃນມະຫາສະມຸດອິນເດຍ
+IO|ln|*aa
+IO|lo|ເຂດແດນອັງກິດໃນມະຫາສະໝຸດອິນເດຍ
 IO|lt|Indijos Vandenyno Britų Sritis
-IO|lu|Lutanda lwa Angeletele ku mbu wa Indiya
+IO|lu|*aa
 IO|lv|Indijas okeāna Britu teritorija
-IO|mg|Faridranomasina indiana britanika
+IO|mg|*aa
 IO|mh|*aa
-IO|mi|*aa
+IO|mi|Te Rohe o te Moana Īniana Piritihi
 IO|mk|Британска Индоокеанска Територија
-IO|ml|ബ്രിട്ടീഷ് ഇന്ത്യൻ മഹാസമുദ്ര പ്രദേശം
+IO|ml|ബ്രിട്ടീഷ് ഇന്ത്യൻ ഓഷ്യൻ ടെറിട്ടറി
 IO|mn|Британийн харьяа Энэтхэгийн далай дахь нутаг дэвсгэр
 IO|mo|Teritoriul Britanic din Oceanul Indian
 IO|mr|ब्रिटिश हिंद महासागर प्रदेश
 IO|ms|Wilayah Lautan Hindi British
-IO|mt|Territorju Brittaniku tal-Oċean Indjan
+IO|mt|*aa
 IO|my|ဗြိတိသျှပိုင် အိန္ဒိယသမုဒ္ဒရာကျွန်းများ
 IO|na|*aa
 IO|nb|Det britiske territoriet i Indiahavet
@@ -19872,8 +19872,8 @@ IO|nv|*aa
 IO|ny|*aa
 IO|oc|*aa
 IO|oj|*aa
-IO|om|*aa
-IO|or|ବ୍ରିଟିଶ୍‌ ଭାରତ ମାହାସାଗର କ୍ଷେତ୍ର
+IO|om|Daangaa Galaana Hindii Biritish
+IO|or|ବ୍ରିଟିଶ୍‌ ଭାରତୀୟ ମହାସାଗର କ୍ଷେତ୍ର
 IO|os|*aa
 IO|pa|ਬਰਤਾਨਵੀ ਹਿੰਦ ਮਹਾਂਸਾਗਰ ਖਿੱਤਾ
 IO|pi|*aa
@@ -19881,34 +19881,34 @@ IO|pl|Brytyjskie Terytorium Oceanu Indyjskiego
 IO|ps|د برتانوي هند سمندري سيمه
 IO|pt|Território Britânico do Oceano Índico
 IO|qu|*es
-IO|rm|Territori Britannic en l’Ocean Indic
-IO|rn|Intara y’Ubwongereza yo mu birwa by’Abahindi
+IO|rm|*aa
+IO|rn|*aa
 IO|ro|*mo
 IO|ru|Британская территория в Индийском океане
 IO|rw|*aa
 IO|sa|*aa
-IO|sc|*aa
+IO|sc|Territòriu Britànnicu de s’Otzèanu Indianu
 IO|sd|برطانوي هندي سمنڊ خطو
 IO|se|*aa
-IO|sg|Sêse tî Anglëe na Ngûyämä tî Ênnde
+IO|sg|*aa
 IO|si|බ්‍රිතාන්‍ය ඉන්දීය සාගර බල ප්‍රදේශය
 IO|sk|Britské indickooceánske územie
 IO|sl|Britansko ozemlje v Indijskem oceanu
 IO|sm|*aa
 IO|sn|*aa
-IO|so|Dhul xadeedka Badweynta Hindiya ee Biritishka
+IO|so|Dhul xadeedka Badweynta Hindiya ee Ingiriiska
 IO|sq|Territori Britanik i Oqeanit Indian
 IO|sr|Британска територија Индијског океана
 IO|ss|*aa
 IO|st|*aa
 IO|su|*aa
 IO|sv|Brittiska territoriet i Indiska oceanen
-IO|sw|*ki
+IO|sw|Eneo la Uingereza katika Bahari Hindi
 IO|ta|பிரிட்டிஷ் இந்தியப் பெருங்கடல் பிரதேசம்
 IO|te|బ్రిటిష్ హిందూ మహాసముద్ర ప్రాంతం
 IO|tg|Қаламрави Британия дар уқёнуси Ҳинд
 IO|th|บริติชอินเดียนโอเชียนเทร์ริทอรี
-IO|ti|ናይ ብሪጣኒያ ህንዲ ውቅያኖስ ግዝኣት
+IO|ti|ብሪጣንያዊ ህንዳዊ ውቅያኖስ ግዝኣት
 IO|tk|Britaniýanyň Hindi okeanyndaky territoriýalary
 IO|tl|*aa
 IO|tn|*aa
@@ -19918,8 +19918,8 @@ IO|ts|*aa
 IO|tt|Британиянең Һинд Океанындагы Территориясе
 IO|tw|*aa
 IO|ty|*aa
-IO|ug|ئەنگلىيەگە قاراشلىق ھىندى ئوكيان تېررىتورىيەسى
-IO|uk|Британська територія в Індійському Океані
+IO|ug|*aa
+IO|uk|Британська територія в Індійському океані
 IO|ur|برطانوی بحر ہند کا علاقہ
 IO|uz|Britaniyaning Hind okeanidagi hududi
 IO|ve|*aa
@@ -19927,7 +19927,7 @@ IO|vi|Lãnh thổ Ấn Độ Dương thuộc Anh
 IO|vo|*aa
 IO|wa|*aa
 IO|wo|Terituwaaru Brëtaañ ci Oseyaa Enjeŋ
-IO|xh|*aa
+IO|xh|EBritish Indian Ocean Territory
 IO|yi|*aa
 IO|yo|Etíkun Índíánì ti Ìlú Bírítísì
 IO|za|*aa
@@ -19962,7 +19962,7 @@ IQ|co|*aa
 IQ|cr|*aa
 IQ|cs|Irák
 IQ|cu|*aa
-IQ|cv|*aa
+IQ|cv|*bg
 IQ|cy|Irac
 IQ|da|*af
 IQ|de|*af
@@ -19993,7 +19993,7 @@ IQ|he|עיראק
 IQ|hi|इराक
 IQ|ho|*aa
 IQ|hr|*af
-IQ|ht|*aa
+IQ|ht|*af
 IQ|hu|*af
 IQ|hy|Իրաք
 IQ|hz|*aa
@@ -20023,7 +20023,7 @@ IQ|kn|ಇರಾಕ್
 IQ|ko|이라크
 IQ|kr|*aa
 IQ|ks|ایٖراق
-IQ|ku|*aa
+IQ|ku|Îraq
 IQ|kv|*aa
 IQ|kw|*aa
 IQ|ky|*bg
@@ -20038,7 +20038,7 @@ IQ|lu|*bm
 IQ|lv|Irāka
 IQ|mg|*af
 IQ|mh|*aa
-IQ|mi|*aa
+IQ|mi|*lv
 IQ|mk|*bg
 IQ|ml|ഇറാഖ്
 IQ|mn|*bg
@@ -20060,7 +20060,7 @@ IQ|nv|*aa
 IQ|ny|*aa
 IQ|oc|*aa
 IQ|oj|*aa
-IQ|om|*aa
+IQ|om|Iraaq
 IQ|or|ଇରାକ୍
 IQ|os|*aa
 IQ|pa|ਇਰਾਕ
@@ -20096,7 +20096,7 @@ IQ|ta|ஈராக்
 IQ|te|ఇరాక్
 IQ|tg|Ироқ
 IQ|th|อิรัก
-IQ|ti|*am
+IQ|ti|ዒራቕ
 IQ|tk|Yrak
 IQ|tl|*aa
 IQ|tn|*aa
@@ -20115,7 +20115,7 @@ IQ|vi|*aa
 IQ|vo|*aa
 IQ|wa|*aa
 IQ|wo|Irag
-IQ|xh|*aa
+IQ|xh|E-Iraq
 IQ|yi|*aa
 IQ|yo|*bm
 IQ|za|*aa
@@ -20150,7 +20150,7 @@ IR|co|*aa
 IR|cr|*aa
 IR|cs|Írán
 IR|cu|*aa
-IR|cv|*aa
+IR|cv|*bg
 IR|cy|*aa
 IR|da|*aa
 IR|de|*aa
@@ -20226,7 +20226,7 @@ IR|lu|Ira
 IR|lv|Irāna
 IR|mg|*aa
 IR|mh|*aa
-IR|mi|*aa
+IR|mi|*lv
 IR|mk|*bg
 IR|ml|ഇറാൻ
 IR|mn|*bg
@@ -20248,7 +20248,7 @@ IR|nv|*aa
 IR|ny|*aa
 IR|oc|*aa
 IR|oj|*aa
-IR|om|*aa
+IR|om|*et
 IR|or|ଇରାନ
 IR|os|*aa
 IR|pa|ਈਰਾਨ
@@ -20263,7 +20263,7 @@ IR|ro|*aa
 IR|ru|*bg
 IR|rw|*aa
 IR|sa|*aa
-IR|sc|*aa
+IR|sc|Iràn
 IR|sd|*ps
 IR|se|*aa
 IR|sg|Iräan
@@ -20303,7 +20303,7 @@ IR|vi|*aa
 IR|vo|*aa
 IR|wa|*aa
 IR|wo|*bm
-IR|xh|*aa
+IR|xh|E-Iran
 IR|yi|*ji
 IR|yo|*rn
 IR|za|*aa
@@ -20338,7 +20338,7 @@ IS|co|*aa
 IS|cr|*aa
 IS|cs|*br
 IS|cu|*aa
-IS|cv|*aa
+IS|cv|*ce
 IS|cy|Gwlad yr Iâ
 IS|da|*br
 IS|de|*br
@@ -20369,13 +20369,13 @@ IS|he|איסלנד
 IS|hi|आइसलैंड
 IS|ho|*aa
 IS|hr|*br
-IS|ht|*aa
+IS|ht|*fr
 IS|hu|Izland
 IS|hy|Իսլանդիա
 IS|hz|*aa
 IS|ia|Islanda
 IS|id|*es
-IS|ie|*aa
+IS|ie|*br
 IS|ig|*aa
 IS|ii|*aa
 IS|ik|*aa
@@ -20399,7 +20399,7 @@ IS|kn|ಐಸ್‌ಲ್ಯಾಂಡ್
 IS|ko|아이슬란드
 IS|kr|*aa
 IS|ks|اَیِسلینڑ
-IS|ku|Îslenda
+IS|ku|Îslanda
 IS|kv|*aa
 IS|kw|*aa
 IS|ky|*bg
@@ -20414,14 +20414,14 @@ IS|lu|Isilande
 IS|lv|*fr
 IS|mg|Islandy
 IS|mh|*aa
-IS|mi|*aa
+IS|mi|Tiorangi
 IS|mk|Исланд
 IS|ml|ഐസ്‌ലാന്റ്
 IS|mn|*mk
 IS|mo|*ia
 IS|mr|आइसलँड
 IS|ms|*aa
-IS|mt|l-iżlanda
+IS|mt|l-Iżlanda
 IS|my|အိုက်စလန်
 IS|na|*aa
 IS|nb|*br
@@ -20436,7 +20436,7 @@ IS|nv|*aa
 IS|ny|*aa
 IS|oc|*aa
 IS|oj|*aa
-IS|om|*aa
+IS|om|Ayeslaand
 IS|or|ଆଇସଲ୍ୟାଣ୍ଡ
 IS|os|*aa
 IS|pa|ਆਈਸਲੈਂਡ
@@ -20451,7 +20451,7 @@ IS|ro|*ia
 IS|ru|*bg
 IS|rw|*aa
 IS|sa|*aa
-IS|sc|*aa
+IS|sc|*ia
 IS|sd|آئس لينڊ
 IS|se|Islánda
 IS|sg|Islânde
@@ -20472,7 +20472,7 @@ IS|ta|ஐஸ்லாந்து
 IS|te|ఐస్లాండ్
 IS|tg|*bg
 IS|th|ไอซ์แลนด์
-IS|ti|ኣየርላንድ
+IS|ti|ኣይስላንድ
 IS|tk|Islandiýa
 IS|tl|*aa
 IS|tn|*aa
@@ -20491,7 +20491,7 @@ IS|vi|*aa
 IS|vo|*aa
 IS|wa|*aa
 IS|wo|Islànd
-IS|xh|*aa
+IS|xh|E-Iceland
 IS|yi|*ji
 IS|yo|Aṣilandi
 IS|za|*aa
@@ -20526,7 +20526,7 @@ IT|co|*aa
 IT|cr|*aa
 IT|cs|Itálie
 IT|cu|*aa
-IT|cv|*aa
+IT|cv|*ce
 IT|cy|Yr Eidal
 IT|da|Italien
 IT|de|*da
@@ -20557,13 +20557,13 @@ IT|he|איטליה
 IT|hi|इटली
 IT|ho|*aa
 IT|hr|*bs
-IT|ht|*aa
+IT|ht|*fr
 IT|hu|Olaszország
 IT|hy|Իտալիա
 IT|hz|*aa
 IT|ia|*br
 IT|id|*br
-IT|ie|*aa
+IT|ie|*br
 IT|ig|*aa
 IT|ii|ꑴꄊꆺ
 IT|ik|*aa
@@ -20624,7 +20624,7 @@ IT|nv|*aa
 IT|ny|*aa
 IT|oc|*aa
 IT|oj|*aa
-IT|om|*aa
+IT|om|Xaaliyaan
 IT|or|ଇଟାଲୀ
 IT|os|*ce
 IT|pa|ਇਟਲੀ
@@ -20639,7 +20639,7 @@ IT|ro|*br
 IT|ru|*bg
 IT|rw|*aa
 IT|sa|इटली:
-IT|sc|*aa
+IT|sc|*ca
 IT|sd|اٽلي
 IT|se|*pt
 IT|sg|Italùii
@@ -20660,7 +20660,7 @@ IT|ta|இத்தாலி
 IT|te|ఇటలీ
 IT|tg|*bg
 IT|th|อิตาลี
-IT|ti|*am
+IT|ti|ኢጣልያ
 IT|tk|Italiýa
 IT|tl|*aa
 IT|tn|*aa
@@ -20679,7 +20679,7 @@ IT|vi|*aa
 IT|vo|*aa
 IT|wa|*aa
 IT|wo|*ak
-IT|xh|*aa
+IT|xh|E-Italy
 IT|yi|*ji
 IT|yo|Itáli
 IT|za|*aa
@@ -20689,8 +20689,8 @@ JE|aa|Jersey
 JE|ab|*aa
 JE|ae|*aa
 JE|af|*aa
-JE|ak|*aa
-JE|am|ጀርሲ
+JE|ak|Gyɛsi
+JE|am|ጀርዚ
 JE|an|*aa
 JE|ar|جيرسي
 JE|as|জাৰ্চি
@@ -20714,7 +20714,7 @@ JE|co|*aa
 JE|cr|*aa
 JE|cs|*aa
 JE|cu|*aa
-JE|cv|*aa
+JE|cv|*ce
 JE|cy|*aa
 JE|da|*aa
 JE|de|*aa
@@ -20790,7 +20790,7 @@ JE|lu|*aa
 JE|lv|Džērsija
 JE|mg|*aa
 JE|mh|*aa
-JE|mi|*aa
+JE|mi|Tōrehe
 JE|mk|Џерси
 JE|ml|ജേഴ്സി
 JE|mn|*ky
@@ -20812,7 +20812,7 @@ JE|nv|*aa
 JE|ny|*aa
 JE|oc|*aa
 JE|oj|*aa
-JE|om|*aa
+JE|om|Jeersii
 JE|or|ଜର୍ସି
 JE|os|*aa
 JE|pa|ਜਰਸੀ
@@ -20867,9 +20867,9 @@ JE|vi|*aa
 JE|vo|*aa
 JE|wa|*aa
 JE|wo|Serse
-JE|xh|*aa
+JE|xh|EJersey
 JE|yi|*ji
-JE|yo|*aa
+JE|yo|Jẹsì
 JE|za|*aa
 JE|zh|泽西岛
 JE|zu|i-Jersey
@@ -20902,7 +20902,7 @@ JM|co|*aa
 JM|cr|*aa
 JM|cs|*bs
 JM|cu|*aa
-JM|cv|*aa
+JM|cv|*be
 JM|cy|*aa
 JM|da|*aa
 JM|de|*af
@@ -20933,7 +20933,7 @@ JM|he|ג׳מייקה
 JM|hi|जमैका
 JM|ho|*aa
 JM|hr|*bs
-JM|ht|*aa
+JM|ht|*fr
 JM|hu|*aa
 JM|hy|Ճամայկա
 JM|hz|*aa
@@ -20978,7 +20978,7 @@ JM|lu|Jamaiki
 JM|lv|*af
 JM|mg|Jamaïka
 JM|mh|*aa
-JM|mi|*aa
+JM|mi|Hemeika
 JM|mk|Јамајка
 JM|ml|ജമൈക്ക
 JM|mn|*be
@@ -21000,7 +21000,7 @@ JM|nv|*aa
 JM|ny|*aa
 JM|oc|*aa
 JM|oj|*aa
-JM|om|*aa
+JM|om|Jamaayikaa
 JM|or|ଜାମାଇକା
 JM|os|*aa
 JM|pa|ਜਮਾਇਕਾ
@@ -21015,7 +21015,7 @@ JM|ro|*aa
 JM|ru|*be
 JM|rw|*aa
 JM|sa|*aa
-JM|sc|*aa
+JM|sc|Giamàica
 JM|sd|جميڪا
 JM|se|*aa
 JM|sg|Zamaîka
@@ -21055,7 +21055,7 @@ JM|vi|*aa
 JM|vo|*aa
 JM|wa|*aa
 JM|wo|Samayig
-JM|xh|*aa
+JM|xh|EJamaica
 JM|yi|*ji
 JM|yo|*af
 JM|za|*aa
@@ -21090,7 +21090,7 @@ JO|co|*aa
 JO|cr|*aa
 JO|cs|Jordánsko
 JO|cu|*aa
-JO|cv|*aa
+JO|cv|Иордани
 JO|cy|Gwlad Iorddonen
 JO|da|*aa
 JO|de|Jordanien
@@ -21121,7 +21121,7 @@ JO|he|ירדן
 JO|hi|जॉर्डन
 JO|ho|*aa
 JO|hr|*aa
-JO|ht|*aa
+JO|ht|*fr
 JO|hu|Jordánia
 JO|hy|Հորդանան
 JO|hz|*aa
@@ -21150,7 +21150,7 @@ JO|km|ហ៊្សកដានី
 JO|kn|ಜೋರ್ಡಾನ್
 JO|ko|요르단
 JO|kr|*aa
-JO|ks|*aa
+JO|ks|جورڈن
 JO|ku|Urdun
 JO|kv|*aa
 JO|kw|*aa
@@ -21166,7 +21166,7 @@ JO|lu|Jodani
 JO|lv|Jordānija
 JO|mg|*br
 JO|mh|*aa
-JO|mi|*aa
+JO|mi|Hōrano
 JO|mk|Јордан
 JO|ml|ജോർദ്ദാൻ
 JO|mn|Йордан
@@ -21188,7 +21188,7 @@ JO|nv|*aa
 JO|ny|*aa
 JO|oc|*aa
 JO|oj|*aa
-JO|om|*aa
+JO|om|Jirdaan
 JO|or|ଜୋର୍ଡାନ୍
 JO|os|*aa
 JO|pa|ਜਾਰਡਨ
@@ -21203,7 +21203,7 @@ JO|ro|*mo
 JO|ru|*kk
 JO|rw|*aa
 JO|sa|*aa
-JO|sc|*aa
+JO|sc|Giordània
 JO|sd|*fa
 JO|se|*hu
 JO|sg|Zordanïi
@@ -21224,7 +21224,7 @@ JO|ta|ஜோர்டான்
 JO|te|జోర్డాన్
 JO|tg|Урдун
 JO|th|จอร์แดน
-JO|ti|*am
+JO|ti|ዮርዳኖስ
 JO|tk|Iordaniýa
 JO|tl|*aa
 JO|tn|*aa
@@ -21243,7 +21243,7 @@ JO|vi|*aa
 JO|vo|*aa
 JO|wa|*aa
 JO|wo|Sordani
-JO|xh|*aa
+JO|xh|EJordan
 JO|yi|*aa
 JO|yo|Jọdani
 JO|za|*aa
@@ -21278,7 +21278,7 @@ JP|co|*aa
 JP|cr|*aa
 JP|cs|Japonsko
 JP|cu|*aa
-JP|cv|*aa
+JP|cv|*ce
 JP|cy|*aa
 JP|da|*aa
 JP|de|*aa
@@ -21300,7 +21300,7 @@ JP|fr|Japon
 JP|fy|*aa
 JP|ga|an tSeapáin
 JP|gd|An t-Seapan
-JP|gl|O Xapón
+JP|gl|Xapón
 JP|gn|*aa
 JP|gu|જાપાન
 JP|gv|*aa
@@ -21309,7 +21309,7 @@ JP|he|יפן
 JP|hi|जापान
 JP|ho|*aa
 JP|hr|*aa
-JP|ht|*aa
+JP|ht|*fr
 JP|hu|Japán
 JP|hy|Ճապոնիա
 JP|hz|*aa
@@ -21339,10 +21339,10 @@ JP|kn|ಜಪಾನ್
 JP|ko|일본
 JP|kr|*aa
 JP|ks|جاپان
-JP|ku|*fr
+JP|ku|Japonya
 JP|kv|*aa
 JP|kw|*aa
-JP|ky|*bg
+JP|ky|*kk
 JP|la|*aa
 JP|lb|*aa
 JP|lg|*fi
@@ -21376,7 +21376,7 @@ JP|nv|*aa
 JP|ny|*aa
 JP|oc|*aa
 JP|oj|*aa
-JP|om|*aa
+JP|om|Jaappaan
 JP|or|ଜାପାନ
 JP|os|*mn
 JP|pa|ਜਪਾਨ
@@ -21391,7 +21391,7 @@ JP|ro|*eu
 JP|ru|*bg
 JP|rw|*aa
 JP|sa|जापन:
-JP|sc|*aa
+JP|sc|Giapone
 JP|sd|*ks
 JP|se|Japána
 JP|sg|Zapöon
@@ -21417,7 +21417,7 @@ JP|tk|Ýaponiýa
 JP|tl|*aa
 JP|tn|*aa
 JP|to|Siapani
-JP|tr|Japonya
+JP|tr|*ku
 JP|ts|*aa
 JP|tt|*bg
 JP|tw|*aa
@@ -21431,7 +21431,7 @@ JP|vi|Nhật Bản
 JP|vo|*aa
 JP|wa|*aa
 JP|wo|Sàppoŋ
-JP|xh|*aa
+JP|xh|EJapan
 JP|yi|*ji
 JP|yo|*fi
 JP|za|*aa
@@ -21441,7 +21441,7 @@ KE|aa|Kenya
 KE|ab|*aa
 KE|ae|*aa
 KE|af|Kenia
-KE|ak|Kɛnya
+KE|ak|*aa
 KE|am|ኬንያ
 KE|an|*aa
 KE|ar|كينيا
@@ -21466,7 +21466,7 @@ KE|co|*aa
 KE|cr|*aa
 KE|cs|Keňa
 KE|cu|*aa
-KE|cv|*aa
+KE|cv|*ce
 KE|cy|*aa
 KE|da|*aa
 KE|de|*af
@@ -21542,7 +21542,7 @@ KE|lu|*aa
 KE|lv|*bs
 KE|mg|*aa
 KE|mh|*aa
-KE|mi|*aa
+KE|mi|*af
 KE|mk|Кенија
 KE|ml|കെനിയ
 KE|mn|*ce
@@ -21579,7 +21579,7 @@ KE|ro|*aa
 KE|ru|*bg
 KE|rw|*aa
 KE|sa|*aa
-KE|sc|*aa
+KE|sc|Kènya
 KE|sd|ڪينيا
 KE|se|*af
 KE|sg|Kenyäa
@@ -21619,7 +21619,7 @@ KE|vi|*aa
 KE|vo|*aa
 KE|wa|*aa
 KE|wo|Keeña
-KE|xh|*aa
+KE|xh|EKenya
 KE|yi|*ji
 KE|yo|*aa
 KE|za|*aa
@@ -21647,14 +21647,14 @@ KG|bn|কিরগিজিস্তান
 KG|bo|*aa
 KG|br|*aa
 KG|bs|*af
-KG|ca|Kirguizistan
+KG|ca|Kirguizstan
 KG|ce|Киргизи
 KG|ch|*aa
 KG|co|*aa
 KG|cr|*aa
 KG|cs|Kyrgyzstán
 KG|cu|*aa
-KG|cv|*aa
+KG|cv|*ce
 KG|cy|*aa
 KG|da|Kirgisistan
 KG|de|*da
@@ -21663,7 +21663,7 @@ KG|dz|ཀིར་གིས་སཏཱན
 KG|ee|Kirgizstan nutome
 KG|el|Κιργιστάν
 KG|en|*aa
-KG|eo|Kirgizistano
+KG|eo|Kirgizujo
 KG|es|Kirguistán
 KG|et|Kõrgõzstan
 KG|eu|Kirgizistan
@@ -21685,7 +21685,7 @@ KG|he|קירגיזסטן
 KG|hi|किर्गिज़स्तान
 KG|ho|*aa
 KG|hr|*af
-KG|ht|*aa
+KG|ht|*fr
 KG|hu|Kirgizisztán
 KG|hy|Ղրղզստան
 KG|hz|*aa
@@ -21714,7 +21714,7 @@ KG|km|កៀហ្ស៊ីស៊ីស្ថាន
 KG|kn|ಕಿರ್ಗಿಸ್ಥಾನ್
 KG|ko|키르기스스탄
 KG|kr|*aa
-KG|ks|کِرگِستان
+KG|ks|کرغزستان
 KG|ku|Qirgizistan
 KG|kv|*aa
 KG|kw|*aa
@@ -21730,10 +21730,10 @@ KG|lu|Kigizisita
 KG|lv|Kirgizstāna
 KG|mg|Kiordistan
 KG|mh|*aa
-KG|mi|*aa
+KG|mi|Kikitānga
 KG|mk|Киргистан
 KG|ml|കിർഗിസ്ഥാൻ
-KG|mn|*be
+KG|mn|Киргиз
 KG|mo|Kârgâzstan
 KG|mr|किरगिझस्तान
 KG|ms|*aa
@@ -21752,7 +21752,7 @@ KG|nv|*aa
 KG|ny|*aa
 KG|oc|*aa
 KG|oj|*aa
-KG|om|*aa
+KG|om|Kiyirigiyizistan
 KG|or|କିର୍ଗିଜିସ୍ତାନ
 KG|os|*aa
 KG|pa|ਕਿਰਗਿਜ਼ਸਤਾਨ
@@ -21767,7 +21767,7 @@ KG|ro|*mo
 KG|ru|Киргизия
 KG|rw|*aa
 KG|sa|*aa
-KG|sc|*aa
+KG|sc|Kirghìzistan
 KG|sd|ڪرغستان
 KG|se|*da
 KG|sg|Kirigizitùaan
@@ -21788,7 +21788,7 @@ KG|ta|கிர்கிஸ்தான்
 KG|te|కిర్గిజిస్తాన్
 KG|tg|Қирғизистон
 KG|th|คีร์กีซสถาน
-KG|ti|ኪርጂስታን
+KG|ti|ኪርጊዝስታን
 KG|tk|Gyrgyzystan
 KG|tl|*aa
 KG|tn|*aa
@@ -21800,14 +21800,14 @@ KG|tw|*aa
 KG|ty|*aa
 KG|ug|قىرغىزىستان
 KG|uk|*bg
-KG|ur|کرغزستان
+KG|ur|*ks
 KG|uz|Qirgʻiziston
 KG|ve|*aa
 KG|vi|*aa
 KG|vo|*aa
 KG|wa|*aa
 KG|wo|Kirgistaŋ
-KG|xh|*aa
+KG|xh|EKyrgyzstan
 KG|yi|*aa
 KG|yo|Kuriṣisitani
 KG|za|*aa
@@ -21842,7 +21842,7 @@ KH|co|*aa
 KH|cr|*aa
 KH|cs|*bs
 KH|cu|*aa
-KH|cv|*aa
+KH|cv|*be
 KH|cy|*aa
 KH|da|*ca
 KH|de|Kambodscha
@@ -21873,13 +21873,13 @@ KH|he|קמבודיה
 KH|hi|कंबोडिया
 KH|ho|*aa
 KH|hr|*bs
-KH|ht|*aa
+KH|ht|*fr
 KH|hu|Kambodzsa
 KH|hy|Կամբոջա
 KH|hz|*aa
 KH|ia|Cambodgia
 KH|id|Kamboja
-KH|ie|*aa
+KH|ie|*ca
 KH|ig|*aa
 KH|ii|*aa
 KH|ik|*aa
@@ -21903,7 +21903,7 @@ KH|kn|ಕಾಂಬೋಡಿಯಾ
 KH|ko|캄보디아
 KH|kr|*aa
 KH|ks|کَمبوڑِیا
-KH|ku|*az
+KH|ku|Kamboçya
 KH|kv|*aa
 KH|kw|*aa
 KH|ky|*be
@@ -21918,7 +21918,7 @@ KH|lu|*ln
 KH|lv|*bs
 KH|mg|Kambôdja
 KH|mh|*aa
-KH|mi|*aa
+KH|mi|Kamapōtia
 KH|mk|Камбоџа
 KH|ml|കംബോഡിയ
 KH|mn|Камбож
@@ -21940,7 +21940,7 @@ KH|nv|*aa
 KH|ny|*aa
 KH|oc|*aa
 KH|oj|*aa
-KH|om|*aa
+KH|om|Kamboodiyaa
 KH|or|କାମ୍ବୋଡିଆ
 KH|os|*aa
 KH|pa|ਕੰਬੋਡੀਆ
@@ -21955,7 +21955,7 @@ KH|ro|*ia
 KH|ru|*be
 KH|rw|*aa
 KH|sa|*aa
-KH|sc|*aa
+KH|sc|Cambòdia
 KH|sd|ڪمبوڊيا
 KH|se|*bs
 KH|sg|Kämbôzi
@@ -21976,12 +21976,12 @@ KH|ta|கம்போடியா
 KH|te|కంబోడియా
 KH|tg|Камбоҷа
 KH|th|กัมพูชา
-KH|ti|*am
+KH|ti|ካምቦድያ
 KH|tk|*id
 KH|tl|*aa
 KH|tn|*aa
 KH|to|Kamipōtia
-KH|tr|Kamboçya
+KH|tr|*ku
 KH|ts|*aa
 KH|tt|*be
 KH|tw|*aa
@@ -21995,7 +21995,7 @@ KH|vi|Campuchia
 KH|vo|*aa
 KH|wa|*aa
 KH|wo|Kàmboj
-KH|xh|*aa
+KH|xh|ECambodia
 KH|yi|*ji
 KH|yo|Kàmùbódíà
 KH|za|*aa
@@ -22030,7 +22030,7 @@ KI|co|*aa
 KI|cr|*aa
 KI|cs|*aa
 KI|cu|*aa
-KI|cv|*aa
+KI|cv|*bg
 KI|cy|*aa
 KI|da|*aa
 KI|de|*aa
@@ -22050,8 +22050,8 @@ KI|fj|*aa
 KI|fo|*aa
 KI|fr|*aa
 KI|fy|*aa
-KI|ga|Cireabaití
-KI|gd|Ciribeas
+KI|ga|Ciribeas
+KI|gd|*ga
 KI|gl|*aa
 KI|gn|*aa
 KI|gu|કિરિબાટી
@@ -22106,7 +22106,7 @@ KI|lu|*aa
 KI|lv|*aa
 KI|mg|*aa
 KI|mh|*aa
-KI|mi|*aa
+KI|mi|Kiripati
 KI|mk|*bg
 KI|ml|കിരിബാട്ടി
 KI|mn|*bg
@@ -22128,7 +22128,7 @@ KI|nv|*aa
 KI|ny|*aa
 KI|oc|*aa
 KI|oj|*aa
-KI|om|*aa
+KI|om|Kiribaatii
 KI|or|କିରିବାଟି
 KI|os|*aa
 KI|pa|ਕਿਰਬਾਤੀ
@@ -22183,7 +22183,7 @@ KI|vi|*aa
 KI|vo|*aa
 KI|wa|*aa
 KI|wo|*aa
-KI|xh|*aa
+KI|xh|EKiribati
 KI|yi|*ji
 KI|yo|*aa
 KI|za|*aa
@@ -22218,7 +22218,7 @@ KM|co|*aa
 KM|cr|*aa
 KM|cs|Komory
 KM|cu|*aa
-KM|cv|*aa
+KM|cv|Комор утравӗсем
 KM|cy|*aa
 KM|da|Comorerne
 KM|de|Komoren
@@ -22249,14 +22249,14 @@ KM|he|קומורו
 KM|hi|कोमोरोस
 KM|ho|*aa
 KM|hr|*bs
-KM|ht|*aa
+KM|ht|*ca
 KM|hu|Comore-szigetek
 KM|hy|Կոմորյան կղզիներ
 KM|hz|*aa
 KM|ia|*aa
 KM|id|Komoro
 KM|ie|*aa
-KM|ig|Comorosu
+KM|ig|*aa
 KM|ii|*aa
 KM|ik|*aa
 KM|in|*id
@@ -22294,7 +22294,7 @@ KM|lu|Komoru
 KM|lv|Komoru salas
 KM|mg|Kômaoro
 KM|mh|*aa
-KM|mi|*aa
+KM|mi|*id
 KM|mk|Коморски Острови
 KM|ml|കോമൊറോസ്
 KM|mn|Коморын арлууд
@@ -22316,7 +22316,7 @@ KM|nv|*aa
 KM|ny|*aa
 KM|oc|*aa
 KM|oj|*aa
-KM|om|*aa
+KM|om|Komoroos
 KM|or|କୋମୋରସ୍
 KM|os|*aa
 KM|pa|ਕੋਮੋਰੋਸ
@@ -22331,7 +22331,7 @@ KM|ro|*af
 KM|ru|Коморы
 KM|rw|*aa
 KM|sa|*aa
-KM|sc|*aa
+KM|sc|*es
 KM|sd|ڪوموروس
 KM|se|Komoros
 KM|sg|Kömôro
@@ -22371,7 +22371,7 @@ KM|vi|*aa
 KM|vo|*aa
 KM|wa|*aa
 KM|wo|*ff
-KM|xh|*aa
+KM|xh|EComoros
 KM|yi|*ji
 KM|yo|Kòmòrósì
 KM|za|*aa
@@ -22399,14 +22399,14 @@ KN|bn|সেন্ট কিটস ও নেভিস
 KN|bo|*aa
 KN|br|Saint Kitts ha Nevis
 KN|bs|Sveti Kits i Nevis
-KN|ca|Saint Christopher i Nevis
+KN|ca|Saint Kitts i Nevis
 KN|ce|Сент-Китс а, Невис а
 KN|ch|*aa
 KN|co|*aa
 KN|cr|*aa
 KN|cs|Svatý Kryštof a Nevis
 KN|cu|*aa
-KN|cv|*aa
+KN|cv|Сент-Китс тата Невис
 KN|cy|Saint Kitts a Nevis
 KN|da|Saint Kitts og Nevis
 KN|de|St. Kitts und Nevis
@@ -22415,7 +22415,7 @@ KN|dz|སེནཊ་ ཀིཊས་ དང་ ནེ་བིས
 KN|ee|Saint Kitis kple Nevis nutome
 KN|el|Σεν Κιτς και Νέβις
 KN|en|*aa
-KN|eo|Sent-Kristofo kaj Neviso
+KN|eo|Sankta Kristoforo kaj Neviso
 KN|es|San Cristóbal y Nieves
 KN|et|Saint Kitts ja Nevis
 KN|eu|Saint Kitts eta Nevis
@@ -22437,14 +22437,14 @@ KN|he|סנט קיטס ונוויס
 KN|hi|सेंट किट्स और नेविस
 KN|ho|*aa
 KN|hr|Sveti Kristofor i Nevis
-KN|ht|*aa
+KN|ht|*fr
 KN|hu|Saint Kitts és Nevis
 KN|hy|Սենթ Քիտս և Նևիս
 KN|hz|*aa
 KN|ia|Sancte Christophoro e Nevis
 KN|id|Saint Kitts dan Nevis
 KN|ie|*aa
-KN|ig|Kitts na Nevis Dị nsọ
+KN|ig|*aa
 KN|ii|*aa
 KN|ik|*aa
 KN|in|*id
@@ -22482,7 +22482,7 @@ KN|lu|Santu krístofe ne Neves
 KN|lv|Sentkitsa un Nevisa
 KN|mg|*fr
 KN|mh|*aa
-KN|mi|*aa
+KN|mi|Hato Kiti me Newhi
 KN|mk|Свети Китс и Невис
 KN|ml|സെന്റ് കിറ്റ്‌സും നെവിസും
 KN|mn|Сент-Киттс ба Невис
@@ -22504,12 +22504,12 @@ KN|nv|*aa
 KN|ny|*aa
 KN|oc|*aa
 KN|oj|*aa
-KN|om|*aa
+KN|om|St. Kiitis fi Neevis
 KN|or|ସେଣ୍ଟ କିଟସ୍‌ ଏବଂ ନେଭିସ୍‌
 KN|os|*aa
 KN|pa|ਸੇਂਟ ਕਿਟਸ ਐਂਡ ਨੇਵਿਸ
 KN|pi|*aa
-KN|pl|Saint Kitts i Nevis
+KN|pl|*ca
 KN|ps|سینټ کټس او نیویس
 KN|pt|São Cristóvão e Névis
 KN|qu|*es
@@ -22519,7 +22519,7 @@ KN|ro|*mo
 KN|ru|Сент-Китс и Невис
 KN|rw|*aa
 KN|sa|*aa
-KN|sc|*aa
+KN|sc|Santu Cristolu e Nevis
 KN|sd|سينٽ ڪٽس و نيوس
 KN|se|*et
 KN|sg|Sên-Krïstôfo-na-Nevîsi
@@ -22528,7 +22528,7 @@ KN|sk|Svätý Krištof a Nevis
 KN|sl|Saint Kitts in Nevis
 KN|sm|*aa
 KN|sn|*nd
-KN|so|St. Kitts & Nefis
+KN|so|St. Kitts iyo Nevis
 KN|sq|Shën-Kits dhe Nevis
 KN|sr|Сент Китс и Невис
 KN|ss|*aa
@@ -22559,7 +22559,7 @@ KN|vi|St. Kitts và Nevis
 KN|vo|*aa
 KN|wa|*aa
 KN|wo|Saŋ Kits ak Newis
-KN|xh|*aa
+KN|xh|ESt. Kitts & Nevis
 KN|yi|*aa
 KN|yo|Kiiti ati Neefi
 KN|za|*aa
@@ -22569,7 +22569,7 @@ KP|aa|North Korea
 KP|ab|*aa
 KP|ae|*aa
 KP|af|Noord-Korea
-KP|ak|Etifi Koria
+KP|ak|Korea Atifi
 KP|am|ሰሜን ኮሪያ
 KP|an|*aa
 KP|ar|كوريا الشمالية
@@ -22594,7 +22594,7 @@ KP|co|*aa
 KP|cr|*aa
 KP|cs|Severní Korea
 KP|cu|*aa
-KP|cv|*aa
+KP|cv|КХДР
 KP|cy|Gogledd Corea
 KP|da|Nordkorea
 KP|de|*da
@@ -22625,14 +22625,14 @@ KP|he|קוריאה הצפונית
 KP|hi|उत्तर कोरिया
 KP|ho|*aa
 KP|hr|*bs
-KP|ht|*aa
+KP|ht|*fr
 KP|hu|Észak-Korea
 KP|hy|Հյուսիսային Կորեա
 KP|hz|*aa
 KP|ia|*ca
 KP|id|Korea Utara
 KP|ie|*aa
-KP|ig|Ugwu Korea
+KP|ig|*aa
 KP|ii|*aa
 KP|ik|*aa
 KP|in|*id
@@ -22655,7 +22655,7 @@ KP|kn|ಉತ್ತರ ಕೊರಿಯಾ
 KP|ko|북한
 KP|kr|*aa
 KP|ks|شُمٲلی کورِیا
-KP|ku|Korêya Bakur
+KP|ku|Koreya Bakur
 KP|kv|*aa
 KP|kw|*aa
 KP|ky|Түндүк Корея
@@ -22670,7 +22670,7 @@ KP|lu|Kore wa muulu
 KP|lv|Ziemeļkoreja
 KP|mg|Korea Avaratra
 KP|mh|*aa
-KP|mi|*aa
+KP|mi|Kōrea ki te Raki
 KP|mk|Северна Кореја
 KP|ml|ഉത്തരകൊറിയ
 KP|mn|Хойд Солонгос
@@ -22692,7 +22692,7 @@ KP|nv|*aa
 KP|ny|*aa
 KP|oc|*aa
 KP|oj|*aa
-KP|om|*aa
+KP|om|Kooriyaa Kaaba
 KP|or|ଉତ୍ତର କୋରିଆ
 KP|os|*aa
 KP|pa|ਉੱਤਰ ਕੋਰੀਆ
@@ -22707,7 +22707,7 @@ KP|ro|*mo
 KP|ru|КНДР
 KP|rw|*aa
 KP|sa|*aa
-KP|sc|*aa
+KP|sc|Corea de su Nord
 KP|sd|اتر ڪوريا
 KP|se|Davvi-Korea
 KP|sg|Korëe tî Banga
@@ -22728,7 +22728,7 @@ KP|ta|வட கொரியா
 KP|te|ఉత్తర కొరియా
 KP|tg|Кореяи Шимолӣ
 KP|th|เกาหลีเหนือ
-KP|ti|*am
+KP|ti|ሰሜን ኮርያ
 KP|tk|Demirgazyk Koreýa
 KP|tl|Hilagang Korea
 KP|tn|*aa
@@ -22747,7 +22747,7 @@ KP|vi|Triều Tiên
 KP|vo|*aa
 KP|wa|*aa
 KP|wo|Kore Noor
-KP|xh|*aa
+KP|xh|EMntla Korea
 KP|yi|*aa
 KP|yo|Guusu Kọria
 KP|za|*aa
@@ -22757,7 +22757,7 @@ KR|aa|South Korea
 KR|ab|*aa
 KR|ae|*aa
 KR|af|Suid-Korea
-KR|ak|Anaafo Koria
+KR|ak|Korea Anaafoɔ
 KR|am|ደቡብ ኮሪያ
 KR|an|*aa
 KR|ar|كوريا الجنوبية
@@ -22782,7 +22782,7 @@ KR|co|*aa
 KR|cr|*aa
 KR|cs|Jižní Korea
 KR|cu|*aa
-KR|cv|*aa
+KR|cv|Корей Республики
 KR|cy|De Corea
 KR|da|Sydkorea
 KR|de|Südkorea
@@ -22813,7 +22813,7 @@ KR|he|קוריאה הדרומית
 KR|hi|दक्षिण कोरिया
 KR|ho|*aa
 KR|hr|*bs
-KR|ht|*aa
+KR|ht|*fr
 KR|hu|Dél-Korea
 KR|hy|Հարավային Կորեա
 KR|hz|*aa
@@ -22843,7 +22843,7 @@ KR|kn|ದಕ್ಷಿಣ ಕೊರಿಯಾ
 KR|ko|대한민국
 KR|kr|*aa
 KR|ks|جنوٗبی کورِیا
-KR|ku|Korêya Başûr
+KR|ku|Koreya Başûr
 KR|kv|*aa
 KR|kw|*aa
 KR|ky|Түштүк Корея
@@ -22858,7 +22858,7 @@ KR|lu|Kore wa mwinshi
 KR|lv|Dienvidkoreja
 KR|mg|Korea Atsimo
 KR|mh|*aa
-KR|mi|*aa
+KR|mi|Kōrea ki te Tonga
 KR|mk|Јужна Кореја
 KR|ml|ദക്ഷിണകൊറിയ
 KR|mn|Өмнөд Солонгос
@@ -22880,7 +22880,7 @@ KR|nv|*aa
 KR|ny|*aa
 KR|oc|*aa
 KR|oj|*aa
-KR|om|*aa
+KR|om|Kooriyaa Kibbaa
 KR|or|ଦକ୍ଷିଣ କୋରିଆ
 KR|os|*aa
 KR|pa|ਦੱਖਣ ਕੋਰੀਆ
@@ -22895,7 +22895,7 @@ KR|ro|*mo
 KR|ru|Республика Корея
 KR|rw|*aa
 KR|sa|*aa
-KR|sc|*aa
+KR|sc|Corea de su Sud
 KR|sd|ڏکڻ ڪوريا
 KR|se|Mátta-Korea
 KR|sg|Korëe tî Mbongo
@@ -22914,16 +22914,16 @@ KR|sv|*da
 KR|sw|*ki
 KR|ta|தென் கொரியா
 KR|te|దక్షిణ కొరియా
-KR|tg|*aa
+KR|tg|Кореяи Ҷанубӣ
 KR|th|เกาหลีใต้
-KR|ti|*am
+KR|ti|ደቡብ ኮርያ
 KR|tk|Günorta Koreýa
 KR|tl|Timog Korea
 KR|tn|*aa
 KR|to|Kōlea tonga
 KR|tr|Güney Kore
 KR|ts|*aa
-KR|tt|*aa
+KR|tt|Көньяк Корея
 KR|tw|*aa
 KR|ty|*aa
 KR|ug|كورېيە
@@ -22934,8 +22934,8 @@ KR|ve|*aa
 KR|vi|Hàn Quốc
 KR|vo|*aa
 KR|wa|*aa
-KR|wo|*aa
-KR|xh|*aa
+KR|wo|*fr
+KR|xh|EMzantsi Korea
 KR|yi|*aa
 KR|yo|Ariwa Kọria
 KR|za|*aa
@@ -22945,8 +22945,8 @@ KW|aa|Kuwait
 KW|ab|*aa
 KW|ae|*aa
 KW|af|Koeweit
-KW|ak|Kuwete
-KW|am|ክዌት
+KW|ak|Kuweti
+KW|am|ኩዌት
 KW|an|*aa
 KW|ar|الكويت
 KW|as|কুৱেইট
@@ -22970,7 +22970,7 @@ KW|co|*aa
 KW|cr|*aa
 KW|cs|*bs
 KW|cu|*aa
-KW|cv|*aa
+KW|cv|*be
 KW|cy|*aa
 KW|da|*aa
 KW|de|*aa
@@ -22996,12 +22996,12 @@ KW|gl|*aa
 KW|gn|*aa
 KW|gu|કુવૈત
 KW|gv|*aa
-KW|ha|Kwiyat
+KW|ha|Kuwet
 KW|he|כווית
 KW|hi|कुवैत
 KW|ho|*aa
 KW|hr|*bs
-KW|ht|*aa
+KW|ht|*fr
 KW|hu|*fo
 KW|hy|Քուվեյթ
 KW|hz|*aa
@@ -23037,7 +23037,7 @@ KW|kw|*aa
 KW|ky|*be
 KW|la|*aa
 KW|lb|*aa
-KW|lg|Kuweti
+KW|lg|*ak
 KW|li|*aa
 KW|ln|Koweti
 KW|lo|ກູເວດ
@@ -23046,7 +23046,7 @@ KW|lu|*ln
 KW|lv|Kuveita
 KW|mg|Kôeity
 KW|mh|*aa
-KW|mi|*aa
+KW|mi|Kūweiti
 KW|mk|Кувајт
 KW|ml|കുവൈറ്റ്
 KW|mn|*be
@@ -23068,7 +23068,7 @@ KW|nv|*aa
 KW|ny|*aa
 KW|oc|*aa
 KW|oj|*aa
-KW|om|*aa
+KW|om|Kuweet
 KW|or|କୁଏତ୍
 KW|os|*aa
 KW|pa|ਕੁਵੈਤ
@@ -23123,9 +23123,9 @@ KW|vi|*aa
 KW|vo|*aa
 KW|wa|*aa
 KW|wo|Kowet
-KW|xh|*aa
+KW|xh|EKuwait
 KW|yi|*aa
-KW|yo|*lg
+KW|yo|*ak
 KW|za|*aa
 KW|zh|科威特
 KW|zu|i-Kuwait
@@ -23158,7 +23158,7 @@ KY|co|*aa
 KY|cr|*aa
 KY|cs|Kajmanské ostrovy
 KY|cu|*aa
-KY|cv|*aa
+KY|cv|Кайман утравӗсем
 KY|cy|Ynysoedd Cayman
 KY|da|Caymanøerne
 KY|de|Kaimaninseln
@@ -23188,15 +23188,15 @@ KY|ha|Tsibiran Kaiman
 KY|he|איי קיימן
 KY|hi|कैमेन द्वीपसमूह
 KY|ho|*aa
-KY|hr|Kajmanski otoci
-KY|ht|*aa
+KY|hr|Kajmanski Otoci
+KY|ht|*fr
 KY|hu|Kajmán-szigetek
 KY|hy|Կայմանյան կղզիներ
 KY|hz|*aa
 KY|ia|Insulas de Caiman
 KY|id|Kepulauan Cayman
 KY|ie|*aa
-KY|ig|Agwaetiti Cayman
+KY|ig|*aa
 KY|ii|*aa
 KY|ik|*aa
 KY|in|*id
@@ -23234,7 +23234,7 @@ KY|lu|Lutanda lua Kayima
 KY|lv|Kaimanu salas
 KY|mg|Nosy Kayman
 KY|mh|*aa
-KY|mi|*aa
+KY|mi|Ngā Motu Keimana
 KY|mk|Кајмански Острови
 KY|ml|കേയ്മാൻ ദ്വീപുകൾ
 KY|mn|Кайманы арлууд
@@ -23256,7 +23256,7 @@ KY|nv|*aa
 KY|ny|*aa
 KY|oc|*aa
 KY|oj|*aa
-KY|om|*aa
+KY|om|Odoloota Saaymaan
 KY|or|କେମ୍ୟାନ୍‌ ଦ୍ୱୀପପୁଞ୍ଜ
 KY|os|*aa
 KY|pa|ਕੇਮੈਨ ਟਾਪੂ
@@ -23268,10 +23268,10 @@ KY|qu|*es
 KY|rm|Inslas Cayman
 KY|rn|Ibirwa bya Keyimani
 KY|ro|*mo
-KY|ru|Острова Кайман
+KY|ru|о-ва Кайман
 KY|rw|*aa
 KY|sa|*aa
-KY|sc|*aa
+KY|sc|Ìsulas Cayman
 KY|sd|ڪي مين ٻيٽ
 KY|se|Cayman-sullot
 KY|sg|Âzûâ Ngundë, Kaimäni
@@ -23292,7 +23292,7 @@ KY|ta|கெய்மென் தீவுகள்
 KY|te|కేమాన్ దీవులు
 KY|tg|Ҷазираҳои Кайман
 KY|th|หมู่เกาะเคย์แมน
-KY|ti|ደሴታት ኬይማን
+KY|ti|ደሴታት ካይማን
 KY|tk|Kaýman adalary
 KY|tl|*aa
 KY|tn|*aa
@@ -23311,7 +23311,7 @@ KY|vi|Quần đảo Cayman
 KY|vo|*aa
 KY|wa|*aa
 KY|wo|Duni Kaymaŋ
-KY|xh|*aa
+KY|xh|ECayman Islands
 KY|yi|*ji
 KY|yo|Etíokun Kámánì
 KY|za|*aa
@@ -23346,7 +23346,7 @@ KZ|co|*aa
 KZ|cr|*aa
 KZ|cs|Kazachstán
 KZ|cu|*aa
-KZ|cv|*aa
+KZ|cv|*be
 KZ|cy|*aa
 KZ|da|Kasakhstan
 KZ|de|Kasachstan
@@ -23355,7 +23355,7 @@ KZ|dz|ཀ་ཛགས་སཏཱན
 KZ|ee|Kazakstan nutome
 KZ|el|Καζακστάν
 KZ|en|*aa
-KZ|eo|Kazaĥstano
+KZ|eo|Kazaĥujo
 KZ|es|Kazajistán
 KZ|et|Kasahstan
 KZ|eu|*aa
@@ -23406,7 +23406,7 @@ KZ|km|កាហ្សាក់ស្ថាន
 KZ|kn|ಕಝಾಕಿಸ್ಥಾನ್
 KZ|ko|카자흐스탄
 KZ|kr|*aa
-KZ|ks|کَزاکِستان
+KZ|ks|قازقستان
 KZ|ku|Qazaxistan
 KZ|kv|*aa
 KZ|kw|*aa
@@ -23422,7 +23422,7 @@ KZ|lu|Kazakusita
 KZ|lv|Kazahstāna
 KZ|mg|*aa
 KZ|mh|*aa
-KZ|mi|*aa
+KZ|mi|Katatānga
 KZ|mk|*be
 KZ|ml|കസാഖിസ്ഥാൻ
 KZ|mn|*be
@@ -23444,8 +23444,8 @@ KZ|nv|*aa
 KZ|ny|*aa
 KZ|oc|*aa
 KZ|oj|*aa
-KZ|om|*aa
-KZ|or|କାଜାକାସ୍ତାନ
+KZ|om|Kazakistaan
+KZ|or|କାଜାଖସ୍ତାନ୍‌
 KZ|os|*aa
 KZ|pa|ਕਜ਼ਾਖਸਤਾਨ
 KZ|pi|*aa
@@ -23459,8 +23459,8 @@ KZ|ro|*bs
 KZ|ru|*be
 KZ|rw|*aa
 KZ|sa|*aa
-KZ|sc|*aa
-KZ|sd|قازقستان
+KZ|sc|Kazàkistan
+KZ|sd|*ks
 KZ|se|*fo
 KZ|sg|Kazakisitäan
 KZ|si|කසකස්තානය
@@ -23499,7 +23499,7 @@ KZ|vi|*aa
 KZ|vo|*aa
 KZ|wa|*aa
 KZ|wo|Kasaxstaŋ
-KZ|xh|*aa
+KZ|xh|EKazakhstan
 KZ|yi|*aa
 KZ|yo|Kaṣaṣatani
 KZ|za|*aa
@@ -23527,14 +23527,14 @@ LA|bn|লাওস
 LA|bo|*aa
 LA|br|*aa
 LA|bs|*aa
-LA|ca|*aa
+LA|ca|Lao
 LA|ce|*be
 LA|ch|*aa
 LA|co|*aa
 LA|cr|*aa
 LA|cs|*aa
 LA|cu|*aa
-LA|cv|*aa
+LA|cv|*be
 LA|cy|*aa
 LA|da|*aa
 LA|de|*aa
@@ -23560,7 +23560,7 @@ LA|gl|*aa
 LA|gn|*aa
 LA|gu|લાઓસ
 LA|gv|*aa
-LA|ha|Lawas
+LA|ha|Lawos
 LA|he|לאוס
 LA|hi|लाओस
 LA|ho|*aa
@@ -23610,7 +23610,7 @@ LA|lu|*lg
 LA|lv|Laosa
 LA|mg|Laôs
 LA|mh|*aa
-LA|mi|*aa
+LA|mi|Rāoho
 LA|mk|*be
 LA|ml|ലാവോസ്
 LA|mn|*be
@@ -23632,7 +23632,7 @@ LA|nv|*aa
 LA|ny|*aa
 LA|oc|*aa
 LA|oj|*aa
-LA|om|*aa
+LA|om|Laa’oos
 LA|or|ଲାଓସ୍
 LA|os|*aa
 LA|pa|ਲਾਓਸ
@@ -23686,8 +23686,8 @@ LA|ve|*aa
 LA|vi|Lào
 LA|vo|*aa
 LA|wa|*aa
-LA|wo|Lawos
-LA|xh|*aa
+LA|wo|*ha
+LA|xh|ELaos
 LA|yi|*ji
 LA|yo|*ki
 LA|za|*aa
@@ -23722,7 +23722,7 @@ LB|co|*aa
 LB|cr|*aa
 LB|cs|*af
 LB|cu|*aa
-LB|cv|*aa
+LB|cv|*bg
 LB|cy|Libanus
 LB|da|*af
 LB|de|*af
@@ -23744,7 +23744,7 @@ LB|fr|*br
 LB|fy|*af
 LB|ga|an Liobáin
 LB|gd|Leabanon
-LB|gl|O Líbano
+LB|gl|*es
 LB|gn|*aa
 LB|gu|લેબનોન
 LB|gv|*aa
@@ -23753,7 +23753,7 @@ LB|he|לבנון
 LB|hi|लेबनान
 LB|ho|*aa
 LB|hr|*af
-LB|ht|*aa
+LB|ht|*br
 LB|hu|*af
 LB|hy|Լիբանան
 LB|hz|*aa
@@ -23798,7 +23798,7 @@ LB|lu|Liba
 LB|lv|Libāna
 LB|mg|Libana
 LB|mh|*aa
-LB|mi|*aa
+LB|mi|Repanona
 LB|mk|Либан
 LB|ml|ലെബനൻ
 LB|mn|*bg
@@ -23820,7 +23820,7 @@ LB|nv|*aa
 LB|ny|*aa
 LB|oc|*aa
 LB|oj|*aa
-LB|om|*aa
+LB|om|Libaanoon
 LB|or|ଲେବାନନ୍
 LB|os|*aa
 LB|pa|ਲੈਬਨਾਨ
@@ -23835,7 +23835,7 @@ LB|ro|*br
 LB|ru|*bg
 LB|rw|*aa
 LB|sa|*aa
-LB|sc|*aa
+LB|sc|Lèbanu
 LB|sd|*ar
 LB|se|*af
 LB|sg|Libùaan
@@ -23875,7 +23875,7 @@ LB|vi|Li-băng
 LB|vo|*aa
 LB|wa|*aa
 LB|wo|*ff
-LB|xh|*aa
+LB|xh|ELebanon
 LB|yi|*he
 LB|yo|*ki
 LB|za|*aa
@@ -23910,7 +23910,7 @@ LC|co|*aa
 LC|cr|*aa
 LC|cs|Svatá Lucie
 LC|cu|*aa
-LC|cv|*aa
+LC|cv|Сент-Люсия
 LC|cy|*ak
 LC|da|*ak
 LC|de|*aa
@@ -23919,7 +23919,7 @@ LC|dz|སེནཊ་ ལུ་སི་ཡ
 LC|ee|Saint Lusia nutome
 LC|el|Αγία Λουκία
 LC|en|*aa
-LC|eo|Sent-Lucio
+LC|eo|Sankta Lucio
 LC|es|Santa Lucía
 LC|et|*ak
 LC|eu|Santa Luzia
@@ -23941,14 +23941,14 @@ LC|he|סנט לוסיה
 LC|hi|सेंट लूसिया
 LC|ho|*aa
 LC|hr|*bs
-LC|ht|*aa
+LC|ht|*fr
 LC|hu|*ak
 LC|hy|Սենթ Լյուսիա
 LC|hz|*aa
 LC|ia|Sancte Lucia
 LC|id|*ak
 LC|ie|*aa
-LC|ig|Lucia Dị nsọ
+LC|ig|*aa
 LC|ii|*aa
 LC|ik|*aa
 LC|in|*ak
@@ -23964,7 +23964,7 @@ LC|ka|სენტ-ლუსია
 LC|kg|*aa
 LC|ki|Santalusia
 LC|kj|*aa
-LC|kk|Сент-Люсия
+LC|kk|*cv
 LC|kl|*aa
 LC|km|សាំងលូស៊ី
 LC|kn|ಸೇಂಟ್ ಲೂಸಿಯಾ
@@ -23974,7 +23974,7 @@ LC|ks|سینٹ لوٗسِیا
 LC|ku|*ak
 LC|kv|*aa
 LC|kw|*aa
-LC|ky|*kk
+LC|ky|*cv
 LC|la|*aa
 LC|lb|*aa
 LC|lg|Senti Luciya
@@ -23986,7 +23986,7 @@ LC|lu|Santu lisi
 LC|lv|Sentlūsija
 LC|mg|*fr
 LC|mh|*aa
-LC|mi|*aa
+LC|mi|Hato Ruhia
 LC|mk|Сент Лусија
 LC|ml|സെന്റ് ലൂസിയ
 LC|mn|Сент Люсиа
@@ -24008,7 +24008,7 @@ LC|nv|*aa
 LC|ny|*aa
 LC|oc|*aa
 LC|oj|*aa
-LC|om|*aa
+LC|om|St. Suusiyaa
 LC|or|ସେଣ୍ଟ ଲୁସିଆ
 LC|os|*aa
 LC|pa|ਸੇਂਟ ਲੂਸੀਆ
@@ -24020,10 +24020,10 @@ LC|qu|Santa Lucia
 LC|rm|*ak
 LC|rn|Selusiya
 LC|ro|*mo
-LC|ru|*kk
+LC|ru|*cv
 LC|rw|*aa
 LC|sa|*aa
-LC|sc|*aa
+LC|sc|Santa Lughia
 LC|sd|سينٽ لوسيا
 LC|se|*ak
 LC|sg|Sênt-Lisïi
@@ -24042,16 +24042,16 @@ LC|sv|S:t Lucia
 LC|sw|*aa
 LC|ta|செயின்ட் லூசியா
 LC|te|సెయింట్ లూసియా
-LC|tg|*kk
+LC|tg|*cv
 LC|th|เซนต์ลูเซีย
-LC|ti|*am
+LC|ti|ቅድስቲ ሉስያ
 LC|tk|Sent-Lýusiýa
 LC|tl|*ak
 LC|tn|*aa
 LC|to|Sā Lūsia
 LC|tr|*ak
 LC|ts|*aa
-LC|tt|*kk
+LC|tt|*cv
 LC|tw|*aa
 LC|ty|*aa
 LC|ug|ساينت لۇسىيە
@@ -24063,7 +24063,7 @@ LC|vi|*aa
 LC|vo|*aa
 LC|wa|*aa
 LC|wo|Saŋ Lusi
-LC|xh|*aa
+LC|xh|ESt. Lucia
 LC|yi|*aa
 LC|yo|Luṣia
 LC|za|*aa
@@ -24098,7 +24098,7 @@ LI|co|*aa
 LI|cr|*aa
 LI|cs|Lichtenštejnsko
 LI|cu|*aa
-LI|cv|*aa
+LI|cv|*ce
 LI|cy|*aa
 LI|da|*aa
 LI|de|*aa
@@ -24174,10 +24174,10 @@ LI|lu|Lishuteni
 LI|lv|Lihtenšteina
 LI|mg|Listenstein
 LI|mh|*aa
-LI|mi|*aa
+LI|mi|Rīkenetaina
 LI|mk|Лихтенштајн
 LI|ml|ലിച്ചൺസ്റ്റൈൻ
-LI|mn|*ce
+LI|mn|Лихтенштайн
 LI|mo|*aa
 LI|mr|लिक्टेनस्टाइन
 LI|ms|*aa
@@ -24196,8 +24196,8 @@ LI|nv|*aa
 LI|ny|*aa
 LI|oc|*aa
 LI|oj|*aa
-LI|om|*aa
-LI|or|ଲିଚେଟନଷ୍ଟେଇନ୍
+LI|om|Lichistensteyin
+LI|or|ଲିକ୍ଟନ୍‌ଷ୍ଟାଇନ୍‌
 LI|os|*aa
 LI|pa|ਲਿਚੇਂਸਟਾਇਨ
 LI|pi|*aa
@@ -24232,7 +24232,7 @@ LI|ta|லிச்செண்ஸ்டெய்ன்
 LI|te|లిక్టెన్‌స్టెయిన్
 LI|tg|*ce
 LI|th|ลิกเตนสไตน์
-LI|ti|*am
+LI|ti|ሊኽተንሽታይን
 LI|tk|Lihtenşteýn
 LI|tl|*aa
 LI|tn|*aa
@@ -24251,7 +24251,7 @@ LI|vi|*aa
 LI|vo|*aa
 LI|wa|*aa
 LI|wo|Liktensteyin
-LI|xh|*aa
+LI|xh|ELiechtenstein
 LI|yi|*he
 LI|yo|Lẹṣitẹnisiteni
 LI|za|*aa
@@ -24286,7 +24286,7 @@ LK|co|*aa
 LK|cr|*aa
 LK|cs|Srí Lanka
 LK|cu|*aa
-LK|cv|*aa
+LK|cv|*ce
 LK|cy|*aa
 LK|da|*aa
 LK|de|*aa
@@ -24295,7 +24295,7 @@ LK|dz|ཤྲཱི་ལང་ཀ
 LK|ee|Sri Lanka nutome
 LK|el|Σρι Λάνκα
 LK|en|*aa
-LK|eo|Sri-Lanko
+LK|eo|Srilanko
 LK|es|*aa
 LK|et|*aa
 LK|eu|*aa
@@ -24323,7 +24323,7 @@ LK|hy|Շրի Լանկա
 LK|hz|*aa
 LK|ia|*aa
 LK|id|*aa
-LK|ie|*aa
+LK|ie|Sri-Lanka
 LK|ig|*aa
 LK|ii|*aa
 LK|ik|*aa
@@ -24346,7 +24346,7 @@ LK|km|ស្រីលង្កា
 LK|kn|ಶ್ರೀಲಂಕಾ
 LK|ko|스리랑카
 LK|kr|*aa
-LK|ks|سِریٖلَنکا
+LK|ks|سری لنکا
 LK|ku|Srî Lanka
 LK|kv|*aa
 LK|kw|*aa
@@ -24362,7 +24362,7 @@ LK|lu|*bm
 LK|lv|Šrilanka
 LK|mg|*aa
 LK|mh|*aa
-LK|mi|*aa
+LK|mi|Hiri Rānaka
 LK|mk|*bg
 LK|ml|ശ്രീലങ്ക
 LK|mn|*ce
@@ -24384,7 +24384,7 @@ LK|nv|*aa
 LK|ny|*aa
 LK|oc|*aa
 LK|oj|*aa
-LK|om|*aa
+LK|om|Siri Laankaa
 LK|or|ଶ୍ରୀଲଙ୍କା
 LK|os|*aa
 LK|pa|ਸ੍ਰੀ ਲੰਕਾ
@@ -24420,7 +24420,7 @@ LK|ta|இலங்கை
 LK|te|శ్రీలంక
 LK|tg|*ce
 LK|th|ศรีลังกา
-LK|ti|*am
+LK|ti|ስሪ ላንካ
 LK|tk|*az
 LK|tl|*aa
 LK|tn|*aa
@@ -24432,14 +24432,14 @@ LK|tw|*aa
 LK|ty|*aa
 LK|ug|سىرىلانكا
 LK|uk|Шрі-Ланка
-LK|ur|سری لنکا
+LK|ur|*ks
 LK|uz|Shri-Lanka
 LK|ve|*aa
 LK|vi|*aa
 LK|vo|*aa
 LK|wa|*aa
 LK|wo|Siri Lànka
-LK|xh|*aa
+LK|xh|ESri Lanka
 LK|yi|*ji
 LK|yo|*ff
 LK|za|*aa
@@ -24474,7 +24474,7 @@ LR|co|*aa
 LR|cr|*aa
 LR|cs|Libérie
 LR|cu|*aa
-LR|cv|*aa
+LR|cv|*ce
 LR|cy|*aa
 LR|da|*aa
 LR|de|*aa
@@ -24494,7 +24494,7 @@ LR|fj|*aa
 LR|fo|*aa
 LR|fr|*aa
 LR|fy|*aa
-LR|ga|an Libéir
+LR|ga|An Libéir
 LR|gd|Libèir
 LR|gl|*aa
 LR|gn|*aa
@@ -24550,7 +24550,7 @@ LR|lu|*az
 LR|lv|Libērija
 LR|mg|*aa
 LR|mh|*aa
-LR|mi|*aa
+LR|mi|Raipiria
 LR|mk|Либерија
 LR|ml|ലൈബീരിയ
 LR|mn|*ce
@@ -24572,7 +24572,7 @@ LR|nv|*aa
 LR|ny|*aa
 LR|oc|*aa
 LR|oj|*aa
-LR|om|*aa
+LR|om|Laayibeeriyaa
 LR|or|ଲାଇବେରିଆ
 LR|os|*aa
 LR|pa|ਲਾਈਬੀਰੀਆ
@@ -24587,7 +24587,7 @@ LR|ro|*aa
 LR|ru|*bg
 LR|rw|*aa
 LR|sa|*aa
-LR|sc|*aa
+LR|sc|*ca
 LR|sd|لائبیریا
 LR|se|*aa
 LR|sg|Liberïa
@@ -24608,7 +24608,7 @@ LR|ta|லைபீரியா
 LR|te|లైబీరియా
 LR|tg|*bg
 LR|th|ไลบีเรีย
-LR|ti|*am
+LR|ti|ላይበርያ
 LR|tk|Liberiýa
 LR|tl|*aa
 LR|tn|*aa
@@ -24627,7 +24627,7 @@ LR|vi|*aa
 LR|vo|*aa
 LR|wa|*aa
 LR|wo|*az
-LR|xh|*aa
+LR|xh|ELiberia
 LR|yi|*ji
 LR|yo|Laberia
 LR|za|*aa
@@ -24637,24 +24637,24 @@ LS|aa|Lesotho
 LS|ab|*aa
 LS|ae|*aa
 LS|af|*aa
-LS|ak|Lɛsutu
+LS|ak|Lesoto
 LS|am|ሌሶቶ
 LS|an|*aa
 LS|ar|ليسوتو
 LS|as|লেছ’থ’
 LS|av|*aa
 LS|ay|*aa
-LS|az|Lesoto
+LS|az|*ak
 LS|ba|*aa
 LS|be|Лесота
 LS|bg|Лесото
 LS|bh|*aa
 LS|bi|*aa
-LS|bm|*az
+LS|bm|*ak
 LS|bn|লেসোথো
 LS|bo|*aa
 LS|br|*aa
-LS|bs|*az
+LS|bs|*ak
 LS|ca|*aa
 LS|ce|*bg
 LS|ch|*aa
@@ -24662,7 +24662,7 @@ LS|co|*aa
 LS|cr|*aa
 LS|cs|*aa
 LS|cu|*aa
-LS|cv|*aa
+LS|cv|*bg
 LS|cy|*aa
 LS|da|*aa
 LS|de|*aa
@@ -24671,15 +24671,15 @@ LS|dz|ལཻ་སོ་ཐོ
 LS|ee|Lɛsoto nutome
 LS|el|Λεσότο
 LS|en|*aa
-LS|eo|*az
-LS|es|*az
+LS|eo|*ak
+LS|es|*ak
 LS|et|*aa
 LS|eu|*aa
 LS|fa|لسوتو
-LS|ff|*az
+LS|ff|*ak
 LS|fi|*aa
 LS|fj|*aa
-LS|fo|*az
+LS|fo|*ak
 LS|fr|*aa
 LS|fy|*aa
 LS|ga|Leosóta
@@ -24688,11 +24688,11 @@ LS|gl|*aa
 LS|gn|*aa
 LS|gu|લેસોથો
 LS|gv|*aa
-LS|ha|*az
+LS|ha|*ak
 LS|he|לסוטו
 LS|hi|लेसोथो
 LS|ho|*aa
-LS|hr|*az
+LS|hr|*ak
 LS|ht|*aa
 LS|hu|*aa
 LS|hy|Լեսոտո
@@ -24714,7 +24714,7 @@ LS|ji|לעסאטא
 LS|jv|Lésotho
 LS|ka|ლესოთო
 LS|kg|*aa
-LS|ki|*az
+LS|ki|*ak
 LS|kj|*aa
 LS|kk|*bg
 LS|kl|*aa
@@ -24723,7 +24723,7 @@ LS|kn|ಲೆಸೊಥೊ
 LS|ko|레소토
 LS|kr|*aa
 LS|ks|لیسوتھو
-LS|ku|*az
+LS|ku|*ak
 LS|kv|*aa
 LS|kw|*aa
 LS|ky|*bg
@@ -24731,14 +24731,14 @@ LS|la|*aa
 LS|lb|*aa
 LS|lg|Lesoso
 LS|li|*aa
-LS|ln|*az
+LS|ln|*ak
 LS|lo|ເລໂຊໂທ
 LS|lt|Lesotas
-LS|lu|*az
-LS|lv|*az
+LS|lu|*ak
+LS|lv|*ak
 LS|mg|*aa
 LS|mh|*aa
-LS|mi|*aa
+LS|mi|Teroto
 LS|mk|*bg
 LS|ml|ലെസോതോ
 LS|mn|*bg
@@ -24760,17 +24760,17 @@ LS|nv|*aa
 LS|ny|*aa
 LS|oc|*aa
 LS|oj|*aa
-LS|om|*aa
+LS|om|Leseettoo
 LS|or|ଲେସୋଥୋ
 LS|os|*aa
 LS|pa|ਲੇਸੋਥੋ
 LS|pi|*aa
 LS|pl|*aa
 LS|ps|*fa
-LS|pt|*az
-LS|qu|*az
+LS|pt|*ak
+LS|qu|*ak
 LS|rm|*aa
-LS|rn|*az
+LS|rn|*ak
 LS|ro|*aa
 LS|ru|*bg
 LS|rw|*aa
@@ -24781,26 +24781,26 @@ LS|se|*aa
 LS|sg|Lesôtho
 LS|si|ලෙසතෝ
 LS|sk|*aa
-LS|sl|*az
+LS|sl|*ak
 LS|sm|*aa
 LS|sn|*aa
 LS|so|Losooto
-LS|sq|*az
+LS|sq|*ak
 LS|sr|*bg
 LS|ss|*aa
 LS|st|*aa
 LS|su|*aa
 LS|sv|*aa
-LS|sw|*az
+LS|sw|*ak
 LS|ta|லெசோதோ
 LS|te|లెసోతో
 LS|tg|*bg
 LS|th|เลโซโท
 LS|ti|*am
-LS|tk|*az
+LS|tk|*ak
 LS|tl|*aa
 LS|tn|*aa
-LS|to|*az
+LS|to|*ak
 LS|tr|*aa
 LS|ts|*aa
 LS|tt|*bg
@@ -24809,15 +24809,15 @@ LS|ty|*aa
 LS|ug|لېسوتو
 LS|uk|*bg
 LS|ur|*ks
-LS|uz|*az
+LS|uz|*ak
 LS|ve|*aa
 LS|vi|*aa
 LS|vo|*aa
 LS|wa|*aa
-LS|wo|*az
-LS|xh|*aa
+LS|wo|*ak
+LS|xh|ELesotho
 LS|yi|*ji
-LS|yo|*az
+LS|yo|*ak
 LS|za|*aa
 LS|zh|莱索托
 LS|zu|iLesotho
@@ -24850,7 +24850,7 @@ LT|co|*aa
 LT|cr|*aa
 LT|cs|*az
 LT|cu|*aa
-LT|cv|*aa
+LT|cv|*bg
 LT|cy|Lithwania
 LT|da|Litauen
 LT|de|*da
@@ -24881,7 +24881,7 @@ LT|he|ליטא
 LT|hi|लिथुआनिया
 LT|ho|*aa
 LT|hr|*az
-LT|ht|*aa
+LT|ht|*fr
 LT|hu|Litvánia
 LT|hy|Լիտվա
 LT|hz|*aa
@@ -24926,7 +24926,7 @@ LT|lu|*ln
 LT|lv|*lt
 LT|mg|Litoania
 LT|mh|*aa
-LT|mi|*aa
+LT|mi|Rituānia
 LT|mk|Литванија
 LT|ml|ലിത്വാനിയ
 LT|mn|*bg
@@ -24948,7 +24948,7 @@ LT|nv|*aa
 LT|ny|*aa
 LT|oc|*aa
 LT|oj|*aa
-LT|om|*aa
+LT|om|Lutaaniyaa
 LT|or|ଲିଥୁଆନିଆ
 LT|os|*aa
 LT|pa|ਲਿਥੁਆਨੀਆ
@@ -24963,7 +24963,7 @@ LT|ro|*br
 LT|ru|*bg
 LT|rw|*aa
 LT|sa|*aa
-LT|sc|*aa
+LT|sc|*ca
 LT|sd|لٿونيا
 LT|se|*lt
 LT|sg|Lituanïi
@@ -24984,7 +24984,7 @@ LT|ta|லிதுவேனியா
 LT|te|లిథువేనియా
 LT|tg|*bg
 LT|th|ลิทัวเนีย
-LT|ti|*am
+LT|ti|ሊትዌንያ
 LT|tk|*pl
 LT|tl|*aa
 LT|tn|*aa
@@ -25003,7 +25003,7 @@ LT|vi|*az
 LT|vo|*aa
 LT|wa|*aa
 LT|wo|Litiyani
-LT|xh|*aa
+LT|xh|ELithuania
 LT|yi|*ji
 LT|yo|*br
 LT|za|*aa
@@ -25013,7 +25013,7 @@ LU|aa|Luxembourg
 LU|ab|*aa
 LU|ae|*aa
 LU|af|Luxemburg
-LU|ak|Laksembɛg
+LU|ak|Lusimbɛg
 LU|am|ሉክሰምበርግ
 LU|an|*aa
 LU|ar|لوكسمبورغ
@@ -25038,7 +25038,7 @@ LU|co|*aa
 LU|cr|*aa
 LU|cs|Lucembursko
 LU|cu|*aa
-LU|cv|*aa
+LU|cv|*be
 LU|cy|Lwcsembwrg
 LU|da|*aa
 LU|de|*af
@@ -25075,7 +25075,7 @@ LU|hy|Լյուքսեմբուրգ
 LU|hz|*aa
 LU|ia|*af
 LU|id|*bs
-LU|ie|*aa
+LU|ie|*af
 LU|ig|*aa
 LU|ii|*aa
 LU|ik|*aa
@@ -25099,7 +25099,7 @@ LU|kn|ಲಕ್ಸೆಂಬರ್ಗ್
 LU|ko|룩셈부르크
 LU|kr|*aa
 LU|ks|لَکسَمبٔرٕگ
-LU|ku|Lûksembûrg
+LU|ku|Luksembûrg
 LU|kv|*aa
 LU|kw|*aa
 LU|ky|*be
@@ -25114,7 +25114,7 @@ LU|lu|*ln
 LU|lv|Luksemburga
 LU|mg|Lioksamboro
 LU|mh|*aa
-LU|mi|*aa
+LU|mi|Rakapuō
 LU|mk|Луксембург
 LU|ml|ലക്സംബർഗ്
 LU|mn|*be
@@ -25136,7 +25136,7 @@ LU|nv|*aa
 LU|ny|*aa
 LU|oc|*aa
 LU|oj|*aa
-LU|om|*aa
+LU|om|Luksembarg
 LU|or|ଲକ୍ସେମବର୍ଗ
 LU|os|*aa
 LU|pa|ਲਕਜ਼ਮਬਰਗ
@@ -25151,7 +25151,7 @@ LU|ro|*af
 LU|ru|*be
 LU|rw|*aa
 LU|sa|*aa
-LU|sc|*aa
+LU|sc|Lussemburgu
 LU|sd|لگزمبرگ
 LU|se|*aa
 LU|sg|Lugzambûru
@@ -25191,7 +25191,7 @@ LU|vi|*aa
 LU|vo|*aa
 LU|wa|*aa
 LU|wo|Liksàmbur
-LU|xh|*aa
+LU|xh|ELuxembourg
 LU|yi|*ji
 LU|yo|Lusemogi
 LU|za|*aa
@@ -25215,7 +25215,7 @@ LV|bg|Латвия
 LV|bh|*aa
 LV|bi|*aa
 LV|bm|Letoni
-LV|bn|লাত্ভিয়া
+LV|bn|*as
 LV|bo|*aa
 LV|br|*aa
 LV|bs|Latvija
@@ -25226,7 +25226,7 @@ LV|co|*aa
 LV|cr|*aa
 LV|cs|Lotyšsko
 LV|cu|*aa
-LV|cv|*aa
+LV|cv|*ce
 LV|cy|Latfia
 LV|da|*af
 LV|de|Lettland
@@ -25257,7 +25257,7 @@ LV|he|לטביה
 LV|hi|लातविया
 LV|ho|*aa
 LV|hr|*bs
-LV|ht|*aa
+LV|ht|*fr
 LV|hu|Lettország
 LV|hy|Լատվիա
 LV|hz|*aa
@@ -25302,7 +25302,7 @@ LV|lu|*bm
 LV|lv|*bs
 LV|mg|*es
 LV|mh|*aa
-LV|mi|*aa
+LV|mi|Rāwhia
 LV|mk|Латвија
 LV|ml|ലാറ്റ്വിയ
 LV|mn|*ce
@@ -25324,7 +25324,7 @@ LV|nv|*aa
 LV|ny|*aa
 LV|oc|*aa
 LV|oj|*aa
-LV|om|*aa
+LV|om|Lativiyaa
 LV|or|ଲାଟଭିଆ
 LV|os|*aa
 LV|pa|ਲਾਤਵੀਆ
@@ -25339,7 +25339,7 @@ LV|ro|*es
 LV|ru|*bg
 LV|rw|*aa
 LV|sa|*aa
-LV|sc|*aa
+LV|sc|*ca
 LV|sd|لاتويا
 LV|se|Látvia
 LV|sg|Letonùii
@@ -25360,7 +25360,7 @@ LV|ta|லாட்வியா
 LV|te|లాత్వియా
 LV|tg|*bg
 LV|th|ลัตเวีย
-LV|ti|*am
+LV|ti|ላትቭያ
 LV|tk|Latwiýa
 LV|tl|*aa
 LV|tn|*aa
@@ -25379,7 +25379,7 @@ LV|vi|*aa
 LV|vo|*aa
 LV|wa|*aa
 LV|wo|*bm
-LV|xh|*aa
+LV|xh|ELatvia
 LV|yi|*ji
 LV|yo|Latifia
 LV|za|*aa
@@ -25414,7 +25414,7 @@ LY|co|*aa
 LY|cr|*aa
 LY|cs|Libye
 LY|cu|*aa
-LY|cv|*aa
+LY|cv|*ce
 LY|cy|*aa
 LY|da|Libyen
 LY|de|*da
@@ -25434,7 +25434,7 @@ LY|fj|*aa
 LY|fo|*aa
 LY|fr|*cs
 LY|fy|*af
-LY|ga|an Libia
+LY|ga|An Libia
 LY|gd|*br
 LY|gl|*br
 LY|gn|*aa
@@ -25445,7 +25445,7 @@ LY|he|לוב
 LY|hi|लीबिया
 LY|ho|*aa
 LY|hr|*bs
-LY|ht|*aa
+LY|ht|*cs
 LY|hu|*ca
 LY|hy|Լիբիա
 LY|hz|*aa
@@ -25490,7 +25490,7 @@ LY|lu|*bm
 LY|lv|Lībija
 LY|mg|*aa
 LY|mh|*aa
-LY|mi|*aa
+LY|mi|Ripia
 LY|mk|Либија
 LY|ml|ലിബിയ
 LY|mn|*ce
@@ -25512,7 +25512,7 @@ LY|nv|*aa
 LY|ny|*aa
 LY|oc|*aa
 LY|oj|*aa
-LY|om|*aa
+LY|om|Liibiyaa
 LY|or|ଲିବ୍ୟା
 LY|os|*aa
 LY|pa|ਲੀਬੀਆ
@@ -25527,7 +25527,7 @@ LY|ro|*br
 LY|ru|*kk
 LY|rw|*aa
 LY|sa|*aa
-LY|sc|*aa
+LY|sc|Lìbia
 LY|sd|لبيا
 LY|se|*aa
 LY|sg|Libïi
@@ -25548,7 +25548,7 @@ LY|ta|லிபியா
 LY|te|లిబియా
 LY|tg|*bg
 LY|th|ลิเบีย
-LY|ti|*am
+LY|ti|ሊብያ
 LY|tk|Liwiýa
 LY|tl|*aa
 LY|tn|*aa
@@ -25567,7 +25567,7 @@ LY|vi|*aa
 LY|vo|*aa
 LY|wa|*aa
 LY|wo|*bm
-LY|xh|*aa
+LY|xh|ELibya
 LY|yi|*ji
 LY|yo|*ha
 LY|za|*aa
@@ -25602,7 +25602,7 @@ MA|co|*aa
 MA|cr|*aa
 MA|cs|*br
 MA|cu|*aa
-MA|cv|*aa
+MA|cv|*ce
 MA|cy|Moroco
 MA|da|*af
 MA|de|*af
@@ -25633,7 +25633,7 @@ MA|he|מרוקו
 MA|hi|मोरक्को
 MA|ho|*aa
 MA|hr|*br
-MA|ht|*aa
+MA|ht|*fr
 MA|hu|Marokkó
 MA|hy|Մարոկկո
 MA|hz|*aa
@@ -25663,7 +25663,7 @@ MA|kn|ಮೊರಾಕ್ಕೊ
 MA|ko|모로코
 MA|kr|*aa
 MA|ks|موروکو
-MA|ku|*br
+MA|ku|Fas
 MA|kv|*aa
 MA|kw|*aa
 MA|ky|*ce
@@ -25678,7 +25678,7 @@ MA|lu|Maroke
 MA|lv|Maroka
 MA|mg|Marôka
 MA|mh|*aa
-MA|mi|*aa
+MA|mi|*ak
 MA|mk|*bg
 MA|ml|മൊറോക്കൊ
 MA|mn|Морокко
@@ -25700,7 +25700,7 @@ MA|nv|*aa
 MA|ny|*aa
 MA|oc|*aa
 MA|oj|*aa
-MA|om|*aa
+MA|om|Morookoo
 MA|or|ମୋରୋକ୍କୋ
 MA|os|*aa
 MA|pa|ਮੋਰੱਕੋ
@@ -25715,7 +25715,7 @@ MA|ro|*fr
 MA|ru|*ce
 MA|rw|*aa
 MA|sa|*aa
-MA|sc|*aa
+MA|sc|Marocu
 MA|sd|مراڪش
 MA|se|*af
 MA|sg|Marôko
@@ -25741,7 +25741,7 @@ MA|tk|*af
 MA|tl|*aa
 MA|tn|*aa
 MA|to|Moloko
-MA|tr|Fas
+MA|tr|*ku
 MA|ts|*aa
 MA|tt|*ce
 MA|tw|*aa
@@ -25755,7 +25755,7 @@ MA|vi|Ma-rốc
 MA|vo|*aa
 MA|wa|*aa
 MA|wo|Marog
-MA|xh|*aa
+MA|xh|EMorocco
 MA|yi|*ji
 MA|yo|*ak
 MA|za|*aa
@@ -25765,32 +25765,32 @@ MC|aa|Monaco
 MC|ab|*aa
 MC|ae|*aa
 MC|af|*aa
-MC|ak|Mɔnako
+MC|ak|Monako
 MC|am|ሞናኮ
 MC|an|*aa
 MC|ar|موناكو
 MC|as|মোনাকো
 MC|av|*aa
 MC|ay|*aa
-MC|az|Monako
+MC|az|*ak
 MC|ba|*aa
 MC|be|Манака
 MC|bg|Монако
 MC|bh|*aa
 MC|bi|*aa
-MC|bm|*az
+MC|bm|*ak
 MC|bn|*as
 MC|bo|*aa
 MC|br|*aa
-MC|bs|*az
+MC|bs|*ak
 MC|ca|Mònaco
 MC|ce|*bg
 MC|ch|*aa
 MC|co|*aa
 MC|cr|*aa
-MC|cs|*az
+MC|cs|*ak
 MC|cu|*aa
-MC|cv|*aa
+MC|cv|*bg
 MC|cy|*aa
 MC|da|*aa
 MC|de|*aa
@@ -25799,15 +25799,15 @@ MC|dz|མོ་ན་ཀོ
 MC|ee|Monako nutome
 MC|el|Μονακό
 MC|en|*aa
-MC|eo|*az
+MC|eo|*ak
 MC|es|Mónaco
 MC|et|*aa
-MC|eu|*az
+MC|eu|*ak
 MC|fa|موناکو
 MC|ff|Monaakoo
 MC|fi|*aa
 MC|fj|*aa
-MC|fo|*az
+MC|fo|*ak
 MC|fr|*aa
 MC|fy|*aa
 MC|ga|Monacó
@@ -25816,22 +25816,22 @@ MC|gl|*es
 MC|gn|*aa
 MC|gu|મોનાકો
 MC|gv|*aa
-MC|ha|*az
+MC|ha|*ak
 MC|he|מונקו
 MC|hi|मोनाको
 MC|ho|*aa
-MC|hr|*az
+MC|hr|*ak
 MC|ht|*aa
 MC|hu|*aa
 MC|hy|Մոնակո
 MC|hz|*aa
 MC|ia|*aa
-MC|id|*az
-MC|ie|*aa
+MC|id|*ak
+MC|ie|*es
 MC|ig|*aa
 MC|ii|*aa
 MC|ik|*aa
-MC|in|*az
+MC|in|*ak
 MC|io|*aa
 MC|is|Mónakó
 MC|it|*aa
@@ -25839,10 +25839,10 @@ MC|iu|*aa
 MC|iw|*he
 MC|ja|モナコ
 MC|ji|מאנאַקא
-MC|jv|*az
+MC|jv|*ak
 MC|ka|მონაკო
 MC|kg|*aa
-MC|ki|*az
+MC|ki|*ak
 MC|kj|*aa
 MC|kk|*bg
 MC|kl|*aa
@@ -25851,22 +25851,22 @@ MC|kn|ಮೊನಾಕೊ
 MC|ko|모나코
 MC|kr|*aa
 MC|ks|مونیکو
-MC|ku|*az
+MC|ku|*ak
 MC|kv|*aa
 MC|kw|*aa
 MC|ky|*bg
 MC|la|*aa
 MC|lb|*aa
-MC|lg|*az
+MC|lg|*ak
 MC|li|*aa
-MC|ln|*az
+MC|ln|*ak
 MC|lo|ໂມນາໂຄ
 MC|lt|Monakas
 MC|lu|Monaku
-MC|lv|*az
+MC|lv|*ak
 MC|mg|Mônakô
 MC|mh|*aa
-MC|mi|*aa
+MC|mi|Monāko
 MC|mk|*bg
 MC|ml|മൊണാക്കോ
 MC|mn|*bg
@@ -25888,32 +25888,32 @@ MC|nv|*aa
 MC|ny|*aa
 MC|oc|*aa
 MC|oj|*aa
-MC|om|*aa
+MC|om|Moonaakoo
 MC|or|ମୋନାକୋ
 MC|os|*aa
 MC|pa|ਮੋਨਾਕੋ
 MC|pi|*aa
-MC|pl|*az
+MC|pl|*ak
 MC|ps|*fa
 MC|pt|Mônaco
 MC|qu|*es
 MC|rm|*aa
-MC|rn|*az
+MC|rn|*ak
 MC|ro|*aa
 MC|ru|*bg
 MC|rw|*aa
 MC|sa|*aa
-MC|sc|*aa
+MC|sc|Mònacu
 MC|sd|موناڪو
 MC|se|*aa
 MC|sg|Monaköo
 MC|si|මොනාකෝව
-MC|sk|*az
-MC|sl|*az
+MC|sk|*ak
+MC|sl|*ak
 MC|sm|*aa
 MC|sn|*aa
 MC|so|Moonako
-MC|sq|*az
+MC|sq|*ak
 MC|sr|*bg
 MC|ss|*aa
 MC|st|*aa
@@ -25925,11 +25925,11 @@ MC|te|మొనాకో
 MC|tg|*bg
 MC|th|โมนาโก
 MC|ti|*am
-MC|tk|*az
+MC|tk|*ak
 MC|tl|*aa
 MC|tn|*aa
-MC|to|*az
-MC|tr|*az
+MC|to|*ak
+MC|tr|*ak
 MC|ts|*aa
 MC|tt|*bg
 MC|tw|*aa
@@ -25937,15 +25937,15 @@ MC|ty|*aa
 MC|ug|*ar
 MC|uk|*bg
 MC|ur|*fa
-MC|uz|*az
+MC|uz|*ak
 MC|ve|*aa
 MC|vi|*aa
 MC|vo|*aa
 MC|wa|*aa
-MC|wo|*az
-MC|xh|*aa
+MC|wo|*ak
+MC|xh|EMonaco
 MC|yi|*ji
-MC|yo|*az
+MC|yo|*ak
 MC|za|*aa
 MC|zh|摩纳哥
 MC|zu|i-Monaco
@@ -25978,7 +25978,7 @@ MD|co|*aa
 MD|cr|*aa
 MD|cs|Moldavsko
 MD|cu|*aa
-MD|cv|*aa
+MD|cv|*bg
 MD|cy|Moldofa
 MD|da|*aa
 MD|de|Republik Moldau
@@ -26000,7 +26000,7 @@ MD|fr|Moldavie
 MD|fy|Moldavië
 MD|ga|an Mholdóiv
 MD|gd|A’ Mholdobha
-MD|gl|*es
+MD|gl|República Moldova
 MD|gn|*aa
 MD|gu|મોલડોવા
 MD|gv|*aa
@@ -26009,7 +26009,7 @@ MD|he|מולדובה
 MD|hi|मॉल्डोवा
 MD|ho|*aa
 MD|hr|*bs
-MD|ht|*aa
+MD|ht|*fr
 MD|hu|*aa
 MD|hy|Մոլդովա
 MD|hz|*aa
@@ -26038,7 +26038,7 @@ MD|km|ម៉ុលដាវី
 MD|kn|ಮೊಲ್ಡೋವಾ
 MD|ko|몰도바
 MD|kr|*aa
-MD|ks|مولڑاوِیا
+MD|ks|مولڈووا
 MD|ku|*aa
 MD|kv|*aa
 MD|kw|*aa
@@ -26054,7 +26054,7 @@ MD|lu|*bm
 MD|lv|*aa
 MD|mg|Môldavia
 MD|mh|*aa
-MD|mi|*aa
+MD|mi|Morotawa
 MD|mk|Молдавија
 MD|ml|മൾഡോവ
 MD|mn|*bg
@@ -26076,7 +26076,7 @@ MD|nv|*aa
 MD|ny|*aa
 MD|oc|*aa
 MD|oj|*aa
-MD|om|*aa
+MD|om|Moldoovaa
 MD|or|ମୋଲଡୋଭା
 MD|os|*aa
 MD|pa|ਮੋਲਡੋਵਾ
@@ -26091,7 +26091,7 @@ MD|ro|*mo
 MD|ru|*bg
 MD|rw|*aa
 MD|sa|*aa
-MD|sc|*aa
+MD|sc|*ca
 MD|sd|مالدووا
 MD|se|*pt
 MD|sg|Moldavùii
@@ -26131,7 +26131,7 @@ MD|vi|*aa
 MD|vo|*aa
 MD|wa|*aa
 MD|wo|Moldawi
-MD|xh|*aa
+MD|xh|EMoldova
 MD|yi|*ji
 MD|yo|Modofia
 MD|za|*aa
@@ -26141,7 +26141,7 @@ ME|aa|Montenegro
 ME|ab|*aa
 ME|ae|*aa
 ME|af|*aa
-ME|ak|*aa
+ME|ak|Mɔntenegro
 ME|am|ሞንተኔግሮ
 ME|an|*aa
 ME|ar|الجبل الأسود
@@ -26166,7 +26166,7 @@ ME|co|*aa
 ME|cr|*aa
 ME|cs|Černá Hora
 ME|cu|*aa
-ME|cv|*aa
+ME|cv|Черногори
 ME|cy|*aa
 ME|da|*aa
 ME|de|*aa
@@ -26192,12 +26192,12 @@ ME|gl|*aa
 ME|gn|*aa
 ME|gu|મૉન્ટેનેગ્રો
 ME|gv|*aa
-ME|ha|Mantanegara
+ME|ha|Manteneguro
 ME|he|מונטנגרו
 ME|hi|मोंटेनेग्रो
 ME|ho|*aa
 ME|hr|*bs
-ME|ht|*aa
+ME|ht|*fr
 ME|hu|Montenegró
 ME|hy|Չեռնոգորիա
 ME|hz|*aa
@@ -26242,7 +26242,7 @@ ME|lu|*aa
 ME|lv|Melnkalne
 ME|mg|*aa
 ME|mh|*aa
-ME|mi|*aa
+ME|mi|Maungakororiko
 ME|mk|Црна Гора
 ME|ml|മോണ്ടെനെഗ്രോ
 ME|mn|Монтенегро
@@ -26264,7 +26264,7 @@ ME|nv|*aa
 ME|ny|*aa
 ME|oc|*aa
 ME|oj|*aa
-ME|om|*aa
+ME|om|Montenegiroo
 ME|or|ମଣ୍ଟେନିଗ୍ରୋ
 ME|os|*aa
 ME|pa|ਮੋਂਟੇਨੇਗਰੋ
@@ -26300,7 +26300,7 @@ ME|ta|மான்டேனெக்ரோ
 ME|te|మాంటెనెగ్రో
 ME|tg|*kk
 ME|th|มอนเตเนโกร
-ME|ti|ሞንቴኔግሮ
+ME|ti|*am
 ME|tk|Çernogoriýa
 ME|tl|*aa
 ME|tn|*aa
@@ -26319,9 +26319,9 @@ ME|vi|*aa
 ME|vo|*aa
 ME|wa|*aa
 ME|wo|Montenegoro
-ME|xh|*aa
+ME|xh|EMontenegro
 ME|yi|*ji
-ME|yo|*aa
+ME|yo|Montenégrò
 ME|za|*aa
 ME|zh|黑山
 ME|zu|i-Montenegro
@@ -26329,7 +26329,7 @@ MF|aa|St. Martin
 MF|ab|*aa
 MF|ae|*aa
 MF|af|Sint Martin
-MF|ak|*aa
+MF|ak|St. Maatin
 MF|am|ሴንት ማርቲን
 MF|an|*aa
 MF|ar|سان مارتن
@@ -26354,7 +26354,7 @@ MF|co|*aa
 MF|cr|*aa
 MF|cs|Svatý Martin (Francie)
 MF|cu|*aa
-MF|cv|*aa
+MF|cv|*ce
 MF|cy|*br
 MF|da|*br
 MF|de|*aa
@@ -26385,14 +26385,14 @@ MF|he|סן מרטן
 MF|hi|सेंट मार्टिन
 MF|ho|*aa
 MF|hr|*br
-MF|ht|*aa
+MF|ht|*et
 MF|hu|*br
 MF|hy|Սեն Մարտեն
 MF|hz|*aa
-MF|ia|*aa
+MF|ia|Sancte Martino francese
 MF|id|*br
 MF|ie|*aa
-MF|ig|Martin Dị nsọ
+MF|ig|*aa
 MF|ii|*aa
 MF|ik|*aa
 MF|in|*br
@@ -26415,7 +26415,7 @@ MF|kn|ಸೇಂಟ್ ಮಾರ್ಟಿನ್
 MF|ko|생마르탱
 MF|kr|*aa
 MF|ks|سینٹ مارٹِن
-MF|ku|*aa
+MF|ku|*br
 MF|kv|*aa
 MF|kw|*aa
 MF|ky|Сент-Мартин
@@ -26430,7 +26430,7 @@ MF|lu|*aa
 MF|lv|Senmartēna
 MF|mg|*aa
 MF|mh|*aa
-MF|mi|*aa
+MF|mi|Hato Mātene
 MF|mk|Сент Мартин
 MF|ml|സെന്റ് മാർട്ടിൻ
 MF|mn|*ky
@@ -26452,7 +26452,7 @@ MF|nv|*aa
 MF|ny|*aa
 MF|oc|*aa
 MF|oj|*aa
-MF|om|*aa
+MF|om|St. Martiin
 MF|or|ସେଣ୍ଟ ମାର୍ଟିନ୍
 MF|os|*aa
 MF|pa|ਸੇਂਟ ਮਾਰਟਿਨ
@@ -26467,7 +26467,7 @@ MF|ro|*mo
 MF|ru|*ce
 MF|rw|*aa
 MF|sa|*aa
-MF|sc|*aa
+MF|sc|Santu Martine
 MF|sd|سينٽ مارٽن
 MF|se|Frankriikka Saint Martin
 MF|sg|*aa
@@ -26488,7 +26488,7 @@ MF|ta|செயின்ட் மார்ட்டீன்
 MF|te|సెయింట్ మార్టిన్
 MF|tg|Ҷазираи Сент-Мартин
 MF|th|เซนต์มาร์ติน
-MF|ti|*am
+MF|ti|ቅዱስ ማርቲን
 MF|tk|*sq
 MF|tl|*br
 MF|tn|*aa
@@ -26507,9 +26507,9 @@ MF|vi|*aa
 MF|vo|*aa
 MF|wa|*aa
 MF|wo|Saŋ Marteŋ
-MF|xh|*aa
+MF|xh|ESt. Martin
 MF|yi|*aa
-MF|yo|*aa
+MF|yo|Ìlú Màtìnì
 MF|za|*aa
 MF|zh|法属圣马丁
 MF|zu|i-Saint Martin
@@ -26542,7 +26542,7 @@ MG|co|*aa
 MG|cr|*aa
 MG|cs|*af
 MG|cu|*aa
-MG|cv|*aa
+MG|cv|*be
 MG|cy|*aa
 MG|da|*af
 MG|de|*af
@@ -26580,7 +26580,7 @@ MG|hz|*aa
 MG|ia|*aa
 MG|id|*af
 MG|ie|*aa
-MG|ig|*af
+MG|ig|*aa
 MG|ii|*aa
 MG|ik|*aa
 MG|in|*af
@@ -26602,7 +26602,7 @@ MG|km|ម៉ាដាហ្គាស្កា
 MG|kn|ಮಡಗಾಸ್ಕರ್
 MG|ko|마다가스카르
 MG|kr|*aa
-MG|ks|میڑاگاسکار
+MG|ks|میڈاگاسکار
 MG|ku|*af
 MG|kv|*aa
 MG|kw|*aa
@@ -26618,7 +26618,7 @@ MG|lu|*bm
 MG|lv|Madagaskara
 MG|mg|Madagasikara
 MG|mh|*aa
-MG|mi|*aa
+MG|mi|Matakāhika
 MG|mk|*be
 MG|ml|മഡഗാസ്കർ
 MG|mn|*be
@@ -26640,7 +26640,7 @@ MG|nv|*aa
 MG|ny|*aa
 MG|oc|*aa
 MG|oj|*aa
-MG|om|*aa
+MG|om|Madagaaskaar
 MG|or|ମାଡାଗାସ୍କର୍
 MG|os|*aa
 MG|pa|ਮੈਡਾਗਾਸਕਰ
@@ -26655,7 +26655,7 @@ MG|ro|*aa
 MG|ru|*be
 MG|rw|*aa
 MG|sa|*aa
-MG|sc|*aa
+MG|sc|Madagascàr
 MG|sd|مدگاسڪر
 MG|se|*af
 MG|sg|Madagaskära
@@ -26695,7 +26695,7 @@ MG|vi|*aa
 MG|vo|*aa
 MG|wa|*aa
 MG|wo|*ff
-MG|xh|*aa
+MG|xh|EMadagascar
 MG|yi|*ji
 MG|yo|Madasika
 MG|za|*aa
@@ -26705,8 +26705,8 @@ MH|aa|Marshall Islands
 MH|ab|*aa
 MH|ae|*aa
 MH|af|Marshalleilande
-MH|ak|*aa
-MH|am|ማርሻል አይላንድ
+MH|ak|Mahyaa Aeland
+MH|am|ማርሻል ደሴቶች
 MH|an|*aa
 MH|ar|جزر مارشال
 MH|as|মাৰ্শ্বাল দ্বীপপুঞ্জ
@@ -26730,7 +26730,7 @@ MH|co|*aa
 MH|cr|*aa
 MH|cs|Marshallovy ostrovy
 MH|cu|*aa
-MH|cv|*aa
+MH|cv|Маршаллов утравӗсем
 MH|cy|Ynysoedd Marshall
 MH|da|Marshalløerne
 MH|de|Marshallinseln
@@ -26761,7 +26761,7 @@ MH|he|איי מרשל
 MH|hi|मार्शल द्वीपसमूह
 MH|ho|*aa
 MH|hr|Maršalovi Otoci
-MH|ht|*aa
+MH|ht|*fr
 MH|hu|Marshall-szigetek
 MH|hy|Մարշալյան կղզիներ
 MH|hz|*aa
@@ -26791,7 +26791,7 @@ MH|kn|ಮಾರ್ಷಲ್ ದ್ವೀಪಗಳು
 MH|ko|마셜 제도
 MH|kr|*aa
 MH|ks|مارشَل جٔزیٖرٕ
-MH|ku|Giravên Marşal
+MH|ku|Giravên Marşalê
 MH|kv|*aa
 MH|kw|*aa
 MH|ky|*kk
@@ -26806,7 +26806,7 @@ MH|lu|Lutanda lua Marishale
 MH|lv|Māršala salas
 MH|mg|Nosy Marshall
 MH|mh|*aa
-MH|mi|*aa
+MH|mi|Ngā Motu Māhara
 MH|mk|Маршалски Острови
 MH|ml|മാർഷൽ ദ്വീപുകൾ
 MH|mn|Маршаллын арлууд
@@ -26828,7 +26828,7 @@ MH|nv|*aa
 MH|ny|*aa
 MH|oc|*aa
 MH|oj|*aa
-MH|om|*aa
+MH|om|Odoloota Maarshaal
 MH|or|ମାର୍ଶାଲ୍ ଦ୍ୱୀପପୁଞ୍ଜ
 MH|os|*aa
 MH|pa|ਮਾਰਸ਼ਲ ਟਾਪੂ
@@ -26840,10 +26840,10 @@ MH|qu|*es
 MH|rm|Inslas da Marshall
 MH|rn|Izinga rya Marishari
 MH|ro|*mo
-MH|ru|Маршалловы Острова
+MH|ru|Маршалловы о-ва
 MH|rw|*aa
 MH|sa|*aa
-MH|sc|*aa
+MH|sc|Ìsulas Marshall
 MH|sd|مارشل ٻيٽ
 MH|se|Marshallsullot
 MH|sg|Âzûâ Märshâl
@@ -26864,7 +26864,7 @@ MH|ta|மார்ஷல் தீவுகள்
 MH|te|మార్షల్ దీవులు
 MH|tg|Ҷазираҳои Маршалл
 MH|th|หมู่เกาะมาร์แชลล์
-MH|ti|*am
+MH|ti|ደሴታት ማርሻል
 MH|tk|Marşall adalary
 MH|tl|*aa
 MH|tn|*aa
@@ -26883,7 +26883,7 @@ MH|vi|Quần đảo Marshall
 MH|vo|*aa
 MH|wa|*aa
 MH|wo|Duni Marsaal
-MH|xh|*aa
+MH|xh|EMarshall Islands
 MH|yi|*ji
 MH|yo|Etikun Máṣali
 MH|za|*aa
@@ -26893,7 +26893,7 @@ MK|aa|North Macedonia
 MK|ab|*aa
 MK|ae|*aa
 MK|af|Noord-Macedonië
-MK|ak|*aa
+MK|ak|Mesidonia Atifi
 MK|am|ሰሜን መቄዶንያ
 MK|an|*aa
 MK|ar|مقدونيا الشمالية
@@ -26918,7 +26918,7 @@ MK|co|*aa
 MK|cr|*aa
 MK|cs|Severní Makedonie
 MK|cu|*aa
-MK|cv|*aa
+MK|cv|Ҫурҫӗр Македони
 MK|cy|Gogledd Macedonia
 MK|da|Nordmakedonien
 MK|de|Nordmazedonien
@@ -26949,20 +26949,20 @@ MK|he|מקדוניה הצפונית
 MK|hi|उत्तरी मकदूनिया
 MK|ho|*aa
 MK|hr|*bs
-MK|ht|*aa
+MK|ht|*fr
 MK|hu|Észak-Macedónia
 MK|hy|Հյուսիսային Մակեդոնիա
 MK|hz|*aa
-MK|ia|Macedonia
+MK|ia|Macedonia del Nord
 MK|id|Makedonia Utara
-MK|ie|*aa
+MK|ie|Nord-Macedonia
 MK|ig|*aa
 MK|ii|*aa
 MK|ik|*aa
 MK|in|*id
 MK|io|*aa
 MK|is|Norður-Makedónía
-MK|it|Macedonia del Nord
+MK|it|*ia
 MK|iu|*aa
 MK|iw|*he
 MK|ja|北マケドニア
@@ -26978,8 +26978,8 @@ MK|km|ម៉ាសេដ្វានខាងជើង
 MK|kn|ಉತ್ತರ ಮ್ಯಾಸಿಡೋನಿಯಾ
 MK|ko|북마케도니아
 MK|kr|*aa
-MK|ks|*aa
-MK|ku|Makedonya
+MK|ks|شُمالی میسڈونیا
+MK|ku|Makendonyaya Bakur
 MK|kv|*aa
 MK|kw|*aa
 MK|ky|Түндүк Македония
@@ -27016,7 +27016,7 @@ MK|nv|*aa
 MK|ny|*aa
 MK|oc|*aa
 MK|oj|*aa
-MK|om|*aa
+MK|om|Maqdooniyaa Kaabaa
 MK|or|ଉତ୍ତର ମାସେଡୋନିଆ
 MK|os|*aa
 MK|pa|ਉੱਤਰੀ ਮੈਕਡੋਨੀਆ
@@ -27031,7 +27031,7 @@ MK|ro|*mo
 MK|ru|Северная Македония
 MK|rw|Masedoniya y’Amajyaruguru
 MK|sa|*aa
-MK|sc|*aa
+MK|sc|Matzedònia de su Nord
 MK|sd|اتر مقدونيا
 MK|se|*aa
 MK|sg|*aa
@@ -27052,7 +27052,7 @@ MK|ta|வடக்கு மாசிடோனியா
 MK|te|ఉత్తర మాసిడోనియా
 MK|tg|Македонияи Шимолӣ
 MK|th|มาซิโดเนียเหนือ
-MK|ti|ሰሜን መቆዶንያ
+MK|ti|*am
 MK|tk|Demirgazyk Makedoniýa
 MK|tl|*aa
 MK|tn|*aa
@@ -27071,7 +27071,7 @@ MK|vi|Bắc Macedonia
 MK|vo|*aa
 MK|wa|*aa
 MK|wo|Maseduwaan bëj Gànnaar
-MK|xh|uMntla Macedonia
+MK|xh|EMntla Macedonia
 MK|yi|*aa
 MK|yo|Àríwá Macedonia
 MK|za|*aa
@@ -27106,7 +27106,7 @@ ML|co|*aa
 ML|cr|*aa
 ML|cs|*aa
 ML|cu|*aa
-ML|cv|*aa
+ML|cv|*bg
 ML|cy|*aa
 ML|da|*aa
 ML|de|*aa
@@ -27182,7 +27182,7 @@ ML|lu|*aa
 ML|lv|*aa
 ML|mg|*aa
 ML|mh|*aa
-ML|mi|*aa
+ML|mi|Māri
 ML|mk|*bg
 ML|ml|മാലി
 ML|mn|*bg
@@ -27204,7 +27204,7 @@ ML|nv|*aa
 ML|ny|*aa
 ML|oc|*aa
 ML|oj|*aa
-ML|om|*aa
+ML|om|Maalii
 ML|or|ମାଲି
 ML|os|*aa
 ML|pa|ਮਾਲੀ
@@ -27259,7 +27259,7 @@ ML|vi|*aa
 ML|vo|*aa
 ML|wa|*aa
 ML|wo|*aa
-ML|xh|*aa
+ML|xh|EMali
 ML|yi|*ji
 ML|yo|*aa
 ML|za|*aa
@@ -27269,7 +27269,7 @@ MM|aa|Myanmar (Burma)
 MM|ab|*aa
 MM|ae|*aa
 MM|af|Mianmar (Birma)
-MM|ak|Miyanma
+MM|ak|Mayaama (Bɛɛma)
 MM|am|ማይናማር(በርማ)
 MM|an|*aa
 MM|ar|ميانمار (بورما)
@@ -27286,7 +27286,7 @@ MM|bm|Myanimari
 MM|bn|মায়ানমার (বার্মা)
 MM|bo|*aa
 MM|br|Myanmar (Birmania)
-MM|bs|Mjanmar
+MM|bs|Mijanmar
 MM|ca|Myanmar (Birmània)
 MM|ce|Мьянма (Бирма)
 MM|ch|*aa
@@ -27294,7 +27294,7 @@ MM|co|*aa
 MM|cr|*aa
 MM|cs|Myanmar (Barma)
 MM|cu|*aa
-MM|cv|*aa
+MM|cv|*ce
 MM|cy|*aa
 MM|da|*aa
 MM|de|Myanmar
@@ -27303,7 +27303,7 @@ MM|dz|མི་ཡཱན་མར་ (བྷར་མ)
 MM|ee|Myanmar (Burma) nutome
 MM|el|Μιανμάρ (Βιρμανία)
 MM|en|*aa
-MM|eo|Mjanmao
+MM|eo|Birmo
 MM|es|*br
 MM|et|Myanmar (Birma)
 MM|eu|*br
@@ -27325,11 +27325,11 @@ MM|he|מיאנמר (בורמה)
 MM|hi|म्यांमार (बर्मा)
 MM|ho|*aa
 MM|hr|Mjanmar (Burma)
-MM|ht|*aa
+MM|ht|*fr
 MM|hu|Mianmar
 MM|hy|Մյանմա (Բիրմա)
 MM|hz|*aa
-MM|ia|*aa
+MM|ia|*br
 MM|id|*aa
 MM|ie|*aa
 MM|ig|*aa
@@ -27354,8 +27354,8 @@ MM|km|មីយ៉ាន់ម៉ា (ភូមា)
 MM|kn|ಮಯನ್ಮಾರ್ (ಬರ್ಮಾ)
 MM|ko|미얀마
 MM|kr|*aa
-MM|ks|مَیَنما بٔرما
-MM|ku|Myanmar (Birmanya)
+MM|ks|میانمار (برما)
+MM|ku|Myanmar (Bûrma)
 MM|kv|*aa
 MM|kw|*aa
 MM|ky|*ce
@@ -27370,7 +27370,7 @@ MM|lu|Myamare
 MM|lv|Mjanma (Birma)
 MM|mg|*de
 MM|mh|*aa
-MM|mi|*aa
+MM|mi|Pēma
 MM|mk|Мјанмар (Бурма)
 MM|ml|മ്യാൻമാർ (ബർമ്മ)
 MM|mn|Мьянмар
@@ -27392,7 +27392,7 @@ MM|nv|*aa
 MM|ny|*aa
 MM|oc|*aa
 MM|oj|*aa
-MM|om|*aa
+MM|om|Maayinaamar (Burma)
 MM|or|ମିଆଁମାର
 MM|os|*aa
 MM|pa|ਮਿਆਂਮਾਰ (ਬਰਮਾ)
@@ -27407,7 +27407,7 @@ MM|ro|*br
 MM|ru|*ce
 MM|rw|*aa
 MM|sa|*aa
-MM|sc|*aa
+MM|sc|Myanmàr (Birmània)
 MM|sd|*ps
 MM|se|Burma
 MM|sg|Myämâra
@@ -27428,26 +27428,26 @@ MM|ta|மியான்மார் (பர்மா)
 MM|te|మయన్మార్
 MM|tg|Мянма
 MM|th|เมียนมา (พม่า)
-MM|ti|ማያንማር
+MM|ti|ሚያንማር (በርማ)
 MM|tk|Mýanma (Birma)
 MM|tl|*aa
 MM|tn|*aa
 MM|to|Mianimā (Pema)
 MM|tr|*aa
 MM|ts|*aa
-MM|tt|*aa
+MM|tt|*ce
 MM|tw|*aa
 MM|ty|*aa
 MM|ug|بىرما
 MM|uk|Мʼянма (Бірма)
-MM|ur|میانمار (برما)
+MM|ur|*ks
 MM|uz|Myanma (Birma)
 MM|ve|*aa
 MM|vi|Myanmar (Miến Điện)
 MM|vo|*aa
 MM|wa|*aa
 MM|wo|Miyanmaar
-MM|xh|*aa
+MM|xh|EMyanmar (Burma)
 MM|yi|*ji
 MM|yo|Manamari
 MM|za|*aa
@@ -27482,7 +27482,7 @@ MN|co|*aa
 MN|cr|*aa
 MN|cs|Mongolsko
 MN|cu|*aa
-MN|cv|*aa
+MN|cv|*ce
 MN|cy|*aa
 MN|da|Mongoliet
 MN|de|Mongolei
@@ -27513,7 +27513,7 @@ MN|he|מונגוליה
 MN|hi|मंगोलिया
 MN|ho|*aa
 MN|hr|*bs
-MN|ht|*aa
+MN|ht|*fr
 MN|hu|Mongólia
 MN|hy|Մոնղոլիա
 MN|hz|*aa
@@ -27543,7 +27543,7 @@ MN|kn|ಮಂಗೋಲಿಯಾ
 MN|ko|몽골
 MN|kr|*aa
 MN|ks|مَنگولِیا
-MN|ku|Mongolya
+MN|ku|Moxolistan
 MN|kv|*aa
 MN|kw|*aa
 MN|ky|*bg
@@ -27558,7 +27558,7 @@ MN|lu|Mongoli
 MN|lv|*bs
 MN|mg|Môngôlia
 MN|mh|*aa
-MN|mi|*aa
+MN|mi|Mongōria
 MN|mk|Монголија
 MN|ml|മംഗോളിയ
 MN|mn|Монгол
@@ -27580,7 +27580,7 @@ MN|nv|*aa
 MN|ny|*aa
 MN|oc|*aa
 MN|oj|*aa
-MN|om|*aa
+MN|om|Mongoliyaa
 MN|or|ମଙ୍ଗୋଲିଆ
 MN|os|*aa
 MN|pa|ਮੰਗੋਲੀਆ
@@ -27595,7 +27595,7 @@ MN|ro|*aa
 MN|ru|*bg
 MN|rw|*aa
 MN|sa|*aa
-MN|sc|*aa
+MN|sc|*ca
 MN|sd|منگوليا
 MN|se|*aa
 MN|sg|Mongolïi
@@ -27616,7 +27616,7 @@ MN|ta|மங்கோலியா
 MN|te|మంగోలియా
 MN|tg|Муғулистон
 MN|th|มองโกเลีย
-MN|ti|*am
+MN|ti|ሞንጎልያ
 MN|tk|Mongoliýa
 MN|tl|*aa
 MN|tn|*aa
@@ -27635,7 +27635,7 @@ MN|vi|Mông Cổ
 MN|vo|*aa
 MN|wa|*aa
 MN|wo|*lu
-MN|xh|*aa
+MN|xh|EMongolia
 MN|yi|*ji
 MN|yo|Mogolia
 MN|za|*aa
@@ -27645,7 +27645,7 @@ MO|aa|Macao SAR China
 MO|ab|*aa
 MO|ae|*aa
 MO|af|Macau SAS China
-MO|ak|*aa
+MO|ak|Makaw Kyaena
 MO|am|ማካኦ ልዩ የአስተዳደር ክልል ቻይና
 MO|an|*aa
 MO|ar|منطقة ماكاو الإدارية الخاصة
@@ -27659,7 +27659,7 @@ MO|bg|Макао, САР на Китай
 MO|bh|*aa
 MO|bi|*aa
 MO|bm|*aa
-MO|bn|ম্যাকাও এসএআর চীনা চীনা (ম্যাকাও এসএআর চীনা) চীনা (ঐতিহ্যবাহী, ম্যাকাও এসএআর চীনা) অঞ্চল: ম্যাকাও এসএআর চীন
+MO|bn|ম্যাকাও এসএআর চীন
 MO|bo|*aa
 MO|br|Macau RMD Sina
 MO|bs|Makao (SAR Kina)
@@ -27670,7 +27670,7 @@ MO|co|*aa
 MO|cr|*aa
 MO|cs|Macao – ZAO Číny
 MO|cu|*aa
-MO|cv|*aa
+MO|cv|Макао (САР)
 MO|cy|Macau SAR Tsieina
 MO|da|SAR Macao
 MO|de|Sonderverwaltungsregion Macau
@@ -27690,7 +27690,7 @@ MO|fj|*aa
 MO|fo|Makao SAR Kina
 MO|fr|R.A.S. chinoise de Macao
 MO|fy|Macao SAR van Sina
-MO|ga|S.R.R. na Síne Macao
+MO|ga|Sainréigiún Riaracháin Macao, Daonphoblacht na Síne
 MO|gd|Macàthu SAR na Sìne
 MO|gl|Macau RAE da China
 MO|gn|*aa
@@ -27701,11 +27701,11 @@ MO|he|מקאו (אזור מנהלי מיוחד של סין)
 MO|hi|मकाऊ (विशेष प्रशासनिक क्षेत्र चीन)
 MO|ho|*aa
 MO|hr|PUP Makao Kina
-MO|ht|*aa
+MO|ht|*fr
 MO|hu|Makaó KKT
 MO|hy|Չինաստանի Մակաո ՀՎՇ
 MO|hz|*aa
-MO|ia|*aa
+MO|ia|Macao, R.A.S. de China
 MO|id|Makau DAK Tiongkok
 MO|ie|*aa
 MO|ig|*aa
@@ -27727,11 +27727,11 @@ MO|kj|*aa
 MO|kk|Макао АӘА
 MO|kl|*aa
 MO|km|ម៉ាកាវ តំបន់រដ្ឋបាលពិសេសចិន
-MO|kn|ಮಕಾವು SAR ಚೈನಾ
+MO|kn|ಮಕಾವು ಎಸ್ಎಆರ್ ಚೈನಾ
 MO|ko|마카오(중국 특별행정구)
 MO|kr|*aa
 MO|ks|مَکاوو ایس اے آر چیٖن
-MO|ku|*aa
+MO|ku|Makaoya Hît ya Çînê
 MO|kv|*aa
 MO|kw|*aa
 MO|ky|Макао Кытай ААА
@@ -27746,9 +27746,9 @@ MO|lu|*aa
 MO|lv|ĶTR īpašais administratīvais reģions Makao
 MO|mg|*aa
 MO|mh|*aa
-MO|mi|*aa
+MO|mi|Makau Haina
 MO|mk|Макао САР
-MO|ml|മക്കാവു SAR ചൈന
+MO|ml|മക്കാവു എസ്.എ.ആർ. ചൈന
 MO|mn|БНХАУ-ын Тусгай захиргааны бүс Макао
 MO|mo|R.A.S. Macao, China
 MO|mr|मकाओ एसएआर चीन
@@ -27768,7 +27768,7 @@ MO|nv|*aa
 MO|ny|*aa
 MO|oc|*aa
 MO|oj|*aa
-MO|om|*aa
+MO|om|Maka’oo SAR Chaayinaa
 MO|or|ମାକାଉ ଏସଏଆର୍‌ ଚାଇନା
 MO|os|*aa
 MO|pa|ਮਕਾਉ ਐਸਏਆਰ ਚੀਨ
@@ -27780,10 +27780,10 @@ MO|qu|Macao RAE China
 MO|rm|Regiun d’administraziun speziala Macao, China
 MO|rn|*aa
 MO|ro|*mo
-MO|ru|Макао (САР)
+MO|ru|*cv
 MO|rw|*aa
 MO|sa|*aa
-MO|sc|*aa
+MO|sc|RAS tzinesa de Macao
 MO|sd|مڪائو SAR چين
 MO|se|Makáo
 MO|sg|*aa
@@ -27804,7 +27804,7 @@ MO|ta|மகாவ் எஸ்ஏஆர் சீனா
 MO|te|మకావ్ ఎస్ఏఆర్ చైనా
 MO|tg|Макао (МММ)
 MO|th|เขตปกครองพิเศษมาเก๊าแห่งสาธารณรัฐประชาชนจีน
-MO|ti|ፍሉይ ምምሕዳር ዞባ ማካዎ
+MO|ti|ፍሉይ ምምሕዳራዊ ዞባ ማካው (ቻይና)
 MO|tk|Makao AAS Hytaý
 MO|tl|*ms
 MO|tn|*aa
@@ -27822,8 +27822,8 @@ MO|ve|*aa
 MO|vi|Đặc khu Hành chính Macao, Trung Quốc
 MO|vo|*aa
 MO|wa|*aa
-MO|wo|*aa
-MO|xh|*aa
+MO|wo|Makaawo
+MO|xh|EMacao SAR China
 MO|yi|*aa
 MO|yo|Agbègbè Ìṣàkóso Pàtàkì Macao
 MO|za|*aa
@@ -27833,7 +27833,7 @@ MP|aa|Northern Mariana Islands
 MP|ab|*aa
 MP|ae|*aa
 MP|af|Noord-Mariane-eilande
-MP|ak|*aa
+MP|ak|Mariana Atifi Fam Aeland
 MP|am|የሰሜናዊ ማሪያና ደሴቶች
 MP|an|*aa
 MP|ar|جزر ماريانا الشمالية
@@ -27851,14 +27851,14 @@ MP|bn|উত্তরাঞ্চলীয় মারিয়ানা দ্
 MP|bo|*aa
 MP|br|Inizi Mariana an Norzh
 MP|bs|Sjeverna Marijanska ostrva
-MP|ca|Illes Mariannes del Nord
+MP|ca|Illes Marianes del Nord
 MP|ce|Къилбаседа Марианан гӀайренаш
 MP|ch|*aa
 MP|co|*aa
 MP|cr|*aa
 MP|cs|Severní Mariany
 MP|cu|*aa
-MP|cv|*aa
+MP|cv|Ҫурҫӗр Мариан утравӗсем
 MP|cy|Ynysoedd Gogledd Mariana
 MP|da|Nordmarianerne
 MP|de|Nördliche Marianen
@@ -27878,7 +27878,7 @@ MP|fj|*aa
 MP|fo|Norðaru Mariuoyggjar
 MP|fr|Îles Mariannes du Nord
 MP|fy|Noardlike Marianeneilannen
-MP|ga|na hOileáin Mháirianacha Thuaidh
+MP|ga|Na hOileáin Mháirianacha Thuaidh
 MP|gd|Na h-Eileanan Mairianach a Tuath
 MP|gl|Illas Marianas do Norte
 MP|gn|*aa
@@ -27888,8 +27888,8 @@ MP|ha|Tsibiran Mariyana Na Arewa
 MP|he|איי מריאנה הצפוניים
 MP|hi|उत्तरी मारियाना द्वीपसमूह
 MP|ho|*aa
-MP|hr|Sjevernomarijanski otoci
-MP|ht|*aa
+MP|hr|Sjevernomarijanski Otoci
+MP|ht|*fr
 MP|hu|Északi Mariana-szigetek
 MP|hy|Հյուսիսային Մարիանյան կղզիներ
 MP|hz|*aa
@@ -27902,7 +27902,7 @@ MP|ik|*aa
 MP|in|*id
 MP|io|*aa
 MP|is|Norður-Maríanaeyjar
-MP|it|Isole Marianne settentrionali
+MP|it|Isole Marianne Settentrionali
 MP|iu|*aa
 MP|iw|*he
 MP|ja|北マリアナ諸島
@@ -27934,7 +27934,7 @@ MP|lu|Lutanda lua Mariane wa muulu
 MP|lv|Ziemeļu Marianas salas
 MP|mg|Nosy Mariana Atsinanana
 MP|mh|*aa
-MP|mi|*aa
+MP|mi|Ngā Motu Mariana ki te Raki
 MP|mk|Северни Маријански Острови
 MP|ml|ഉത്തര മറിയാനാ ദ്വീപുകൾ
 MP|mn|Хойд Марианы арлууд
@@ -27956,7 +27956,7 @@ MP|nv|*aa
 MP|ny|*aa
 MP|oc|*aa
 MP|oj|*aa
-MP|om|*aa
+MP|om|Odola Maariyaanaa Kaabaa
 MP|or|ଉତ୍ତର ମାରିଆନା ଦ୍ୱୀପପୁଞ୍ଜ
 MP|os|*aa
 MP|pa|ਉੱਤਰੀ ਮਾਰੀਆਨਾ ਟਾਪੂ
@@ -27971,7 +27971,7 @@ MP|ro|*mo
 MP|ru|Северные Марианские о-ва
 MP|rw|*aa
 MP|sa|*aa
-MP|sc|*aa
+MP|sc|Ìsulas Mariannas setentrionales
 MP|sd|اتريان ماريانا ٻيٽ
 MP|se|Davvi-Mariánat
 MP|sg|Âzûâ Märïâni tî Banga
@@ -27992,7 +27992,7 @@ MP|ta|வடக்கு மரியானா தீவுகள்
 MP|te|ఉత్తర మరియానా దీవులు
 MP|tg|Ҷазираҳои Марианаи Шимолӣ
 MP|th|หมู่เกาะนอร์เทิร์นมาเรียนา
-MP|ti|ደሴታት ሰሜናዊ ማሪያና
+MP|ti|ሰሜናዊ ደሴታት ማርያና
 MP|tk|Demirgazyk Mariana adalary
 MP|tl|*aa
 MP|tn|*aa
@@ -28011,7 +28011,7 @@ MP|vi|Quần đảo Bắc Mariana
 MP|vo|*aa
 MP|wa|*aa
 MP|wo|Duni Mariyaan Noor
-MP|xh|*aa
+MP|xh|ENorthern Mariana Islands
 MP|yi|*aa
 MP|yo|Etikun Guusu Mariana
 MP|za|*aa
@@ -28046,7 +28046,7 @@ MQ|co|*aa
 MQ|cr|*aa
 MQ|cs|*az
 MQ|cu|*aa
-MQ|cv|*aa
+MQ|cv|*bg
 MQ|cy|*aa
 MQ|da|*aa
 MQ|de|*aa
@@ -28076,14 +28076,14 @@ MQ|ha|*az
 MQ|he|מרטיניק
 MQ|hi|मार्टीनिक
 MQ|ho|*aa
-MQ|hr|*aa
+MQ|hr|*az
 MQ|ht|*aa
 MQ|hu|*aa
 MQ|hy|Մարտինիկա
 MQ|hz|*aa
-MQ|ia|*aa
+MQ|ia|*ca
 MQ|id|*az
-MQ|ie|*aa
+MQ|ie|*ca
 MQ|ig|*aa
 MQ|ii|*aa
 MQ|ik|*aa
@@ -28107,7 +28107,7 @@ MQ|kn|ಮಾರ್ಟಿನಿಕ್
 MQ|ko|마르티니크
 MQ|kr|*aa
 MQ|ks|مارٹِنِک
-MQ|ku|*aa
+MQ|ku|Martînîk
 MQ|kv|*aa
 MQ|kw|*aa
 MQ|ky|*bg
@@ -28122,7 +28122,7 @@ MQ|lu|*ki
 MQ|lv|*eu
 MQ|mg|*eu
 MQ|mh|*aa
-MQ|mi|*aa
+MQ|mi|Mātiniki
 MQ|mk|Мартиник
 MQ|ml|മാർട്ടിനിക്ക്
 MQ|mn|*mk
@@ -28144,7 +28144,7 @@ MQ|nv|*aa
 MQ|ny|*aa
 MQ|oc|*aa
 MQ|oj|*aa
-MQ|om|*aa
+MQ|om|Martinikuwee
 MQ|or|ମାର୍ଟିନିକ୍ୟୁ
 MQ|os|*aa
 MQ|pa|ਮਾਰਟੀਨਿਕ
@@ -28159,7 +28159,7 @@ MQ|ro|*ca
 MQ|ru|*bg
 MQ|rw|*aa
 MQ|sa|*aa
-MQ|sc|*aa
+MQ|sc|*ca
 MQ|sd|مارتينڪ
 MQ|se|*aa
 MQ|sg|Märtïnîki
@@ -28184,7 +28184,7 @@ MQ|ti|*am
 MQ|tk|*eu
 MQ|tl|*aa
 MQ|tn|*aa
-MQ|to|Mātiniki
+MQ|to|*mi
 MQ|tr|*az
 MQ|ts|*aa
 MQ|tt|*bg
@@ -28199,7 +28199,7 @@ MQ|vi|*aa
 MQ|vo|*aa
 MQ|wa|*aa
 MQ|wo|*az
-MQ|xh|*aa
+MQ|xh|EMartinique
 MQ|yi|*ji
 MQ|yo|Matinikuwi
 MQ|za|*aa
@@ -28234,7 +28234,7 @@ MR|co|*aa
 MR|cr|*aa
 MR|cs|Mauritánie
 MR|cu|*aa
-MR|cv|*aa
+MR|cv|*ce
 MR|cy|*aa
 MR|da|Mauretanien
 MR|de|*da
@@ -28254,7 +28254,7 @@ MR|fj|*aa
 MR|fo|Móritania
 MR|fr|Mauritanie
 MR|fy|*af
-MR|ga|an Mháratáin
+MR|ga|An Mháratái
 MR|gd|Moratàinea
 MR|gl|*aa
 MR|gn|*aa
@@ -28265,7 +28265,7 @@ MR|he|מאוריטניה
 MR|hi|मॉरिटानिया
 MR|ho|*aa
 MR|hr|Mauretanija
-MR|ht|*aa
+MR|ht|*fr
 MR|hu|Mauritánia
 MR|hy|Մավրիտանիա
 MR|hz|*aa
@@ -28310,7 +28310,7 @@ MR|lu|*ln
 MR|lv|Mauritānija
 MR|mg|Maoritania
 MR|mh|*aa
-MR|mi|*aa
+MR|mi|Mauritānia
 MR|mk|Мавританија
 MR|ml|മൗറിറ്റാനിയ
 MR|mn|*ce
@@ -28332,7 +28332,7 @@ MR|nv|*aa
 MR|ny|*aa
 MR|oc|*aa
 MR|oj|*aa
-MR|om|*aa
+MR|om|Mawuritaaniyaa
 MR|or|ମୌରିଟାନିଆ
 MR|os|*aa
 MR|pa|ਮੋਰਿਟਾਨੀਆ
@@ -28347,7 +28347,7 @@ MR|ro|*aa
 MR|ru|*bg
 MR|rw|*aa
 MR|sa|*aa
-MR|sc|*aa
+MR|sc|*ca
 MR|sd|*ar
 MR|se|Mauretánia
 MR|sg|Moritanïi
@@ -28365,10 +28365,10 @@ MR|su|*aa
 MR|sv|*da
 MR|sw|*ki
 MR|ta|மௌரிடானியா
-MR|te|మౌరిటేనియా
+MR|te|మారిటేనియా
 MR|tg|*bg
 MR|th|มอริเตเนีย
-MR|ti|*am
+MR|ti|ማውሪታንያ
 MR|tk|Mawritaniýa
 MR|tl|*aa
 MR|tn|*aa
@@ -28387,7 +28387,7 @@ MR|vi|*aa
 MR|vo|*aa
 MR|wa|*aa
 MR|wo|Mooritani
-MR|xh|*aa
+MR|xh|EMauritania
 MR|yi|*ji
 MR|yo|Maritania
 MR|za|*aa
@@ -28422,7 +28422,7 @@ MS|co|*aa
 MS|cr|*aa
 MS|cs|*aa
 MS|cu|*aa
-MS|cv|*aa
+MS|cv|*ce
 MS|cy|*aa
 MS|da|*aa
 MS|de|*aa
@@ -28483,7 +28483,7 @@ MS|kn|ಮಾಂಟ್‌ಸೆರಟ್
 MS|ko|몬트세라트
 MS|kr|*aa
 MS|ks|مانٹسیراٹ
-MS|ku|*aa
+MS|ku|Montserat
 MS|kv|*aa
 MS|kw|*aa
 MS|ky|*ce
@@ -28498,7 +28498,7 @@ MS|lu|Musera
 MS|lv|Montserrata
 MS|mg|*aa
 MS|mh|*aa
-MS|mi|*aa
+MS|mi|Monoterā
 MS|mk|Монсерат
 MS|ml|മൊണ്ടെസരത്ത്
 MS|mn|*ce
@@ -28520,7 +28520,7 @@ MS|nv|*aa
 MS|ny|*aa
 MS|oc|*aa
 MS|oj|*aa
-MS|om|*aa
+MS|om|Montiseerat
 MS|or|ମଣ୍ଟେସେରାଟ୍
 MS|os|*aa
 MS|pa|ਮੋਂਟਸੇਰਾਤ
@@ -28545,7 +28545,7 @@ MS|sl|*aa
 MS|sm|*aa
 MS|sn|*aa
 MS|so|*aa
-MS|sq|Montserat
+MS|sq|*ku
 MS|sr|*mk
 MS|ss|*aa
 MS|st|*aa
@@ -28556,7 +28556,7 @@ MS|ta|மாண்ட்செராட்
 MS|te|మాంట్సెరాట్
 MS|tg|*ce
 MS|th|มอนต์เซอร์รัต
-MS|ti|*am
+MS|ti|ሞንትሰራት
 MS|tk|Monserrat
 MS|tl|*aa
 MS|tn|*aa
@@ -28575,7 +28575,7 @@ MS|vi|*aa
 MS|vo|*aa
 MS|wa|*aa
 MS|wo|Mooseraa
-MS|xh|*aa
+MS|xh|EMontserrat
 MS|yi|*ji
 MS|yo|Motserati
 MS|za|*aa
@@ -28610,7 +28610,7 @@ MT|co|*aa
 MT|cr|*aa
 MT|cs|*aa
 MT|cu|*aa
-MT|cv|*aa
+MT|cv|*be
 MT|cy|*aa
 MT|da|*aa
 MT|de|*aa
@@ -28641,7 +28641,7 @@ MT|he|מלטה
 MT|hi|माल्टा
 MT|ho|*aa
 MT|hr|*aa
-MT|ht|*aa
+MT|ht|*ff
 MT|hu|*ga
 MT|hy|Մալթա
 MT|hz|*aa
@@ -28686,7 +28686,7 @@ MT|lu|Malite
 MT|lv|*aa
 MT|mg|*aa
 MT|mh|*aa
-MT|mi|*aa
+MT|mi|Mārata
 MT|mk|*bg
 MT|ml|മാൾട്ട
 MT|mn|*be
@@ -28708,7 +28708,7 @@ MT|nv|*aa
 MT|ny|*aa
 MT|oc|*aa
 MT|oj|*aa
-MT|om|*aa
+MT|om|Maaltaa
 MT|or|ମାଲ୍ଟା
 MT|os|*aa
 MT|pa|ਮਾਲਟਾ
@@ -28763,7 +28763,7 @@ MT|vi|*aa
 MT|vo|*aa
 MT|wa|*aa
 MT|wo|Malt
-MT|xh|*aa
+MT|xh|EMalta
 MT|yi|*ji
 MT|yo|Malata
 MT|za|*aa
@@ -28798,7 +28798,7 @@ MU|co|*aa
 MU|cr|*aa
 MU|cs|Mauricius
 MU|cu|*aa
-MU|cv|*aa
+MU|cv|*ce
 MU|cy|*aa
 MU|da|*aa
 MU|de|*aa
@@ -28829,13 +28829,13 @@ MU|he|מאוריציוס
 MU|hi|मॉरीशस
 MU|ho|*aa
 MU|hr|*bs
-MU|ht|*aa
+MU|ht|*fr
 MU|hu|*aa
 MU|hy|Մավրիկիոս
 MU|hz|*aa
-MU|ia|*aa
+MU|ia|Mauritio
 MU|id|*aa
-MU|ie|*aa
+MU|ie|*es
 MU|ig|*aa
 MU|ii|*aa
 MU|ik|*aa
@@ -28859,7 +28859,7 @@ MU|kn|ಮಾರಿಷಸ್
 MU|ko|모리셔스
 MU|kr|*aa
 MU|ks|مورِشَس
-MU|ku|Maurîtius
+MU|ku|*aa
 MU|kv|*aa
 MU|kw|*aa
 MU|ky|*kk
@@ -28874,7 +28874,7 @@ MU|lu|Morise
 MU|lv|Maurīcija
 MU|mg|Maorisy
 MU|mh|*aa
-MU|mi|*aa
+MU|mi|Marihi
 MU|mk|Маврициус
 MU|ml|മൗറീഷ്യസ്
 MU|mn|*kk
@@ -28896,7 +28896,7 @@ MU|nv|*aa
 MU|ny|*aa
 MU|oc|*aa
 MU|oj|*aa
-MU|om|*aa
+MU|om|Moorishiyees
 MU|or|ମରିସସ
 MU|os|*aa
 MU|pa|ਮੌਰੀਸ਼ਸ
@@ -28911,7 +28911,7 @@ MU|ro|*aa
 MU|ru|*kk
 MU|rw|*aa
 MU|sa|*aa
-MU|sc|*aa
+MU|sc|Maurìtzius
 MU|sd|موريشس
 MU|se|*aa
 MU|sg|Mörîsi
@@ -28932,7 +28932,7 @@ MU|ta|மொரிசியஸ்
 MU|te|మారిషస్
 MU|tg|*kk
 MU|th|มอริเชียส
-MU|ti|ማሩሸስ
+MU|ti|ማውሪሸስ
 MU|tk|Mawrikiý
 MU|tl|*aa
 MU|tn|*aa
@@ -28951,7 +28951,7 @@ MU|vi|*aa
 MU|vo|*aa
 MU|wa|*aa
 MU|wo|*ff
-MU|xh|*aa
+MU|xh|EMauritius
 MU|yi|*ji
 MU|yo|Maritiusi
 MU|za|*aa
@@ -28986,7 +28986,7 @@ MV|co|*aa
 MV|cr|*aa
 MV|cs|Maledivy
 MV|cu|*aa
-MV|cv|*aa
+MV|cv|Мальдивсем
 MV|cy|Y Maldives
 MV|da|Maldiverne
 MV|de|Malediven
@@ -29021,9 +29021,9 @@ MV|ht|*aa
 MV|hu|Maldív-szigetek
 MV|hy|Մալդիվներ
 MV|hz|*aa
-MV|ia|*aa
+MV|ia|*es
 MV|id|Maladewa
-MV|ie|*aa
+MV|ie|*es
 MV|ig|Maldivesa
 MV|ii|*aa
 MV|ik|*aa
@@ -29047,7 +29047,7 @@ MV|kn|ಮಾಲ್ಡೀವ್ಸ್
 MV|ko|몰디브
 MV|kr|*aa
 MV|ks|مالدیٖو
-MV|ku|Maldîv
+MV|ku|Maldîva
 MV|kv|*aa
 MV|kw|*aa
 MV|ky|Мальдив
@@ -29062,7 +29062,7 @@ MV|lu|Madive
 MV|lv|Maldīvija
 MV|mg|Maldiva
 MV|mh|*aa
-MV|mi|*aa
+MV|mi|Māratiri
 MV|mk|*bg
 MV|ml|മാലിദ്വീപ്
 MV|mn|*ky
@@ -29084,7 +29084,7 @@ MV|nv|*aa
 MV|ny|*aa
 MV|oc|*aa
 MV|oj|*aa
-MV|om|*aa
+MV|om|Maaldiivs
 MV|or|ମାଲଦିଭସ୍‌
 MV|os|*aa
 MV|pa|ਮਾਲਦੀਵ
@@ -29099,10 +29099,10 @@ MV|ro|*it
 MV|ru|Мальдивы
 MV|rw|*aa
 MV|sa|*aa
-MV|sc|*aa
+MV|sc|*es
 MV|sd|*ps
 MV|se|Malediivvat
-MV|sg|Maldîva
+MV|sg|*ku
 MV|si|මාල දිවයින
 MV|sk|Maldivy
 MV|sl|*bm
@@ -29139,7 +29139,7 @@ MV|vi|*aa
 MV|vo|*aa
 MV|wa|*aa
 MV|wo|Maldiiw
-MV|xh|*aa
+MV|xh|EMaldives
 MV|yi|*ji
 MV|yo|Maladifi
 MV|za|*aa
@@ -29174,7 +29174,7 @@ MW|co|*aa
 MW|cr|*aa
 MW|cs|*aa
 MW|cu|*aa
-MW|cv|*aa
+MW|cv|*bg
 MW|cy|*aa
 MW|da|*aa
 MW|de|*aa
@@ -29250,7 +29250,7 @@ MW|lu|*aa
 MW|lv|Malāvija
 MW|mg|Malaoì
 MW|mh|*aa
-MW|mi|*aa
+MW|mi|Marāwi
 MW|mk|*bg
 MW|ml|മലാവി
 MW|mn|*bg
@@ -29272,7 +29272,7 @@ MW|nv|*aa
 MW|ny|*aa
 MW|oc|*aa
 MW|oj|*aa
-MW|om|*aa
+MW|om|Maalaawwii
 MW|or|ମାଲୱି
 MW|os|*aa
 MW|pa|ਮਲਾਵੀ
@@ -29327,7 +29327,7 @@ MW|vi|*aa
 MW|vo|*aa
 MW|wa|*aa
 MW|wo|*aa
-MW|xh|*aa
+MW|xh|EMalawi
 MW|yi|*ji
 MW|yo|*aa
 MW|za|*aa
@@ -29362,7 +29362,7 @@ MX|co|*aa
 MX|cr|*aa
 MX|cs|Mexiko
 MX|cu|*aa
-MX|cv|*aa
+MX|cv|*ce
 MX|cy|Mecsico
 MX|da|*aa
 MX|de|*cs
@@ -29388,12 +29388,12 @@ MX|gl|*es
 MX|gn|*aa
 MX|gu|મેક્સિકો
 MX|gv|*aa
-MX|ha|Makasiko
+MX|ha|Mesiko
 MX|he|מקסיקו
 MX|hi|मैक्सिको
 MX|ho|*aa
 MX|hr|*af
-MX|ht|*aa
+MX|ht|*fr
 MX|hu|Mexikó
 MX|hy|Մեքսիկա
 MX|hz|*aa
@@ -29401,7 +29401,7 @@ MX|ia|*aa
 MX|id|*af
 MX|ie|*aa
 MX|ig|*aa
-MX|ii|*aa
+MX|ii|ꃀꑭꇬ
 MX|ik|*aa
 MX|in|*af
 MX|io|*aa
@@ -29423,7 +29423,7 @@ MX|kn|ಮೆಕ್ಸಿಕೊ
 MX|ko|멕시코
 MX|kr|*aa
 MX|ks|مؠکسِکو
-MX|ku|Meksîk
+MX|ku|Meksîka
 MX|kv|*aa
 MX|kw|*aa
 MX|ky|*ce
@@ -29438,7 +29438,7 @@ MX|lu|*ln
 MX|lv|*az
 MX|mg|*az
 MX|mh|*aa
-MX|mi|*aa
+MX|mi|Mēhiko
 MX|mk|*bg
 MX|ml|മെക്സിക്കോ
 MX|mn|Мексик
@@ -29460,7 +29460,7 @@ MX|nv|*aa
 MX|ny|*aa
 MX|oc|*aa
 MX|oj|*aa
-MX|om|*aa
+MX|om|Meeksiikoo
 MX|or|ମେକ୍ସିକୋ
 MX|os|*aa
 MX|pa|ਮੈਕਸੀਕੋ
@@ -29475,7 +29475,7 @@ MX|ro|*mo
 MX|ru|*ce
 MX|rw|*aa
 MX|sa|*aa
-MX|sc|*aa
+MX|sc|Mèssicu
 MX|sd|ميڪسيڪو
 MX|se|*af
 MX|sg|Mekisîki
@@ -29515,9 +29515,9 @@ MX|vi|*aa
 MX|vo|*aa
 MX|wa|*aa
 MX|wo|*af
-MX|xh|*aa
+MX|xh|EMexico
 MX|yi|*ji
-MX|yo|Mesiko
+MX|yo|*ha
 MX|za|*aa
 MX|zh|墨西哥
 MX|zu|i-Mexico
@@ -29550,7 +29550,7 @@ MY|co|*aa
 MY|cr|*aa
 MY|cs|Malajsie
 MY|cu|*aa
-MY|cv|*aa
+MY|cv|*ce
 MY|cy|*aa
 MY|da|*aa
 MY|de|*aa
@@ -29576,12 +29576,12 @@ MY|gl|*et
 MY|gn|*aa
 MY|gu|મલેશિયા
 MY|gv|*aa
-MY|ha|Malaisiya
+MY|ha|Malesiya
 MY|he|מלזיה
 MY|hi|मलेशिया
 MY|ho|*aa
 MY|hr|*bs
-MY|ht|*aa
+MY|ht|*fr
 MY|hu|Malajzia
 MY|hy|Մալայզիա
 MY|hz|*aa
@@ -29626,7 +29626,7 @@ MY|lu|*ln
 MY|lv|*lt
 MY|mg|Malaizia
 MY|mh|*aa
-MY|mi|*aa
+MY|mi|Mareia
 MY|mk|Малезија
 MY|ml|മലേഷ്യ
 MY|mn|Малайз
@@ -29648,7 +29648,7 @@ MY|nv|*aa
 MY|ny|*aa
 MY|oc|*aa
 MY|oj|*aa
-MY|om|*aa
+MY|om|Maleeshiyaa
 MY|or|ମାଲେସିଆ
 MY|os|*aa
 MY|pa|ਮਲੇਸ਼ੀਆ
@@ -29663,7 +29663,7 @@ MY|ro|*aa
 MY|ru|*bg
 MY|rw|*aa
 MY|sa|*aa
-MY|sc|*aa
+MY|sc|Malèsia
 MY|sd|ملائيشيا
 MY|se|*fi
 MY|sg|Malezïi
@@ -29684,7 +29684,7 @@ MY|ta|மலேசியா
 MY|te|మలేషియా
 MY|tg|*bg
 MY|th|มาเลเซีย
-MY|ti|*am
+MY|ti|ማለዥያ
 MY|tk|Malaýziýa
 MY|tl|*aa
 MY|tn|*aa
@@ -29703,7 +29703,7 @@ MY|vi|*aa
 MY|vo|*aa
 MY|wa|*aa
 MY|wo|Malesi
-MY|xh|*aa
+MY|xh|EMalaysia
 MY|yi|*ji
 MY|yo|*es
 MY|za|*aa
@@ -29738,7 +29738,7 @@ MZ|co|*aa
 MZ|cr|*aa
 MZ|cs|Mosambik
 MZ|cu|*aa
-MZ|cv|*aa
+MZ|cv|*bg
 MZ|cy|*aa
 MZ|da|*aa
 MZ|de|*cs
@@ -29776,7 +29776,7 @@ MZ|hz|*aa
 MZ|ia|*aa
 MZ|id|*ak
 MZ|ie|*aa
-MZ|ig|*ak
+MZ|ig|*aa
 MZ|ii|*aa
 MZ|ik|*aa
 MZ|in|*ak
@@ -29814,7 +29814,7 @@ MZ|lu|Mozambiki
 MZ|lv|Mozambika
 MZ|mg|*lv
 MZ|mh|*aa
-MZ|mi|*aa
+MZ|mi|Mohapiki
 MZ|mk|*bg
 MZ|ml|മൊസാംബിക്ക്
 MZ|mn|*bg
@@ -29836,7 +29836,7 @@ MZ|nv|*aa
 MZ|ny|*aa
 MZ|oc|*aa
 MZ|oj|*aa
-MZ|om|*aa
+MZ|om|Moozaambik
 MZ|or|ମୋଜାମ୍ବିକ୍‌
 MZ|os|*aa
 MZ|pa|ਮੋਜ਼ਾਮਬੀਕ
@@ -29851,7 +29851,7 @@ MZ|ro|*mo
 MZ|ru|*bg
 MZ|rw|*aa
 MZ|sa|*aa
-MZ|sc|*aa
+MZ|sc|Mozambicu
 MZ|sd|موزمبیق
 MZ|se|*cs
 MZ|sg|Mözämbîka
@@ -29891,7 +29891,7 @@ MZ|vi|*aa
 MZ|vo|*aa
 MZ|wa|*aa
 MZ|wo|Mosàmbig
-MZ|xh|*aa
+MZ|xh|EMozambique
 MZ|yi|*ji
 MZ|yo|Moṣamibiku
 MZ|za|*aa
@@ -29926,7 +29926,7 @@ NA|co|*aa
 NA|cr|*aa
 NA|cs|Namibie
 NA|cu|*aa
-NA|cv|*aa
+NA|cv|*ce
 NA|cy|*aa
 NA|da|*aa
 NA|de|*aa
@@ -29957,7 +29957,7 @@ NA|he|נמיביה
 NA|hi|नामीबिया
 NA|ho|*aa
 NA|hr|*bs
-NA|ht|*aa
+NA|ht|*cs
 NA|hu|*ca
 NA|hy|Նամիբիա
 NA|hz|*aa
@@ -30002,7 +30002,7 @@ NA|lu|*bm
 NA|lv|Namībija
 NA|mg|*aa
 NA|mh|*aa
-NA|mi|*aa
+NA|mi|Namipia
 NA|mk|Намибија
 NA|ml|നമീബിയ
 NA|mn|*ce
@@ -30024,7 +30024,7 @@ NA|nv|*aa
 NA|ny|*aa
 NA|oc|*aa
 NA|oj|*aa
-NA|om|*aa
+NA|om|Namiibiyaa
 NA|or|ନାମିବିଆ
 NA|os|*aa
 NA|pa|ਨਾਮੀਬੀਆ
@@ -30039,7 +30039,7 @@ NA|ro|*aa
 NA|ru|*bg
 NA|rw|*aa
 NA|sa|*aa
-NA|sc|*aa
+NA|sc|Namìbia
 NA|sd|نيميبيا
 NA|se|*aa
 NA|sg|Namibùii
@@ -30060,11 +30060,11 @@ NA|ta|நமீபியா
 NA|te|నమీబియా
 NA|tg|*bg
 NA|th|นามิเบีย
-NA|ti|*am
+NA|ti|ናሚብያ
 NA|tk|Namibiýa
 NA|tl|*aa
 NA|tn|*aa
-NA|to|Namipia
+NA|to|*mi
 NA|tr|Namibya
 NA|ts|*aa
 NA|tt|*bg
@@ -30079,7 +30079,7 @@ NA|vi|*aa
 NA|vo|*aa
 NA|wa|*aa
 NA|wo|*bm
-NA|xh|*aa
+NA|xh|ENamibia
 NA|yi|*ji
 NA|yo|*aa
 NA|za|*aa
@@ -30114,7 +30114,7 @@ NC|co|*aa
 NC|cr|*aa
 NC|cs|Nová Kaledonie
 NC|cu|*aa
-NC|cv|*aa
+NC|cv|Ҫӗнӗ Каледони
 NC|cy|Caledonia Newydd
 NC|da|Ny Kaledonien
 NC|de|Neukaledonien
@@ -30145,7 +30145,7 @@ NC|he|קלדוניה החדשה
 NC|hi|न्यू कैलेडोनिया
 NC|ho|*aa
 NC|hr|*bs
-NC|ht|*aa
+NC|ht|*fr
 NC|hu|Új-Kaledónia
 NC|hy|Նոր Կալեդոնիա
 NC|hz|*aa
@@ -30190,7 +30190,7 @@ NC|lu|Kaledoni wa mumu
 NC|lv|Jaunkaledonija
 NC|mg|*fr
 NC|mh|*aa
-NC|mi|*aa
+NC|mi|Whenua Kanaki
 NC|mk|Нова Каледонија
 NC|ml|ന്യൂ കാലിഡോണിയ
 NC|mn|Шинэ Каледони
@@ -30212,7 +30212,7 @@ NC|nv|*aa
 NC|ny|*aa
 NC|oc|*aa
 NC|oj|*aa
-NC|om|*aa
+NC|om|Neewu Kaaleedoniyaa
 NC|or|ନୂତନ କାଲେଡୋନିଆ
 NC|os|*aa
 NC|pa|ਨਿਊ ਕੈਲੇਡੋਨੀਆ
@@ -30227,7 +30227,7 @@ NC|ro|*mo
 NC|ru|Новая Каледония
 NC|rw|*aa
 NC|sa|*aa
-NC|sc|*aa
+NC|sc|Caledònia Noa
 NC|sd|نیو ڪالیڊونیا
 NC|se|Ođđa-Kaledonia
 NC|sg|Finî Kaledonïi
@@ -30248,7 +30248,7 @@ NC|ta|நியூ கேலிடோனியா
 NC|te|క్రొత్త కాలెడోనియా
 NC|tg|Каледонияи Нав
 NC|th|นิวแคลิโดเนีย
-NC|ti|*am
+NC|ti|ኒው ካለዶንያ
 NC|tk|Täze Kaledoniýa
 NC|tl|*aa
 NC|tn|*aa
@@ -30267,7 +30267,7 @@ NC|vi|*aa
 NC|vo|*aa
 NC|wa|*aa
 NC|wo|Nuwel Kaledoni
-NC|xh|*aa
+NC|xh|ENew Caledonia
 NC|yi|*ji
 NC|yo|Kaledonia Titun
 NC|za|*aa
@@ -30277,7 +30277,7 @@ NE|aa|Niger
 NE|ab|*aa
 NE|ae|*aa
 NE|af|*aa
-NE|ak|Nigyɛ
+NE|ak|Nigyɛɛ
 NE|am|ኒጀር
 NE|an|*aa
 NE|ar|النيجر
@@ -30302,7 +30302,7 @@ NE|co|*aa
 NE|cr|*aa
 NE|cs|*aa
 NE|cu|*aa
-NE|cv|*aa
+NE|cv|*bg
 NE|cy|*aa
 NE|da|*aa
 NE|de|*aa
@@ -30322,7 +30322,7 @@ NE|fj|*aa
 NE|fo|*aa
 NE|fr|*aa
 NE|fy|*aa
-NE|ga|an Nígir
+NE|ga|An Nígir
 NE|gd|Nìgeir
 NE|gl|Níxer
 NE|gn|*aa
@@ -30378,7 +30378,7 @@ NE|lu|Nijere
 NE|lv|Nigēra
 NE|mg|*aa
 NE|mh|*aa
-NE|mi|*aa
+NE|mi|Ngāika
 NE|mk|*bg
 NE|ml|നൈജർ
 NE|mn|*bg
@@ -30400,7 +30400,7 @@ NE|nv|*aa
 NE|ny|*aa
 NE|oc|*aa
 NE|oj|*aa
-NE|om|*aa
+NE|om|Niijer
 NE|or|ନାଇଜର
 NE|os|*aa
 NE|pa|ਨਾਈਜਰ
@@ -30455,7 +30455,7 @@ NE|vi|*aa
 NE|vo|*aa
 NE|wa|*aa
 NE|wo|Niiseer
-NE|xh|*aa
+NE|xh|ENiger
 NE|yi|*ji
 NE|yo|Nàìjá
 NE|za|*aa
@@ -30465,7 +30465,7 @@ NF|aa|Norfolk Island
 NF|ab|*aa
 NF|ae|*aa
 NF|af|Norfolkeiland
-NF|ak|Nɔfolk Aeland
+NF|ak|Norfold Supɔ
 NF|am|ኖርፎልክ ደሴት
 NF|an|*aa
 NF|ar|جزيرة نورفولك
@@ -30483,14 +30483,14 @@ NF|bn|নরফোক দ্বীপ
 NF|bo|*aa
 NF|br|Enez Norfolk
 NF|bs|Ostrvo Norfolk
-NF|ca|Norfolk
+NF|ca|Illa Norfolk
 NF|ce|Норфолк гӀайре
 NF|ch|*aa
 NF|co|*aa
 NF|cr|*aa
-NF|cs|*ca
+NF|cs|Norfolk
 NF|cu|*aa
-NF|cv|*aa
+NF|cv|Норфолк утравӗ
 NF|cy|Ynys Norfolk
 NF|da|*aa
 NF|de|Norfolkinsel
@@ -30501,7 +30501,7 @@ NF|el|Νήσος Νόρφολκ
 NF|en|*aa
 NF|eo|Norfolkinsulo
 NF|es|Isla Norfolk
-NF|et|*ca
+NF|et|*cs
 NF|eu|Norfolk uhartea
 NF|fa|جزیرهٔ نورفولک
 NF|ff|Duuɗe Norfolk
@@ -30512,7 +30512,7 @@ NF|fr|Île Norfolk
 NF|fy|Norfolkeilân
 NF|ga|Oileán Norfolk
 NF|gd|Eilean Norfolk
-NF|gl|Illa Norfolk
+NF|gl|*ca
 NF|gn|*aa
 NF|gu|નોરફોક આઇલેન્ડ્સ
 NF|gv|*aa
@@ -30521,13 +30521,13 @@ NF|he|האי נורפוק
 NF|hi|नॉरफ़ॉक द्वीप
 NF|ho|*aa
 NF|hr|Otok Norfolk
-NF|ht|*aa
+NF|ht|*fr
 NF|hu|Norfolk-sziget
 NF|hy|Նորֆոլկ կղզի
 NF|hz|*aa
 NF|ia|Insula Norfolk
 NF|id|Kepulauan Norfolk
-NF|ie|*aa
+NF|ie|Insul Norfolk
 NF|ig|Agwaetiti Norfolk
 NF|ii|*aa
 NF|ik|*aa
@@ -30551,7 +30551,7 @@ NF|kn|ನಾರ್ಫೋಕ್ ದ್ವೀಪ
 NF|ko|노퍽섬
 NF|kr|*aa
 NF|ks|نارفاک جٔزیٖرٕ
-NF|ku|Girava Norfolk
+NF|ku|Girava Norfolkê
 NF|kv|*aa
 NF|kw|*aa
 NF|ky|*kk
@@ -30566,7 +30566,7 @@ NF|lu|Lutanda lua Norfok
 NF|lv|Norfolkas sala
 NF|mg|Nosy Norfolk
 NF|mh|*aa
-NF|mi|*aa
+NF|mi|Te Moutere Nōpoke
 NF|mk|Норфолшки Остров
 NF|ml|നോർഫോക് ദ്വീപ്
 NF|mn|Норфолк арал
@@ -30580,7 +30580,7 @@ NF|nb|Norfolkøya
 NF|nd|*aa
 NF|ne|नोरफोल्क टापु
 NF|ng|*aa
-NF|nl|*ca
+NF|nl|*cs
 NF|nn|*nb
 NF|no|*nb
 NF|nr|*aa
@@ -30588,12 +30588,12 @@ NF|nv|*aa
 NF|ny|*aa
 NF|oc|*aa
 NF|oj|*aa
-NF|om|*aa
+NF|om|Odola Noorfoolk
 NF|or|ନର୍ଫକ୍ ଦ୍ଵୀପ
 NF|os|*aa
 NF|pa|ਨੋਰਫੌਕ ਟਾਪੂ
 NF|pi|*aa
-NF|pl|*ca
+NF|pl|*cs
 NF|ps|نارفولک ټاپوګان
 NF|pt|Ilha Norfolk
 NF|qu|*es
@@ -30603,12 +30603,12 @@ NF|ro|*ia
 NF|ru|о-в Норфолк
 NF|rw|*aa
 NF|sa|*aa
-NF|sc|*aa
+NF|sc|Ìsula Norfolk
 NF|sd|نورفوڪ ٻيٽ
 NF|se|Norfolksullot
 NF|sg|Zûâ Nôrfôlko
 NF|si|නෝෆෝක් දූපත
-NF|sk|*ca
+NF|sk|*cs
 NF|sl|Norfolški otok
 NF|sm|*aa
 NF|sn|Chitsuwa cheNorfolk
@@ -30624,7 +30624,7 @@ NF|ta|நார்ஃபோக் தீவு
 NF|te|నార్ఫోక్ దీవి
 NF|tg|Ҷазираи Норфолк
 NF|th|เกาะนอร์ฟอล์ก
-NF|ti|*am
+NF|ti|ደሴት ኖርፎልክ
 NF|tk|Norfolk adasy
 NF|tl|*aa
 NF|tn|*aa
@@ -30643,9 +30643,9 @@ NF|vi|Đảo Norfolk
 NF|vo|*aa
 NF|wa|*aa
 NF|wo|Dunu Norfolk
-NF|xh|*aa
+NF|xh|ENorfolk Island
 NF|yi|*ji
-NF|yo|Etikun Nọ́úfókì
+NF|yo|Erékùsù Nọ́úfókì
 NF|za|*aa
 NF|zh|诺福克岛
 NF|zu|i-Norfolk Island
@@ -30678,7 +30678,7 @@ NG|co|*aa
 NG|cr|*aa
 NG|cs|Nigérie
 NG|cu|*aa
-NG|cv|*aa
+NG|cv|*ce
 NG|cy|*aa
 NG|da|*aa
 NG|de|*aa
@@ -30698,13 +30698,13 @@ NG|fj|*aa
 NG|fo|*aa
 NG|fr|*aa
 NG|fy|*aa
-NG|ga|an Nigéir
+NG|ga|An Nigéir
 NG|gd|Nigèiria
 NG|gl|Nixeria
 NG|gn|*aa
 NG|gu|નાઇજેરિયા
 NG|gv|*aa
-NG|ha|Najeriya
+NG|ha|Nijeriya
 NG|he|ניגריה
 NG|hi|नाइजीरिया
 NG|ho|*aa
@@ -30754,7 +30754,7 @@ NG|lu|Nijerya
 NG|lv|Nigērija
 NG|mg|Nizeria
 NG|mh|*aa
-NG|mi|*aa
+NG|mi|Ngāitiria
 NG|mk|Нигерија
 NG|ml|നൈജീരിയ
 NG|mn|*ce
@@ -30776,7 +30776,7 @@ NG|nv|*aa
 NG|ny|*aa
 NG|oc|*aa
 NG|oj|*aa
-NG|om|*aa
+NG|om|Naayijeeriyaa
 NG|or|ନାଇଜେରିଆ
 NG|os|*aa
 NG|pa|ਨਾਈਜੀਰੀਆ
@@ -30786,12 +30786,12 @@ NG|ps|نایجیریا
 NG|pt|*hu
 NG|qu|*aa
 NG|rm|*aa
-NG|rn|Nijeriya
+NG|rn|*ha
 NG|ro|*aa
 NG|ru|*bg
 NG|rw|*aa
 NG|sa|*aa
-NG|sc|*aa
+NG|sc|*ca
 NG|sd|نائيجيريا
 NG|se|*aa
 NG|sg|Nizerïa
@@ -30812,7 +30812,7 @@ NG|ta|நைஜீரியா
 NG|te|నైజీరియా
 NG|tg|*bg
 NG|th|ไนจีเรีย
-NG|ti|*am
+NG|ti|ናይጀርያ
 NG|tk|Nigeriýa
 NG|tl|*aa
 NG|tn|*aa
@@ -30831,7 +30831,7 @@ NG|vi|*aa
 NG|vo|*aa
 NG|wa|*aa
 NG|wo|Niseriya
-NG|xh|*aa
+NG|xh|ENigeria
 NG|yi|*ji
 NG|yo|Nàìjíríà
 NG|za|*aa
@@ -30866,7 +30866,7 @@ NI|co|*aa
 NI|cr|*aa
 NI|cs|Nikaragua
 NI|cu|*aa
-NI|cv|*aa
+NI|cv|*bg
 NI|cy|*aa
 NI|da|*aa
 NI|de|*aa
@@ -30942,7 +30942,7 @@ NI|lu|*bm
 NI|lv|*bs
 NI|mg|Nikaragoà
 NI|mh|*aa
-NI|mi|*aa
+NI|mi|Nikarāhua
 NI|mk|Никарагва
 NI|ml|നിക്കരാഗ്വ
 NI|mn|*bg
@@ -30964,7 +30964,7 @@ NI|nv|*aa
 NI|ny|*aa
 NI|oc|*aa
 NI|oj|*aa
-NI|om|*aa
+NI|om|*ff
 NI|or|ନିକାରାଗୁଆ
 NI|os|*aa
 NI|pa|ਨਿਕਾਰਾਗੁਆ
@@ -30979,7 +30979,7 @@ NI|ro|*aa
 NI|ru|*bg
 NI|rw|*aa
 NI|sa|*aa
-NI|sc|*aa
+NI|sc|Nicaràgua
 NI|sd|نڪراگوا
 NI|se|*aa
 NI|sg|*cs
@@ -31019,7 +31019,7 @@ NI|vi|*aa
 NI|vo|*aa
 NI|wa|*aa
 NI|wo|*ha
-NI|xh|*aa
+NI|xh|ENicaragua
 NI|yi|*ji
 NI|yo|*cs
 NI|za|*aa
@@ -31046,7 +31046,7 @@ NL|bm|Peyiba
 NL|bn|নেদারল্যান্ডস
 NL|bo|*aa
 NL|br|Izelvroioù
-NL|bs|Holandija
+NL|bs|Nizozemska
 NL|ca|Països Baixos
 NL|ce|Нидерландаш
 NL|ch|*aa
@@ -31054,18 +31054,18 @@ NL|co|*aa
 NL|cr|*aa
 NL|cs|Nizozemsko
 NL|cu|*aa
-NL|cv|*aa
+NL|cv|Нидерланд
 NL|cy|Yr Iseldiroedd
-NL|da|Holland
+NL|da|Nederlandene
 NL|de|Niederlande
 NL|dv|*aa
 NL|dz|ནེ་དར་ལནཌས྄
 NL|ee|Netherlands nutome
-NL|el|Ολλανδία
+NL|el|Κάτω Χώρες
 NL|en|*aa
 NL|eo|Nederlando
 NL|es|Países Bajos
-NL|et|*da
+NL|et|Holland
 NL|eu|Herbehereak
 NL|fa|هلند
 NL|ff|Nederlannda
@@ -31084,8 +31084,8 @@ NL|ha|Holan
 NL|he|הולנד
 NL|hi|नीदरलैंड
 NL|ho|*aa
-NL|hr|Nizozemska
-NL|ht|*aa
+NL|hr|*bs
+NL|ht|*fr
 NL|hu|Hollandia
 NL|hy|Նիդեռլանդներ
 NL|hz|*aa
@@ -31097,7 +31097,7 @@ NL|ii|*aa
 NL|ik|*aa
 NL|in|*id
 NL|io|*aa
-NL|is|*da
+NL|is|*et
 NL|it|Paesi Bassi
 NL|iu|*aa
 NL|iw|*he
@@ -31108,19 +31108,19 @@ NL|ka|ნიდერლანდები
 NL|kg|*aa
 NL|ki|Uholanzi
 NL|kj|*aa
-NL|kk|Нидерланд
+NL|kk|*cv
 NL|kl|*aa
 NL|km|ហូឡង់
 NL|kn|ನೆದರ್‌ಲ್ಯಾಂಡ್ಸ್
 NL|ko|네덜란드
 NL|kr|*aa
 NL|ks|نیٖدَرلینڑ
-NL|ku|Holenda
+NL|ku|Holanda
 NL|kv|*aa
 NL|kw|*aa
-NL|ky|*kk
+NL|ky|*cv
 NL|la|*aa
-NL|lb|*da
+NL|lb|*et
 NL|lg|Holandi
 NL|li|*aa
 NL|ln|Olandɛ
@@ -31128,12 +31128,12 @@ NL|lo|ເນເທີແລນ
 NL|lt|Nyderlandai
 NL|lu|*ln
 NL|lv|Nīderlande
-NL|mg|Holanda
+NL|mg|*ku
 NL|mh|*aa
-NL|mi|*aa
+NL|mi|Hōrana
 NL|mk|Холандија
 NL|ml|നെതർലാൻഡ്‌സ്
-NL|mn|*kk
+NL|mn|*cv
 NL|mo|Țările de Jos
 NL|mr|नेदरलँड
 NL|ms|*id
@@ -31152,7 +31152,7 @@ NL|nv|*aa
 NL|ny|*aa
 NL|oc|*aa
 NL|oj|*aa
-NL|om|*aa
+NL|om|Neezerlaand
 NL|or|ନେଦରଲ୍ୟାଣ୍ଡ
 NL|os|*aa
 NL|pa|ਨੀਦਰਲੈਂਡ
@@ -31167,13 +31167,13 @@ NL|ro|*mo
 NL|ru|Нидерланды
 NL|rw|*aa
 NL|sa|*aa
-NL|sc|*aa
+NL|sc|Paisos Bassos
 NL|sd|نيدرلينڊ
 NL|se|Vuolleeatnamat
 NL|sg|Holände
 NL|si|නෙදර්ලන්තය
 NL|sk|Holandsko
-NL|sl|*hr
+NL|sl|*bs
 NL|sm|*aa
 NL|sn|*aa
 NL|so|Nederlaands
@@ -31188,14 +31188,14 @@ NL|ta|நெதர்லாந்து
 NL|te|నెదర్లాండ్స్
 NL|tg|*bg
 NL|th|เนเธอร์แลนด์
-NL|ti|ኔዘርላንድስ
+NL|ti|*am
 NL|tk|Niderlandlar
 NL|tl|*aa
 NL|tn|*aa
 NL|to|Hōlani
 NL|tr|Hollanda
 NL|ts|*aa
-NL|tt|*kk
+NL|tt|*cv
 NL|tw|*aa
 NL|ty|*aa
 NL|ug|گوللاندىيە
@@ -31207,7 +31207,7 @@ NL|vi|Hà Lan
 NL|vo|*aa
 NL|wa|*aa
 NL|wo|Peyi Baa
-NL|xh|*aa
+NL|xh|ENetherlands
 NL|yi|*ji
 NL|yo|Nedalandi
 NL|za|*aa
@@ -31242,7 +31242,7 @@ NO|co|*aa
 NO|cr|*aa
 NO|cs|Norsko
 NO|cu|*aa
-NO|cv|*aa
+NO|cv|*ce
 NO|cy|Norwy
 NO|da|Norge
 NO|de|Norwegen
@@ -31273,7 +31273,7 @@ NO|he|נורווגיה
 NO|hi|नॉर्वे
 NO|ho|*aa
 NO|hr|*bs
-NO|ht|*aa
+NO|ht|*fr
 NO|hu|Norvégia
 NO|hy|Նորվեգիա
 NO|hz|*aa
@@ -31318,10 +31318,10 @@ NO|lu|Noriveje
 NO|lv|Norvēģija
 NO|mg|Nôrvezy
 NO|mh|*aa
-NO|mi|*aa
+NO|mi|Nōwei
 NO|mk|Норвешка
 NO|ml|നോർവെ
-NO|mn|*ce
+NO|mn|Норвег
 NO|mo|*br
 NO|mr|*hi
 NO|ms|*aa
@@ -31340,7 +31340,7 @@ NO|nv|*aa
 NO|ny|*aa
 NO|oc|*aa
 NO|oj|*aa
-NO|om|*aa
+NO|om|Noorwey
 NO|or|ନରୱେ
 NO|os|*aa
 NO|pa|ਨਾਰਵੇ
@@ -31355,7 +31355,7 @@ NO|ro|*br
 NO|ru|*bg
 NO|rw|*aa
 NO|sa|*aa
-NO|sc|*aa
+NO|sc|Norvègia
 NO|sd|ناروي
 NO|se|Norga
 NO|sg|Nörvêzi
@@ -31376,7 +31376,7 @@ NO|ta|நார்வே
 NO|te|నార్వే
 NO|tg|*bg
 NO|th|นอร์เวย์
-NO|ti|ኖርዌ
+NO|ti|ኖርወይ
 NO|tk|Norwegiýa
 NO|tl|*aa
 NO|tn|*aa
@@ -31395,7 +31395,7 @@ NO|vi|Na Uy
 NO|vo|*aa
 NO|wa|*aa
 NO|wo|*ff
-NO|xh|*aa
+NO|xh|ENorway
 NO|yi|*ji
 NO|yo|Nọọwii
 NO|za|*aa
@@ -31405,7 +31405,7 @@ NP|aa|Nepal
 NP|ab|*aa
 NP|ae|*aa
 NP|af|*aa
-NP|ak|Nɛpɔl
+NP|ak|Nɛpal
 NP|am|ኔፓል
 NP|an|*aa
 NP|ar|نيبال
@@ -31430,7 +31430,7 @@ NP|co|*aa
 NP|cr|*aa
 NP|cs|Nepál
 NP|cu|*aa
-NP|cv|*aa
+NP|cv|*be
 NP|cy|*aa
 NP|da|*aa
 NP|de|*aa
@@ -31461,7 +31461,7 @@ NP|he|נפאל
 NP|hi|नेपाल
 NP|ho|*aa
 NP|hr|*aa
-NP|ht|*aa
+NP|ht|*fr
 NP|hu|*cs
 NP|hy|Նեպալ
 NP|hz|*aa
@@ -31506,7 +31506,7 @@ NP|lu|*ln
 NP|lv|Nepāla
 NP|mg|Nepala
 NP|mh|*aa
-NP|mi|*aa
+NP|mi|Nepōra
 NP|mk|*be
 NP|ml|നേപ്പാൾ
 NP|mn|Балба
@@ -31528,7 +31528,7 @@ NP|nv|*aa
 NP|ny|*aa
 NP|oc|*aa
 NP|oj|*aa
-NP|om|*aa
+NP|om|Neeppal
 NP|or|ନେପାଳ
 NP|os|*aa
 NP|pa|ਨੇਪਾਲ
@@ -31543,7 +31543,7 @@ NP|ro|*aa
 NP|ru|*be
 NP|rw|*aa
 NP|sa|*aa
-NP|sc|*aa
+NP|sc|Nèpal
 NP|sd|نيپال
 NP|se|*aa
 NP|sg|Nëpâli
@@ -31583,7 +31583,7 @@ NP|vi|*aa
 NP|vo|*aa
 NP|wa|*aa
 NP|wo|*ff
-NP|xh|*aa
+NP|xh|ENepal
 NP|yi|*ji
 NP|yo|Nepa
 NP|za|*aa
@@ -31618,7 +31618,7 @@ NR|co|*aa
 NR|cr|*aa
 NR|cs|*aa
 NR|cu|*aa
-NR|cv|*aa
+NR|cv|*be
 NR|cy|*aa
 NR|da|*aa
 NR|de|*aa
@@ -31716,7 +31716,7 @@ NR|nv|*aa
 NR|ny|*aa
 NR|oc|*aa
 NR|oj|*aa
-NR|om|*aa
+NR|om|Naawuruu
 NR|or|ନାଉରୁ
 NR|os|*aa
 NR|pa|ਨਾਉਰੂ
@@ -31752,7 +31752,7 @@ NR|ta|நௌரு
 NR|te|నౌరు
 NR|tg|*be
 NR|th|นาอูรู
-NR|ti|*am
+NR|ti|ናውሩ
 NR|tk|*aa
 NR|tl|*aa
 NR|tn|*aa
@@ -31771,7 +31771,7 @@ NR|vi|*aa
 NR|vo|*aa
 NR|wa|*aa
 NR|wo|Nawru
-NR|xh|*aa
+NR|xh|ENauru
 NR|yi|*aa
 NR|yo|*aa
 NR|za|*aa
@@ -31782,7 +31782,7 @@ NU|ab|*aa
 NU|ae|*aa
 NU|af|*aa
 NU|ak|Niyu
-NU|am|ኒኡይ
+NU|am|ኒዌ
 NU|an|*aa
 NU|ar|نيوي
 NU|as|নিউ
@@ -31806,7 +31806,7 @@ NU|co|*aa
 NU|cr|*aa
 NU|cs|*aa
 NU|cu|*aa
-NU|cv|*aa
+NU|cv|*ce
 NU|cy|*aa
 NU|da|*aa
 NU|de|*aa
@@ -31832,7 +31832,7 @@ NU|gl|*aa
 NU|gn|*aa
 NU|gu|નીયુ
 NU|gv|*aa
-NU|ha|*ak
+NU|ha|*aa
 NU|he|ניווה
 NU|hi|नीयू
 NU|ho|*aa
@@ -31904,7 +31904,7 @@ NU|nv|*aa
 NU|ny|*aa
 NU|oc|*aa
 NU|oj|*aa
-NU|om|*aa
+NU|om|Niwu’e
 NU|or|ନିଉ
 NU|os|*aa
 NU|pa|ਨਿਯੂ
@@ -31940,7 +31940,7 @@ NU|ta|நியுவே
 NU|te|నియూ
 NU|tg|*ce
 NU|th|นีอูเอ
-NU|ti|*am
+NU|ti|ኒዩ
 NU|tk|*aa
 NU|tl|*aa
 NU|tn|*aa
@@ -31959,7 +31959,7 @@ NU|vi|*aa
 NU|vo|*aa
 NU|wa|*aa
 NU|wo|Niw
-NU|xh|*aa
+NU|xh|ENiue
 NU|yi|*aa
 NU|yo|*aa
 NU|za|*aa
@@ -31994,7 +31994,7 @@ NZ|co|*aa
 NZ|cr|*aa
 NZ|cs|Nový Zéland
 NZ|cu|*aa
-NZ|cv|*aa
+NZ|cv|Ҫӗнӗ Зеланди
 NZ|cy|Seland Newydd
 NZ|da|*aa
 NZ|de|Neuseeland
@@ -32025,13 +32025,13 @@ NZ|he|ניו זילנד
 NZ|hi|न्यूज़ीलैंड
 NZ|ho|*aa
 NZ|hr|*bs
-NZ|ht|*aa
+NZ|ht|*fr
 NZ|hu|Új-Zéland
 NZ|hy|Նոր Զելանդիա
 NZ|hz|*aa
 NZ|ia|Nove Zelanda
 NZ|id|Selandia Baru
-NZ|ie|*aa
+NZ|ie|Nov-Zeland
 NZ|ig|*aa
 NZ|ii|*aa
 NZ|ik|*aa
@@ -32054,8 +32054,8 @@ NZ|km|នូវែល​សេឡង់
 NZ|kn|ನ್ಯೂಜಿಲೆಂಡ್
 NZ|ko|뉴질랜드
 NZ|kr|*aa
-NZ|ks|نیوٗزِلینڑ
-NZ|ku|Nû Zelenda
+NZ|ks|نیوزی لینڈ
+NZ|ku|Zelandaya Nû
 NZ|kv|*aa
 NZ|kw|*aa
 NZ|ky|Жаңы Зеландия
@@ -32072,7 +32072,7 @@ NZ|mg|*fr
 NZ|mh|*aa
 NZ|mi|Aotearoa
 NZ|mk|Нов Зеланд
-NZ|ml|ന്യൂസിലാൻറ്
+NZ|ml|ന്യൂസിലൻഡ്
 NZ|mn|Шинэ Зеланд
 NZ|mo|Noua Zeelandă
 NZ|mr|न्यूझीलंड
@@ -32092,7 +32092,7 @@ NZ|nv|*aa
 NZ|ny|*aa
 NZ|oc|*aa
 NZ|oj|*aa
-NZ|om|*aa
+NZ|om|Neewu Zilaand
 NZ|or|ନ୍ୟୁଜିଲାଣ୍ଡ
 NZ|os|*aa
 NZ|pa|ਨਿਊਜ਼ੀਲੈਂਡ
@@ -32107,7 +32107,7 @@ NZ|ro|*mo
 NZ|ru|Новая Зеландия
 NZ|rw|*aa
 NZ|sa|*aa
-NZ|sc|*aa
+NZ|sc|Zelanda Noa
 NZ|sd|نيو زيلينڊ
 NZ|se|Ođđa-Selánda
 NZ|sg|Finî Zelânde
@@ -32140,14 +32140,14 @@ NZ|tw|*aa
 NZ|ty|*aa
 NZ|ug|يېڭى زېلاندىيە
 NZ|uk|Нова Зеландія
-NZ|ur|نیوزی لینڈ
+NZ|ur|*ks
 NZ|uz|Yangi Zelandiya
 NZ|ve|*aa
 NZ|vi|*aa
 NZ|vo|*aa
 NZ|wa|*aa
 NZ|wo|Nuwel Selànd
-NZ|xh|*aa
+NZ|xh|ENew Zealand
 NZ|yi|*ji
 NZ|yo|Ṣilandi Titun
 NZ|za|*aa
@@ -32182,7 +32182,7 @@ OM|co|*aa
 OM|cr|*aa
 OM|cs|Omán
 OM|cu|*aa
-OM|cv|*aa
+OM|cv|*bg
 OM|cy|*aa
 OM|da|*aa
 OM|de|*aa
@@ -32258,7 +32258,7 @@ OM|lu|Omane
 OM|lv|Omāna
 OM|mg|*aa
 OM|mh|*aa
-OM|mi|*aa
+OM|mi|Ōmana
 OM|mk|*bg
 OM|ml|ഒമാൻ
 OM|mn|*bg
@@ -32280,7 +32280,7 @@ OM|nv|*aa
 OM|ny|*aa
 OM|oc|*aa
 OM|oj|*aa
-OM|om|*aa
+OM|om|*et
 OM|or|ଓମାନ୍
 OM|os|*aa
 OM|pa|ਓਮਾਨ
@@ -32295,7 +32295,7 @@ OM|ro|*aa
 OM|ru|*bg
 OM|rw|*aa
 OM|sa|*aa
-OM|sc|*aa
+OM|sc|*gd
 OM|sd|*fa
 OM|se|*aa
 OM|sg|Omâni
@@ -32316,7 +32316,7 @@ OM|ta|ஓமன்
 OM|te|ఓమన్
 OM|tg|Умон
 OM|th|โอมาน
-OM|ti|*am
+OM|ti|ዖማን
 OM|tk|*aa
 OM|tl|*aa
 OM|tn|*aa
@@ -32335,7 +32335,7 @@ OM|vi|*aa
 OM|vo|*aa
 OM|wa|*aa
 OM|wo|*et
-OM|xh|*aa
+OM|xh|E-Oman
 OM|yi|*aa
 OM|yo|Ọọma
 OM|za|*aa
@@ -32370,7 +32370,7 @@ PA|co|*aa
 PA|cr|*aa
 PA|cs|*aa
 PA|cu|*aa
-PA|cv|*aa
+PA|cv|*be
 PA|cy|*aa
 PA|da|*aa
 PA|de|*aa
@@ -32414,7 +32414,7 @@ PA|ik|*aa
 PA|in|*aa
 PA|io|*aa
 PA|is|*aa
-PA|it|*br
+PA|it|*aa
 PA|iu|*aa
 PA|iw|*he
 PA|ja|パナマ
@@ -32468,7 +32468,7 @@ PA|nv|*aa
 PA|ny|*aa
 PA|oc|*aa
 PA|oj|*aa
-PA|om|*aa
+PA|om|Paanamaa
 PA|or|ପାନାମା
 PA|os|*aa
 PA|pa|ਪਨਾਮਾ
@@ -32483,7 +32483,7 @@ PA|ro|*aa
 PA|ru|*be
 PA|rw|*aa
 PA|sa|*aa
-PA|sc|*aa
+PA|sc|Pànama
 PA|sd|پناما
 PA|se|*aa
 PA|sg|*aa
@@ -32523,9 +32523,9 @@ PA|vi|*aa
 PA|vo|*aa
 PA|wa|*aa
 PA|wo|*aa
-PA|xh|*aa
+PA|xh|EPanama
 PA|yi|*ji
-PA|yo|*aa
+PA|yo|Paramá
 PA|za|*aa
 PA|zh|巴拿马
 PA|zu|i-Panama
@@ -32558,7 +32558,7 @@ PE|co|*aa
 PE|cr|*aa
 PE|cs|*aa
 PE|cu|*aa
-PE|cv|*aa
+PE|cv|*be
 PE|cy|Periw
 PE|da|*aa
 PE|de|*aa
@@ -32580,7 +32580,7 @@ PE|fr|Pérou
 PE|fy|*aa
 PE|ga|Peiriú
 PE|gd|Pearù
-PE|gl|O Perú
+PE|gl|*ca
 PE|gn|*aa
 PE|gu|પેરુ
 PE|gv|*aa
@@ -32589,13 +32589,13 @@ PE|he|פרו
 PE|hi|पेरू
 PE|ho|*aa
 PE|hr|*aa
-PE|ht|*aa
+PE|ht|*fr
 PE|hu|*aa
 PE|hy|Պերու
 PE|hz|*aa
 PE|ia|*aa
 PE|id|*aa
-PE|ie|*aa
+PE|ie|*ca
 PE|ig|*aa
 PE|ii|*aa
 PE|ik|*aa
@@ -32656,7 +32656,7 @@ PE|nv|*aa
 PE|ny|*aa
 PE|oc|*aa
 PE|oj|*aa
-PE|om|*aa
+PE|om|Peeruu
 PE|or|ପେରୁ
 PE|os|*aa
 PE|pa|ਪੇਰੂ
@@ -32671,7 +32671,7 @@ PE|ro|*aa
 PE|ru|*be
 PE|rw|*aa
 PE|sa|*aa
-PE|sc|*aa
+PE|sc|*it
 PE|sd|پيرو
 PE|se|*aa
 PE|sg|Perüu
@@ -32711,9 +32711,9 @@ PE|vi|*aa
 PE|vo|*aa
 PE|wa|*aa
 PE|wo|*aa
-PE|xh|*aa
+PE|xh|EPeru
 PE|yi|*ji
-PE|yo|*aa
+PE|yo|Pèérù
 PE|za|*aa
 PE|zh|秘鲁
 PE|zu|i-Peru
@@ -32746,7 +32746,7 @@ PF|co|*aa
 PF|cr|*aa
 PF|cs|Francouzská Polynésie
 PF|cu|*aa
-PF|cv|*aa
+PF|cv|Франци Полинези
 PF|cy|Polynesia Ffrengig
 PF|da|Fransk Polynesien
 PF|de|Französisch-Polynesien
@@ -32768,7 +32768,7 @@ PF|fr|Polynésie française
 PF|fy|Frans-Polynesië
 PF|ga|Polainéis na Fraince
 PF|gd|Poilinèis na Frainge
-PF|gl|A Polinesia Francesa
+PF|gl|*es
 PF|gn|*aa
 PF|gu|ફ્રેંચ પોલિનેશિયા
 PF|gv|*aa
@@ -32777,20 +32777,20 @@ PF|he|פולינזיה הצרפתית
 PF|hi|फ़्रेंच पोलिनेशिया
 PF|ho|*aa
 PF|hr|*bs
-PF|ht|*aa
+PF|ht|*fr
 PF|hu|Francia Polinézia
 PF|hy|Ֆրանսիական Պոլինեզիա
 PF|hz|*aa
 PF|ia|Polynesia francese
 PF|id|Polinesia Prancis
 PF|ie|*aa
-PF|ig|Frenchi Polynesia
+PF|ig|*aa
 PF|ii|*aa
 PF|ik|*aa
 PF|in|*id
 PF|io|*aa
 PF|is|Franska Pólýnesía
-PF|it|Polinesia francese
+PF|it|Polinesia Francese
 PF|iu|*aa
 PF|iw|*he
 PF|ja|仏領ポリネシア
@@ -32807,7 +32807,7 @@ PF|kn|ಫ್ರೆಂಚ್ ಪಾಲಿನೇಷ್ಯಾ
 PF|ko|프랑스령 폴리네시아
 PF|kr|*aa
 PF|ks|فرانسی پولِنیشِیا
-PF|ku|Polînezyaya Fransî
+PF|ku|Polînezyaya Fransizî
 PF|kv|*aa
 PF|kw|*aa
 PF|ky|Полинезия (франциялык)
@@ -32822,7 +32822,7 @@ PF|lu|Polinezi wa Nfalanse
 PF|lv|Francijas Polinēzija
 PF|mg|Polynezia frantsay
 PF|mh|*aa
-PF|mi|*aa
+PF|mi|Poronēhia Wīwī
 PF|mk|Француска Полинезија
 PF|ml|ഫ്രഞ്ച് പോളിനേഷ്യ
 PF|mn|Францын Полинез
@@ -32844,7 +32844,7 @@ PF|nv|*aa
 PF|ny|*aa
 PF|oc|*aa
 PF|oj|*aa
-PF|om|*aa
+PF|om|Polineeshiyaa Faransaay
 PF|or|ଫ୍ରେଞ୍ଚ ପଲିନେସିଆ
 PF|os|*aa
 PF|pa|ਫਰੈਂਚ ਪੋਲੀਨੇਸ਼ੀਆ
@@ -32859,7 +32859,7 @@ PF|ro|*mo
 PF|ru|Французская Полинезия
 PF|rw|*aa
 PF|sa|*aa
-PF|sc|*aa
+PF|sc|Polinèsia frantzesa
 PF|sd|فرانسيسي پولينيشيا
 PF|se|Frankriikka Polynesia
 PF|sg|Polinezïi tî farânzi
@@ -32880,7 +32880,7 @@ PF|ta|பிரெஞ்சு பாலினேஷியா
 PF|te|ఫ్రెంచ్ పోలినీషియా
 PF|tg|Полинезияи Фаронса
 PF|th|เฟรนช์โปลินีเซีย
-PF|ti|ናይ ፈረንሳይ ፖሊነዝያ
+PF|ti|ፈረንሳዊት ፖሊነዥያ
 PF|tk|Fransuz Polineziýasy
 PF|tl|*aa
 PF|tn|*aa
@@ -32899,7 +32899,7 @@ PF|vi|Polynesia thuộc Pháp
 PF|vo|*aa
 PF|wa|*aa
 PF|wo|Polinesi Farañse
-PF|xh|*aa
+PF|xh|EFrench Polynesia
 PF|yi|*ji
 PF|yo|Firenṣi Polinesia
 PF|za|*aa
@@ -32909,7 +32909,7 @@ PG|aa|Papua New Guinea
 PG|ab|*aa
 PG|ae|*aa
 PG|af|Papoea-Nieu-Guinee
-PG|ak|Papua Guinea Foforo
+PG|ak|Papua Gini Foforɔ
 PG|am|ፓፑዋ ኒው ጊኒ
 PG|an|*aa
 PG|ar|بابوا غينيا الجديدة
@@ -32934,7 +32934,7 @@ PG|co|*aa
 PG|cr|*aa
 PG|cs|Papua-Nová Guinea
 PG|cu|*aa
-PG|cv|*aa
+PG|cv|Папуа — Ҫӗнӗ Гвиней
 PG|cy|Papua Guinea Newydd
 PG|da|Papua Ny Guinea
 PG|de|Papua-Neuguinea
@@ -32965,7 +32965,7 @@ PG|he|פפואה גינאה החדשה
 PG|hi|पापुआ न्यू गिनी
 PG|ho|*aa
 PG|hr|*bs
-PG|ht|*aa
+PG|ht|*fr
 PG|hu|Pápua Új-Guinea
 PG|hy|Պապուա Նոր Գվինեա
 PG|hz|*aa
@@ -33010,7 +33010,7 @@ PG|lu|Papwazi wa Nginɛ wa mumu
 PG|lv|Papua-Jaungvineja
 PG|mg|*fr
 PG|mh|*aa
-PG|mi|*aa
+PG|mi|Papua Nūkini
 PG|mk|Папуа Нова Гвинеја
 PG|ml|പാപ്പുവ ന്യൂ ഗിനിയ
 PG|mn|Папуа Шинэ Гвиней
@@ -33032,8 +33032,8 @@ PG|nv|*aa
 PG|ny|*aa
 PG|oc|*aa
 PG|oj|*aa
-PG|om|*aa
-PG|or|ପପୁଆ ନ୍ୟୁ ଗୁଏନିଆ
+PG|om|Papuwa Neawu Giinii
+PG|or|ପପୁଆ ନ୍ୟୁ ଗିନି
 PG|os|*aa
 PG|pa|ਪਾਪੂਆ ਨਿਊ ਗਿਨੀ
 PG|pi|*aa
@@ -33047,7 +33047,7 @@ PG|ro|*mo
 PG|ru|Папуа — Новая Гвинея
 PG|rw|*aa
 PG|sa|*aa
-PG|sc|*aa
+PG|sc|Pàpua Guinea Noa
 PG|sd|پاپوا نیو گني
 PG|se|Papua-Ođđa-Guinea
 PG|sg|Papû Finî Ginëe, Papuazïi
@@ -33068,7 +33068,7 @@ PG|ta|பப்புவா நியூ கினியா
 PG|te|పాపువా న్యూ గినియా
 PG|tg|Папуа Гвинеяи Нав
 PG|th|ปาปัวนิวกินี
-PG|ti|*am
+PG|ti|ፓፕዋ ኒው ጊኒ
 PG|tk|Papua - Täze Gwineýa
 PG|tl|*aa
 PG|tn|*aa
@@ -33087,7 +33087,7 @@ PG|vi|*aa
 PG|vo|*aa
 PG|wa|*aa
 PG|wo|Papuwasi Gine Gu Bees
-PG|xh|*aa
+PG|xh|EPapua New Guinea
 PG|yi|*ji
 PG|yo|Paapu ti Giini
 PG|za|*aa
@@ -33097,7 +33097,7 @@ PH|aa|Philippines
 PH|ab|*aa
 PH|ae|*aa
 PH|af|Filippyne
-PH|ak|*aa
+PH|ak|Filipin
 PH|am|ፊሊፒንስ
 PH|an|*aa
 PH|ar|الفلبين
@@ -33122,7 +33122,7 @@ PH|co|*aa
 PH|cr|*aa
 PH|cs|Filipíny
 PH|cu|*aa
-PH|cv|*aa
+PH|cv|Филиппинсем
 PH|cy|Y Philipinau
 PH|da|Filippinerne
 PH|de|Philippinen
@@ -33142,13 +33142,13 @@ PH|fj|*aa
 PH|fo|Filipsoyggjar
 PH|fr|*aa
 PH|fy|Filipijnen
-PH|ga|na hOileáin Fhilipíneacha
+PH|ga|Na hOileáin Fhilipíneacha
 PH|gd|Na h-Eileanan Filipineach
 PH|gl|*es
 PH|gn|*aa
 PH|gu|ફિલિપિન્સ
 PH|gv|*aa
-PH|ha|Filipin
+PH|ha|*ak
 PH|he|הפיליפינים
 PH|hi|फ़िलिपींस
 PH|ho|*aa
@@ -33159,7 +33159,7 @@ PH|hy|Ֆիլիպիններ
 PH|hz|*aa
 PH|ia|Philippinas
 PH|id|Filipina
-PH|ie|*aa
+PH|ie|*ca
 PH|ig|*aa
 PH|ii|*aa
 PH|ik|*aa
@@ -33182,8 +33182,8 @@ PH|km|ហ្វ៊ីលីពីន
 PH|kn|ಫಿಲಿಫೈನ್ಸ್
 PH|ko|필리핀
 PH|kr|*aa
-PH|ks|فِلِپِینس
-PH|ku|Filîpîn
+PH|ks|فلپائن
+PH|ku|Fîlîpîn
 PH|kv|*aa
 PH|kw|*aa
 PH|ky|Филиппин
@@ -33198,7 +33198,7 @@ PH|lu|Nfilipi
 PH|lv|Filipīnas
 PH|mg|*id
 PH|mh|*aa
-PH|mi|*aa
+PH|mi|Piripīni
 PH|mk|*bg
 PH|ml|ഫിലിപ്പീൻസ്
 PH|mn|*ky
@@ -33220,7 +33220,7 @@ PH|nv|*aa
 PH|ny|*aa
 PH|oc|*aa
 PH|oj|*aa
-PH|om|*aa
+PH|om|Filippiins
 PH|or|ଫିଲିପାଇନସ୍
 PH|os|*aa
 PH|pa|ਫਿਲੀਪੀਨਜ
@@ -33235,8 +33235,8 @@ PH|ro|*mo
 PH|ru|Филиппины
 PH|rw|*aa
 PH|sa|*aa
-PH|sc|*aa
-PH|sd|فلپائن
+PH|sc|*es
+PH|sd|*ks
 PH|se|Filippiinnat
 PH|sg|Filipîni
 PH|si|පිලිපීනය
@@ -33268,14 +33268,14 @@ PH|tw|*aa
 PH|ty|*aa
 PH|ug|فىلىپپىن
 PH|uk|Філіппіни
-PH|ur|*sd
+PH|ur|*ks
 PH|uz|*az
 PH|ve|*aa
 PH|vi|*aa
 PH|vo|*aa
 PH|wa|*aa
-PH|wo|*ha
-PH|xh|*aa
+PH|wo|*ak
+PH|xh|EPhilippines
 PH|yi|*ji
 PH|yo|*bm
 PH|za|*aa
@@ -33310,7 +33310,7 @@ PK|co|*aa
 PK|cr|*aa
 PK|cs|Pákistán
 PK|cu|*aa
-PK|cv|*aa
+PK|cv|*bg
 PK|cy|*aa
 PK|da|*aa
 PK|de|*aa
@@ -33386,7 +33386,7 @@ PK|lu|Pakisita
 PK|lv|Pakistāna
 PK|mg|*aa
 PK|mh|*aa
-PK|mi|*aa
+PK|mi|Pakitāne
 PK|mk|*bg
 PK|ml|പാക്കിസ്ഥാൻ
 PK|mn|*bg
@@ -33408,7 +33408,7 @@ PK|nv|*aa
 PK|ny|*aa
 PK|oc|*aa
 PK|oj|*aa
-PK|om|*aa
+PK|om|Paakistaan
 PK|or|ପାକିସ୍ତାନ
 PK|os|*aa
 PK|pa|ਪਾਕਿਸਤਾਨ
@@ -33423,7 +33423,7 @@ PK|ro|*aa
 PK|ru|*bg
 PK|rw|*aa
 PK|sa|*aa
-PK|sc|*aa
+PK|sc|Pàkistan
 PK|sd|پاڪستان
 PK|se|*aa
 PK|sg|Pakistäan
@@ -33463,7 +33463,7 @@ PK|vi|*aa
 PK|vo|*aa
 PK|wa|*aa
 PK|wo|Pakistaŋ
-PK|xh|*aa
+PK|xh|EPakistan
 PK|yi|*ji
 PK|yo|Pakisitan
 PK|za|*aa
@@ -33473,7 +33473,7 @@ PL|aa|Poland
 PL|ab|*aa
 PL|ae|*aa
 PL|af|Pole
-PL|ak|*aa
+PL|ak|Pɔland
 PL|am|ፖላንድ
 PL|an|*aa
 PL|ar|بولندا
@@ -33498,7 +33498,7 @@ PL|co|*aa
 PL|cr|*aa
 PL|cs|Polsko
 PL|cu|*aa
-PL|cv|*aa
+PL|cv|*ce
 PL|cy|Gwlad Pwyl
 PL|da|Polen
 PL|de|*da
@@ -33529,13 +33529,13 @@ PL|he|פולין
 PL|hi|पोलैंड
 PL|ho|*aa
 PL|hr|*bs
-PL|ht|*aa
+PL|ht|*fr
 PL|hu|Lengyelország
 PL|hy|Լեհաստան
 PL|hz|*aa
 PL|ia|*br
 PL|id|Polandia
-PL|ie|*aa
+PL|ie|*br
 PL|ig|*aa
 PL|ii|*aa
 PL|ik|*aa
@@ -33558,7 +33558,7 @@ PL|km|ប៉ូឡូញ
 PL|kn|ಪೋಲ್ಯಾಂಡ್
 PL|ko|폴란드
 PL|kr|*aa
-PL|ks|پولینڑ
+PL|ks|پولینڈ
 PL|ku|Polonya
 PL|kv|*aa
 PL|kw|*aa
@@ -33574,7 +33574,7 @@ PL|lu|Mpoloni
 PL|lv|Polija
 PL|mg|Pôlôna
 PL|mh|*aa
-PL|mi|*aa
+PL|mi|Pōrana
 PL|mk|Полска
 PL|ml|പോളണ്ട്
 PL|mn|Польш
@@ -33596,7 +33596,7 @@ PL|nv|*aa
 PL|ny|*aa
 PL|oc|*aa
 PL|oj|*aa
-PL|om|*aa
+PL|om|Poolaand
 PL|or|ପୋଲାଣ୍ଡ
 PL|os|*aa
 PL|pa|ਪੋਲੈਂਡ
@@ -33611,7 +33611,7 @@ PL|ro|*br
 PL|ru|*ce
 PL|rw|*aa
 PL|sa|*aa
-PL|sc|*aa
+PL|sc|*ca
 PL|sd|پولينڊ
 PL|se|*da
 PL|sg|Pölôni
@@ -33644,14 +33644,14 @@ PL|tw|*aa
 PL|ty|*aa
 PL|ug|پولشا
 PL|uk|Польща
-PL|ur|پولینڈ
+PL|ur|*ks
 PL|uz|Polsha
 PL|ve|*aa
 PL|vi|Ba Lan
 PL|vo|*aa
 PL|wa|*aa
 PL|wo|*ff
-PL|xh|*aa
+PL|xh|EPoland
 PL|yi|*ji
 PL|yo|*ki
 PL|za|*aa
@@ -33662,7 +33662,7 @@ PM|ab|*aa
 PM|ae|*aa
 PM|af|Sint Pierre en Miquelon
 PM|ak|Saint Pierre ne Miquelon
-PM|am|ቅዱስ ፒዬር እና ሚኩኤሎን
+PM|am|ሴንት ፒዬር እና ሚኩኤሎን
 PM|an|*aa
 PM|ar|سان بيير ومكويلون
 PM|as|ছেইণ্ট পিয়েৰে আৰু মিকিউৱেলন
@@ -33686,7 +33686,7 @@ PM|co|*aa
 PM|cr|*aa
 PM|cs|Saint-Pierre a Miquelon
 PM|cu|*aa
-PM|cv|*aa
+PM|cv|Сен-Пьер & Микелон
 PM|cy|*ca
 PM|da|Saint Pierre og Miquelon
 PM|de|St. Pierre und Miquelon
@@ -33695,7 +33695,7 @@ PM|dz|སིནཊ་པི་ཡེར་ ཨེནཌ་ མིཀོ་ལེ
 PM|ee|Saint Pierre kple Mikelɔn nutome
 PM|el|Σεν Πιερ και Μικελόν
 PM|en|*aa
-PM|eo|Sent-Piero kaj Mikelono
+PM|eo|Sankta Piero kaj Mikelono
 PM|es|San Pedro y Miquelón
 PM|et|Saint-Pierre ja Miquelon
 PM|eu|Saint-Pierre eta Mikelune
@@ -33716,15 +33716,15 @@ PM|ha|San Piyar da Mikelan
 PM|he|סנט פייר ומיקלון
 PM|hi|सेंट पिएरे और मिक्वेलान
 PM|ho|*aa
-PM|hr|*ca
-PM|ht|*aa
+PM|hr|*bs
+PM|ht|*ca
 PM|hu|Saint-Pierre és Miquelon
 PM|hy|Սեն Պիեռ և Միքելոն
 PM|hz|*aa
 PM|ia|St. Pierre e Miquelon
 PM|id|Saint Pierre dan Miquelon
 PM|ie|*aa
-PM|ig|Pierre na Miquelon Dị nsọ
+PM|ig|*aa
 PM|ii|*aa
 PM|ik|*aa
 PM|in|*id
@@ -33762,7 +33762,7 @@ PM|lu|Santu pététo ne Mikelu
 PM|lv|Senpjēra un Mikelona
 PM|mg|*ca
 PM|mh|*aa
-PM|mi|*aa
+PM|mi|Hato Piere & Mikerona
 PM|mk|Сент Пјер и Микелан
 PM|ml|സെന്റ് പിയറി ആൻഡ് മിക്വലൻ
 PM|mn|Сент-Пьер ба Микело
@@ -33784,7 +33784,7 @@ PM|nv|*aa
 PM|ny|*aa
 PM|oc|*aa
 PM|oj|*aa
-PM|om|*aa
+PM|om|Ql. Piyeeree fi Mikuyelon
 PM|or|ସେଣ୍ଟ ପିଏରେ ଏବଂ ମିକ୍ୱେଲନ୍‌
 PM|os|*aa
 PM|pa|ਸੇਂਟ ਪੀਅਰੇ ਐਂਡ ਮਿਕੇਲਨ
@@ -33799,7 +33799,7 @@ PM|ro|*mo
 PM|ru|Сен-Пьер и Микелон
 PM|rw|*aa
 PM|sa|*aa
-PM|sc|*aa
+PM|sc|Santu Predu e Miquelon
 PM|sd|سینٽ پیئر و میڪوئیلون
 PM|se|Saint Pierre ja Miquelon
 PM|sg|Sên-Pyêre na Mikelöon
@@ -33808,7 +33808,7 @@ PM|sk|Saint Pierre a Miquelon
 PM|sl|Saint Pierre in Miquelon
 PM|sm|*aa
 PM|sn|*nd
-PM|so|*nd
+PM|so|St. Pierre iyo Miquelon
 PM|sq|Shën-Pier dhe Mikelon
 PM|sr|Сен Пјер и Микелон
 PM|ss|*aa
@@ -33820,7 +33820,7 @@ PM|ta|செயின்ட் பியர் & மிக்வேலான்
 PM|te|సెయింట్ పియెర్ మరియు మికెలాన్
 PM|tg|Сент-Пер ва Микелон
 PM|th|แซงปีแยร์และมีเกอลง
-PM|ti|ቅዱስ ፒዬርን ሚኩኤሎን
+PM|ti|ቅዱስ ፕየርን ሚከሎንን
 PM|tk|Sen-Pýer we Mikelon
 PM|tl|*aa
 PM|tn|*aa
@@ -33839,7 +33839,7 @@ PM|vi|Saint Pierre và Miquelon
 PM|vo|*aa
 PM|wa|*aa
 PM|wo|Saŋ Peer ak Mikeloŋ
-PM|xh|*aa
+PM|xh|ESt. Pierre & Miquelon
 PM|yi|*aa
 PM|yo|Pẹẹri ati mikuloni
 PM|za|*aa
@@ -33849,7 +33849,7 @@ PN|aa|Pitcairn Islands
 PN|ab|*aa
 PN|ae|*aa
 PN|af|Pitcairneilande
-PN|ak|Pitcairn
+PN|ak|Pitkaan Nsupɔ
 PN|am|ፒትካኢርን ደሴቶች
 PN|an|*aa
 PN|ar|جزر بيتكيرن
@@ -33874,9 +33874,9 @@ PN|co|*aa
 PN|cr|*aa
 PN|cs|Pitcairnovy ostrovy
 PN|cu|*aa
-PN|cv|*aa
+PN|cv|Питкэрн утравӗсем
 PN|cy|Ynysoedd Pitcairn
-PN|da|*ak
+PN|da|Pitcairn
 PN|de|Pitcairninseln
 PN|dv|*aa
 PN|dz|པིཊ་ཀེ་ཡེརན་གླིང་ཚོམ
@@ -33889,7 +33889,7 @@ PN|et|Pitcairni saared
 PN|eu|Pitcairn uharteak
 PN|fa|جزایر پیت‌کرن
 PN|ff|Pitkern
-PN|fi|*ak
+PN|fi|*da
 PN|fj|*aa
 PN|fo|Pitcairnoyggjar
 PN|fr|Îles Pitcairn
@@ -33900,16 +33900,16 @@ PN|gl|Illas Pitcairn
 PN|gn|*aa
 PN|gu|પીટકૈર્ન આઇલેન્ડ્સ
 PN|gv|*aa
-PN|ha|Pitakarin
+PN|ha|Tsibiran Pitcairn
 PN|he|איי פיטקרן
 PN|hi|पिटकैर्न द्वीपसमूह
 PN|ho|*aa
-PN|hr|Otoci Pitcairn
-PN|ht|*aa
+PN|hr|Pitcairnovi Otoci
+PN|ht|*fr
 PN|hu|Pitcairn-szigetek
 PN|hy|Պիտկեռն կղզիներ
 PN|hz|*aa
-PN|ia|*aa
+PN|ia|Insulas Pitcairn
 PN|id|Kepulauan Pitcairn
 PN|ie|*aa
 PN|ig|Agwaetiti Pitcairn
@@ -33934,8 +33934,8 @@ PN|km|កោះ​ភីតកាន
 PN|kn|ಪಿಟ್‌ಕೈರ್ನ್ ದ್ವೀಪಗಳು
 PN|ko|핏케언 제도
 PN|kr|*aa
-PN|ks|پِٹکیرٕنۍ جٔزیٖرٕ
-PN|ku|Giravên Pitcairn
+PN|ks|پِٹکیرٕنؠ جٔزیٖرٕ
+PN|ku|Giravên Pitcairnê
 PN|kv|*aa
 PN|kw|*aa
 PN|ky|*kk
@@ -33950,7 +33950,7 @@ PN|lu|*ln
 PN|lv|Pitkērnas salas
 PN|mg|Pitkairn
 PN|mh|*aa
-PN|mi|*aa
+PN|mi|Pitikeina
 PN|mk|Питкернски Острови
 PN|ml|പിറ്റ്‌കെയ്‌ൻ ദ്വീപുകൾ
 PN|mn|Питкэрн арлууд
@@ -33961,41 +33961,41 @@ PN|mt|Gżejjer Pitcairn
 PN|my|ပစ်တ်ကိန်းကျွန်းစု
 PN|na|*aa
 PN|nb|Pitcairnøyene
-PN|nd|*ak
+PN|nd|*da
 PN|ne|पिटकाइर्न टापुहरु
 PN|ng|*aa
 PN|nl|Pitcairneilanden
-PN|nn|*ak
+PN|nn|*da
 PN|no|*nb
 PN|nr|*aa
 PN|nv|*aa
 PN|ny|*aa
 PN|oc|*aa
 PN|oj|*aa
-PN|om|*aa
+PN|om|Odoloota Pitikaayirin
 PN|or|ପିଟକାଇରିନ୍‌ ଦ୍ୱୀପପୁଞ୍ଜ
 PN|os|*aa
 PN|pa|ਪਿਟਕੇਰਨ ਟਾਪੂ
 PN|pi|*aa
-PN|pl|*ak
+PN|pl|*da
 PN|ps|پيټکيرن ټاپوګان
 PN|pt|Ilhas Pitcairn
 PN|qu|*es
-PN|rm|*ak
+PN|rm|*da
 PN|rn|Pitikeyirini
 PN|ro|*mo
 PN|ru|о-ва Питкэрн
 PN|rw|*aa
 PN|sa|*aa
-PN|sc|*aa
+PN|sc|Ìsulas Pìtcairn
 PN|sd|پٽڪئرن ٻيٽ
-PN|se|*ak
+PN|se|*da
 PN|sg|Pitikêrni
 PN|si|පිට්කෙය්න් දූපත්
 PN|sk|Pitcairnove ostrovy
-PN|sl|*ak
+PN|sl|*da
 PN|sm|*aa
-PN|sn|*ak
+PN|sn|*da
 PN|so|Bitkairn
 PN|sq|Ishujt Pitkern
 PN|sr|Питкерн
@@ -34008,7 +34008,7 @@ PN|ta|பிட்கெய்ர்ன் தீவுகள்
 PN|te|పిట్‌కెయిర్న్ దీవులు
 PN|tg|Ҷазираҳои Питкейрн
 PN|th|หมู่เกาะพิตแคร์น
-PN|ti|ፒትካኢርን
+PN|ti|ደሴታት ፒትካርን
 PN|tk|Pitkern adalary
 PN|tl|*aa
 PN|tn|*aa
@@ -34027,7 +34027,7 @@ PN|vi|Quần đảo Pitcairn
 PN|vo|*aa
 PN|wa|*aa
 PN|wo|Duni Pitkayirn
-PN|xh|*aa
+PN|xh|EPitcairn Islands
 PN|yi|*ji
 PN|yo|Pikarini
 PN|za|*aa
@@ -34038,7 +34038,7 @@ PR|ab|*aa
 PR|ae|*aa
 PR|af|*aa
 PR|ak|Puɛto Riko
-PR|am|ፖርታ ሪኮ
+PR|am|ፑዌርቶ ሪኮ
 PR|an|*aa
 PR|ar|بورتوريكو
 PR|as|পুৱেৰ্টো ৰিকো
@@ -34062,7 +34062,7 @@ PR|co|*aa
 PR|cr|*aa
 PR|cs|Portoriko
 PR|cu|*aa
-PR|cv|*aa
+PR|cv|*ce
 PR|cy|*aa
 PR|da|*aa
 PR|de|*aa
@@ -34071,7 +34071,7 @@ PR|dz|པུ་འེར་ཊོ་རི་ཁོ
 PR|ee|Puerto Riko nutome
 PR|el|Πουέρτο Ρίκο
 PR|en|*aa
-PR|eo|Puerto-Riko
+PR|eo|Puertoriko
 PR|es|*aa
 PR|et|*aa
 PR|eu|*aa
@@ -34093,13 +34093,13 @@ PR|he|פוארטו ריקו
 PR|hi|पोर्टो रिको
 PR|ho|*aa
 PR|hr|*cs
-PR|ht|*aa
+PR|ht|*fr
 PR|hu|*aa
 PR|hy|Պուերտո Ռիկո
 PR|hz|*aa
-PR|ia|*aa
+PR|ia|*fr
 PR|id|*az
-PR|ie|*aa
+PR|ie|Porto-Rico
 PR|ig|*aa
 PR|ii|*aa
 PR|ik|*aa
@@ -34135,10 +34135,10 @@ PR|ln|Pɔtoriko
 PR|lo|ເພືອໂຕ ຣິໂກ
 PR|lt|Puerto Rikas
 PR|lu|Mpotoriku
-PR|lv|Puertoriko
+PR|lv|*eo
 PR|mg|Pôrtô Rikô
 PR|mh|*aa
-PR|mi|*aa
+PR|mi|Peta Riko
 PR|mk|Порторико
 PR|ml|പോർട്ടോ റിക്കോ
 PR|mn|*ce
@@ -34160,7 +34160,7 @@ PR|nv|*aa
 PR|ny|*aa
 PR|oc|*aa
 PR|oj|*aa
-PR|om|*aa
+PR|om|Poortaar Riikoo
 PR|or|ପୁଏର୍ତ୍ତୋ ରିକୋ
 PR|os|*aa
 PR|pa|ਪਿਊਰਟੋ ਰਿਕੋ
@@ -34196,8 +34196,8 @@ PR|ta|பியூர்டோ ரிகோ
 PR|te|ప్యూర్టో రికో
 PR|tg|*ce
 PR|th|เปอร์โตริโก
-PR|ti|*am
-PR|tk|*eo
+PR|ti|ፖርቶ ሪኮ
+PR|tk|Puerto-Riko
 PR|tl|*aa
 PR|tn|*aa
 PR|to|Puēto Liko
@@ -34209,13 +34209,13 @@ PR|ty|*aa
 PR|ug|پۇئېرتو رىكو
 PR|uk|Пуерто-Рико
 PR|ur|پیورٹو ریکو
-PR|uz|*eo
+PR|uz|*tk
 PR|ve|*aa
 PR|vi|*aa
 PR|vo|*aa
 PR|wa|*aa
 PR|wo|*bs
-PR|xh|*aa
+PR|xh|EPuerto Rico
 PR|yi|*ji
 PR|yo|Pọto Riko
 PR|za|*aa
@@ -34239,7 +34239,7 @@ PS|bg|Палестински територии
 PS|bh|*aa
 PS|bi|*aa
 PS|bm|Palesitini
-PS|bn|প্যালেস্টাইনের অঞ্চলসমূহ
+PS|bn|প্যালেস্টাইন ভূখণ্ড
 PS|bo|*aa
 PS|br|Tiriadoù Palestina
 PS|bs|Palestinska Teritorija
@@ -34250,7 +34250,7 @@ PS|co|*aa
 PS|cr|*aa
 PS|cs|Palestinská území
 PS|cu|*aa
-PS|cv|*aa
+PS|cv|Палестинӑн территорийӗсем
 PS|cy|Tiriogaethau Palesteinaidd
 PS|da|De palæstinensiske områder
 PS|de|Palästinensische Autonomiegebiete
@@ -34281,20 +34281,20 @@ PS|he|השטחים הפלסטיניים
 PS|hi|फ़िलिस्तीनी क्षेत्र
 PS|ho|*aa
 PS|hr|Palestinsko područje
-PS|ht|*aa
+PS|ht|*fr
 PS|hu|Palesztin Autonómia
 PS|hy|Պաղեստինյան տարածքներ
 PS|hz|*aa
-PS|ia|*aa
+PS|ia|Territorios palestin
 PS|id|Wilayah Palestina
 PS|ie|*aa
-PS|ig|*aa
+PS|ig|Mpaghara ndị Palestine
 PS|ii|*aa
 PS|ik|*aa
 PS|in|*id
 PS|io|*aa
 PS|is|Heimastjórnarsvæði Palestínumanna
-PS|it|Territori palestinesi
+PS|it|Territori Palestinesi
 PS|iu|*aa
 PS|iw|*he
 PS|ja|パレスチナ自治区
@@ -34310,8 +34310,8 @@ PS|km|ដែនដីប៉ាឡេស្ទីន
 PS|kn|ಪ್ಯಾಲೇಸ್ಟೇನಿಯನ್ ಪ್ರದೇಶಗಳು
 PS|ko|팔레스타인 지구
 PS|kr|*aa
-PS|ks|فَلَستیٖن
-PS|ku|Xakên filistînî
+PS|ks|فلسطینی علاقٕہ
+PS|ku|Herêmên Filîstînî
 PS|kv|*aa
 PS|kw|*aa
 PS|ky|Палестина аймактары
@@ -34326,7 +34326,7 @@ PS|lu|Palesine
 PS|lv|Palestīnas teritorijas
 PS|mg|Palestina
 PS|mh|*aa
-PS|mi|*aa
+PS|mi|Ngā Rohe o Parihitini
 PS|mk|Палестински Територии
 PS|ml|പാലസ്‌തീൻ പ്രദേശങ്ങൾ
 PS|mn|Палестины нутаг дэвсгэр
@@ -34348,7 +34348,7 @@ PS|nv|*aa
 PS|ny|*aa
 PS|oc|*aa
 PS|oj|*aa
-PS|om|*aa
+PS|om|Daangaawwan Paalestaayin
 PS|or|ପାଲେଷ୍ଟେନିୟ ଭୂଭାଗ
 PS|os|*aa
 PS|pa|ਫਿਲੀਸਤੀਨੀ ਇਲਾਕਾ
@@ -34363,7 +34363,7 @@ PS|ro|*mo
 PS|ru|Палестинские территории
 PS|rw|*aa
 PS|sa|*aa
-PS|sc|*aa
+PS|sc|Territòrios palestinesos
 PS|sd|فلسطيني علائقا
 PS|se|*mg
 PS|sg|Sêse tî Palestîni
@@ -34382,16 +34382,16 @@ PS|sv|Palestinska territorierna
 PS|sw|Maeneo ya Palestina
 PS|ta|பாலஸ்தீனிய பிரதேசங்கள்
 PS|te|పాలస్తీనియన్ ప్రాంతాలు
-PS|tg|*aa
+PS|tg|Қаламравҳои Фаластинӣ
 PS|th|ดินแดนปาเลสไตน์
-PS|ti|*am
+PS|ti|ግዝኣታት ፍልስጤም
 PS|tk|Palestina territoriýasy
 PS|tl|*aa
 PS|tn|*aa
 PS|to|Potu Palesitaine
 PS|tr|Filistin Bölgeleri
 PS|ts|*aa
-PS|tt|*aa
+PS|tt|Фәләстин территорияләре
 PS|tw|*aa
 PS|ty|*aa
 PS|ug|پەلەستىن زېمىنى
@@ -34402,8 +34402,8 @@ PS|ve|*aa
 PS|vi|Lãnh thổ Palestine
 PS|vo|*aa
 PS|wa|*aa
-PS|wo|*aa
-PS|xh|*aa
+PS|wo|réew yu Palestine
+PS|xh|IPalestinian Territories
 PS|yi|*aa
 PS|yo|Agbègbè ara Palẹsítínì
 PS|za|*aa
@@ -34438,7 +34438,7 @@ PT|co|*aa
 PT|cr|*aa
 PT|cs|Portugalsko
 PT|cu|*aa
-PT|cv|*aa
+PT|cv|*ce
 PT|cy|Portiwgal
 PT|da|*aa
 PT|de|*aa
@@ -34514,7 +34514,7 @@ PT|lu|Mputulugeshi
 PT|lv|Portugāle
 PT|mg|Pôrtiogala
 PT|mh|*aa
-PT|mi|*aa
+PT|mi|Potukara
 PT|mk|Португалија
 PT|ml|പോർച്ചുഗൽ
 PT|mn|Португал
@@ -34536,7 +34536,7 @@ PT|nv|*aa
 PT|ny|*aa
 PT|oc|*aa
 PT|oj|*aa
-PT|om|*aa
+PT|om|Poorchugaal
 PT|or|ପର୍ତ୍ତୁଗାଲ୍
 PT|os|*aa
 PT|pa|ਪੁਰਤਗਾਲ
@@ -34551,7 +34551,7 @@ PT|ro|*mo
 PT|ru|*bg
 PT|rw|*aa
 PT|sa|*aa
-PT|sc|*aa
+PT|sc|Portogallu
 PT|sd|پرتگال
 PT|se|Portugála
 PT|sg|Pörtugäle, Ködörö Pûra
@@ -34591,7 +34591,7 @@ PT|vi|Bồ Đào Nha
 PT|vo|*aa
 PT|wa|*aa
 PT|wo|Portigaal
-PT|xh|*aa
+PT|xh|EPortugal
 PT|yi|*ji
 PT|yo|Pọ́túgà
 PT|za|*aa
@@ -34626,7 +34626,7 @@ PW|co|*aa
 PW|cr|*aa
 PW|cs|*aa
 PW|cu|*aa
-PW|cv|*aa
+PW|cv|*be
 PW|cy|*aa
 PW|da|*aa
 PW|de|*aa
@@ -34635,7 +34635,7 @@ PW|dz|པ་ལའུ
 PW|ee|Palau nutome
 PW|el|Παλάου
 PW|en|*aa
-PW|eo|Belaŭo
+PW|eo|Palaŭo
 PW|es|Palaos
 PW|et|Belau
 PW|eu|*aa
@@ -34657,7 +34657,7 @@ PW|he|פלאו
 PW|hi|पलाऊ
 PW|ho|*aa
 PW|hr|*aa
-PW|ht|*aa
+PW|ht|*es
 PW|hu|*aa
 PW|hy|Պալաու
 PW|hz|*aa
@@ -34702,7 +34702,7 @@ PW|lu|*aa
 PW|lv|*aa
 PW|mg|Palao
 PW|mh|*aa
-PW|mi|*aa
+PW|mi|Pārau
 PW|mk|*be
 PW|ml|പലാവു
 PW|mn|*be
@@ -34724,7 +34724,7 @@ PW|nv|*aa
 PW|ny|*aa
 PW|oc|*aa
 PW|oj|*aa
-PW|om|*aa
+PW|om|Palaawu
 PW|or|ପାଲାଉ
 PW|os|*aa
 PW|pa|ਪਲਾਉ
@@ -34779,7 +34779,7 @@ PW|vi|*aa
 PW|vo|*aa
 PW|wa|*aa
 PW|wo|Palaw
-PW|xh|*aa
+PW|xh|EPalau
 PW|yi|*aa
 PW|yo|Paalu
 PW|za|*aa
@@ -34789,7 +34789,7 @@ PY|aa|Paraguay
 PY|ab|*aa
 PY|ae|*aa
 PY|af|*aa
-PY|ak|*aa
+PY|ak|Paraguae
 PY|am|ፓራጓይ
 PY|an|*aa
 PY|ar|باراغواي
@@ -34814,7 +34814,7 @@ PY|co|*aa
 PY|cr|*aa
 PY|cs|*aa
 PY|cu|*aa
-PY|cv|*aa
+PY|cv|*be
 PY|cy|*aa
 PY|da|*aa
 PY|de|*aa
@@ -34836,7 +34836,7 @@ PY|fr|*aa
 PY|fy|*aa
 PY|ga|Paragua
 PY|gd|Paraguaidh
-PY|gl|O Paraguai
+PY|gl|*ca
 PY|gn|*aa
 PY|gu|પેરાગ્વે
 PY|gv|*aa
@@ -34875,7 +34875,7 @@ PY|kn|ಪರಾಗ್ವೇ
 PY|ko|파라과이
 PY|kr|*aa
 PY|ks|پَراگُے
-PY|ku|*aa
+PY|ku|Paragûay
 PY|kv|*aa
 PY|kw|*aa
 PY|ky|*be
@@ -34890,7 +34890,7 @@ PY|lu|*ln
 PY|lv|Paragvaja
 PY|mg|Paragoay
 PY|mh|*aa
-PY|mi|*aa
+PY|mi|Parakai
 PY|mk|Парагвај
 PY|ml|പരാഗ്വേ
 PY|mn|*be
@@ -34912,7 +34912,7 @@ PY|nv|*aa
 PY|ny|*aa
 PY|oc|*aa
 PY|oj|*aa
-PY|om|*aa
+PY|om|Paaraguwaay
 PY|or|ପାରାଗୁଏ
 PY|os|*aa
 PY|pa|ਪੈਰਾਗਵੇ
@@ -34927,7 +34927,7 @@ PY|ro|*aa
 PY|ru|*be
 PY|rw|*aa
 PY|sa|*aa
-PY|sc|*aa
+PY|sc|Paraguày
 PY|sd|پيراگوءِ
 PY|se|*aa
 PY|sg|Paraguëe
@@ -34967,7 +34967,7 @@ PY|vi|*aa
 PY|vo|*aa
 PY|wa|*aa
 PY|wo|Paraguwe
-PY|xh|*aa
+PY|xh|EParaguay
 PY|yi|*ji
 PY|yo|Paraguye
 PY|za|*aa
@@ -35002,7 +35002,7 @@ QA|co|*aa
 QA|cr|*aa
 QA|cs|*af
 QA|cu|*aa
-QA|cv|*aa
+QA|cv|*be
 QA|cy|*aa
 QA|da|*aa
 QA|de|*af
@@ -35078,7 +35078,7 @@ QA|lu|*bm
 QA|lv|Katara
 QA|mg|*af
 QA|mh|*aa
-QA|mi|*aa
+QA|mi|Katā
 QA|mk|*be
 QA|ml|ഖത്തർ
 QA|mn|*be
@@ -35100,7 +35100,7 @@ QA|nv|*aa
 QA|ny|*aa
 QA|oc|*aa
 QA|oj|*aa
-QA|om|*aa
+QA|om|Kuwaatar
 QA|or|କତାର୍
 QA|os|*aa
 QA|pa|ਕਤਰ
@@ -35115,7 +35115,7 @@ QA|ro|*aa
 QA|ru|*be
 QA|rw|*aa
 QA|sa|*aa
-QA|sc|*aa
+QA|sc|*es
 QA|sd|*ar
 QA|se|*aa
 QA|sg|Katära
@@ -35136,11 +35136,11 @@ QA|ta|கத்தார்
 QA|te|ఖతార్
 QA|tg|Қатар
 QA|th|กาตาร์
-QA|ti|ቀጠር
+QA|ti|ቐጠር
 QA|tk|*af
 QA|tl|*aa
 QA|tn|*aa
-QA|to|Katā
+QA|to|*mi
 QA|tr|*af
 QA|ts|*aa
 QA|tt|*be
@@ -35155,7 +35155,7 @@ QA|vi|*aa
 QA|vo|*aa
 QA|wa|*aa
 QA|wo|*ff
-QA|xh|*aa
+QA|xh|EQatar
 QA|yi|*ji
 QA|yo|Kota
 QA|za|*aa
@@ -35190,7 +35190,7 @@ RE|co|*aa
 RE|cr|*aa
 RE|cs|*aa
 RE|cu|*aa
-RE|cv|*aa
+RE|cv|*ce
 RE|cy|*aa
 RE|da|*aa
 RE|de|*aa
@@ -35210,7 +35210,7 @@ RE|fj|*aa
 RE|fo|*aa
 RE|fr|La Réunion
 RE|fy|*aa
-RE|ga|*aa
+RE|ga|*fr
 RE|gd|*aa
 RE|gl|*es
 RE|gn|*aa
@@ -35221,11 +35221,11 @@ RE|he|ראוניון
 RE|hi|रियूनियन
 RE|ho|*aa
 RE|hr|*aa
-RE|ht|*aa
+RE|ht|*fr
 RE|hu|*aa
 RE|hy|Ռեյունիոն
 RE|hz|*aa
-RE|ia|*aa
+RE|ia|*bs
 RE|id|*aa
 RE|ie|*aa
 RE|ig|*aa
@@ -35266,8 +35266,8 @@ RE|lu|*ln
 RE|lv|Reinjona
 RE|mg|Larenion
 RE|mh|*aa
-RE|mi|*aa
-RE|mk|Реунион
+RE|mi|Reūnio
+RE|mk|Рејунион
 RE|ml|റീയൂണിയൻ
 RE|mn|*bg
 RE|mo|*aa
@@ -35288,7 +35288,7 @@ RE|nv|*aa
 RE|ny|*aa
 RE|oc|*aa
 RE|oj|*aa
-RE|om|*aa
+RE|om|Riyuuniyeen
 RE|or|ରିୟୁନିଅନ୍
 RE|os|*aa
 RE|pa|ਰਿਯੂਨੀਅਨ
@@ -35303,7 +35303,7 @@ RE|ro|*aa
 RE|ru|*ce
 RE|rw|*aa
 RE|sa|*aa
-RE|sc|*aa
+RE|sc|*it
 RE|sd|ري يونين
 RE|se|*aa
 RE|sg|Reinïon
@@ -35324,7 +35324,7 @@ RE|ta|ரீயூனியன்
 RE|te|రీయూనియన్
 RE|tg|*bg
 RE|th|เรอูนียง
-RE|ti|*am
+RE|ti|ርዩንየን
 RE|tk|Reýunýon
 RE|tl|*aa
 RE|tn|*aa
@@ -35343,7 +35343,7 @@ RE|vi|*aa
 RE|vo|*aa
 RE|wa|*aa
 RE|wo|Reeñoo
-RE|xh|*aa
+RE|xh|ERéunion
 RE|yi|*ji
 RE|yo|Riuniyan
 RE|za|*aa
@@ -35378,7 +35378,7 @@ RO|co|*aa
 RO|cr|*aa
 RO|cs|Rumunsko
 RO|cu|*aa
-RO|cv|*aa
+RO|cv|*ce
 RO|cy|Rwmania
 RO|da|Rumænien
 RO|de|Rumänien
@@ -35409,13 +35409,13 @@ RO|he|רומניה
 RO|hi|रोमानिया
 RO|ho|*aa
 RO|hr|Rumunjska
-RO|ht|*aa
+RO|ht|*fr
 RO|hu|Románia
 RO|hy|Ռումինիա
 RO|hz|*aa
 RO|ia|*aa
 RO|id|Rumania
-RO|ie|*aa
+RO|ie|*id
 RO|ig|*aa
 RO|ii|*aa
 RO|ik|*aa
@@ -35454,7 +35454,7 @@ RO|lu|*ln
 RO|lv|Rumānija
 RO|mg|*aa
 RO|mh|*aa
-RO|mi|*aa
+RO|mi|Romeinia
 RO|mk|Романија
 RO|ml|റൊമാനിയ
 RO|mn|Румын
@@ -35476,7 +35476,7 @@ RO|nv|*aa
 RO|ny|*aa
 RO|oc|*aa
 RO|oj|*aa
-RO|om|*aa
+RO|om|Roomaaniyaa
 RO|or|ରୋମାନିଆ
 RO|os|*aa
 RO|pa|ਰੋਮਾਨੀਆ
@@ -35512,7 +35512,7 @@ RO|ta|ருமேனியா
 RO|te|రోమేనియా
 RO|tg|Руминия
 RO|th|โรมาเนีย
-RO|ti|*am
+RO|ti|ሩማንያ
 RO|tk|Rumyniýa
 RO|tl|*aa
 RO|tn|*aa
@@ -35531,7 +35531,7 @@ RO|vi|*aa
 RO|vo|*aa
 RO|wa|*aa
 RO|wo|*bm
-RO|xh|*aa
+RO|xh|ERomania
 RO|yi|*ji
 RO|yo|*ha
 RO|za|*aa
@@ -35541,7 +35541,7 @@ RS|aa|Serbia
 RS|ab|*aa
 RS|ae|*aa
 RS|af|Serwië
-RS|ak|*aa
+RS|ak|Sɛbia
 RS|am|ሰርብያ
 RS|an|*aa
 RS|ar|صربيا
@@ -35566,7 +35566,7 @@ RS|co|*aa
 RS|cr|*aa
 RS|cs|Srbsko
 RS|cu|*aa
-RS|cv|*aa
+RS|cv|*ce
 RS|cy|*aa
 RS|da|Serbien
 RS|de|*da
@@ -35597,7 +35597,7 @@ RS|he|סרביה
 RS|hi|सर्बिया
 RS|ho|*aa
 RS|hr|*bs
-RS|ht|*aa
+RS|ht|*fr
 RS|hu|Szerbia
 RS|hy|Սերբիա
 RS|hz|*aa
@@ -35627,7 +35627,7 @@ RS|kn|ಸೆರ್ಬಿಯಾ
 RS|ko|세르비아
 RS|kr|*aa
 RS|ks|سَربِیا
-RS|ku|Serbistan
+RS|ku|Sirbistan
 RS|kv|*aa
 RS|kw|*aa
 RS|ky|*kk
@@ -35642,7 +35642,7 @@ RS|lu|*aa
 RS|lv|*lt
 RS|mg|*aa
 RS|mh|*aa
-RS|mi|*aa
+RS|mi|Hirupia
 RS|mk|Србија
 RS|ml|സെർബിയ
 RS|mn|*ce
@@ -35664,7 +35664,7 @@ RS|nv|*aa
 RS|ny|*aa
 RS|oc|*aa
 RS|oj|*aa
-RS|om|*aa
+RS|om|Serbiyaa
 RS|or|ସର୍ବିଆ
 RS|os|*aa
 RS|pa|ਸਰਬੀਆ
@@ -35679,7 +35679,7 @@ RS|ro|*aa
 RS|ru|*kk
 RS|rw|*aa
 RS|sa|*aa
-RS|sc|*aa
+RS|sc|*ca
 RS|sd|*ps
 RS|se|*aa
 RS|sg|*aa
@@ -35700,7 +35700,7 @@ RS|ta|செர்பியா
 RS|te|సెర్బియా
 RS|tg|*kk
 RS|th|เซอร์เบีย
-RS|ti|ሰርቢያ
+RS|ti|*am
 RS|tk|Serbiýa
 RS|tl|*aa
 RS|tn|*aa
@@ -35719,9 +35719,9 @@ RS|vi|*aa
 RS|vo|*aa
 RS|wa|*aa
 RS|wo|*sq
-RS|xh|*aa
+RS|xh|ESerbia
 RS|yi|*ji
-RS|yo|*aa
+RS|yo|Sẹ́bíà
 RS|za|*aa
 RS|zh|塞尔维亚
 RS|zu|i-Serbia
@@ -35754,7 +35754,7 @@ RU|co|*aa
 RU|cr|*aa
 RU|cs|Rusko
 RU|cu|*aa
-RU|cv|*aa
+RU|cv|Раҫҫей
 RU|cy|Rwsia
 RU|da|*af
 RU|de|Russland
@@ -35785,14 +35785,14 @@ RU|he|רוסיה
 RU|hi|रूस
 RU|ho|*aa
 RU|hr|*bs
-RU|ht|*aa
+RU|ht|*fr
 RU|hu|Oroszország
 RU|hy|Ռուսաստան
 RU|hz|*aa
 RU|ia|*aa
 RU|id|*br
 RU|ie|*aa
-RU|ig|Rụssịa
+RU|ig|*aa
 RU|ii|ꊉꇆꌦ
 RU|ik|*aa
 RU|in|*br
@@ -35852,7 +35852,7 @@ RU|nv|*aa
 RU|ny|*aa
 RU|oc|*aa
 RU|oj|*aa
-RU|om|*aa
+RU|om|Raashiyaa
 RU|or|ରୁଷିଆ
 RU|os|Уӕрӕсе
 RU|pa|ਰੂਸ
@@ -35867,7 +35867,7 @@ RU|ro|*br
 RU|ru|*ky
 RU|rw|*aa
 RU|sa|रष्यदेश:
-RU|sc|*aa
+RU|sc|Rùssia
 RU|sd|روس
 RU|se|Ruošša
 RU|sg|Rusïi
@@ -35888,7 +35888,7 @@ RU|ta|ரஷ்யா
 RU|te|రష్యా
 RU|tg|*bg
 RU|th|รัสเซีย
-RU|ti|ራሺያ
+RU|ti|*am
 RU|tk|Russiýa
 RU|tl|*aa
 RU|tn|*aa
@@ -35907,7 +35907,7 @@ RU|vi|Nga
 RU|vo|*aa
 RU|wa|*aa
 RU|wo|*lu
-RU|xh|*aa
+RU|xh|ERashiya
 RU|yi|*ji
 RU|yo|Rọṣia
 RU|za|*aa
@@ -35917,7 +35917,7 @@ RW|aa|Rwanda
 RW|ab|*aa
 RW|ae|*aa
 RW|af|*aa
-RW|ak|*aa
+RW|ak|Rewanda
 RW|am|ሩዋንዳ
 RW|an|*aa
 RW|ar|رواندا
@@ -35942,7 +35942,7 @@ RW|co|*aa
 RW|cr|*aa
 RW|cs|*aa
 RW|cu|*aa
-RW|cv|*aa
+RW|cv|*be
 RW|cy|*aa
 RW|da|*aa
 RW|de|*az
@@ -36018,7 +36018,7 @@ RW|lu|*aa
 RW|lv|*az
 RW|mg|Roanda
 RW|mh|*aa
-RW|mi|*aa
+RW|mi|Rāwana
 RW|mk|*be
 RW|ml|റുവാണ്ട
 RW|mn|*be
@@ -36040,7 +36040,7 @@ RW|nv|*aa
 RW|ny|*aa
 RW|oc|*aa
 RW|oj|*aa
-RW|om|*aa
+RW|om|Ruwwandaa
 RW|or|ରାୱାଣ୍ଡା
 RW|os|*aa
 RW|pa|ਰਵਾਂਡਾ
@@ -36055,7 +36055,7 @@ RW|ro|*aa
 RW|ru|*be
 RW|rw|U Rwanda
 RW|sa|*aa
-RW|sc|*aa
+RW|sc|*az
 RW|sd|روانڊا
 RW|se|*aa
 RW|sg|Ruandäa
@@ -36076,7 +36076,7 @@ RW|ta|ருவாண்டா
 RW|te|రువాండా
 RW|tg|*be
 RW|th|รวันดา
-RW|ti|*am
+RW|ti|ርዋንዳ
 RW|tk|*az
 RW|tl|*aa
 RW|tn|*aa
@@ -36095,7 +36095,7 @@ RW|vi|*aa
 RW|vo|*aa
 RW|wa|*aa
 RW|wo|Ruwànda
-RW|xh|*aa
+RW|xh|ERwanda
 RW|yi|*ji
 RW|yo|*bm
 RW|za|*aa
@@ -36123,14 +36123,14 @@ SA|bn|সৌদি আরব
 SA|bo|*aa
 SA|br|Arabia Saoudat
 SA|bs|Saudijska Arabija
-SA|ca|Aràbia Saudita
+SA|ca|Aràbia Saudí
 SA|ce|СаӀудийн Ӏаьрбийчоь
 SA|ch|*aa
 SA|co|*aa
 SA|cr|*aa
 SA|cs|Saúdská Arábie
 SA|cu|*aa
-SA|cv|*aa
+SA|cv|Сауд Аравийӗ
 SA|cy|*aa
 SA|da|Saudi-Arabien
 SA|de|*da
@@ -36139,7 +36139,7 @@ SA|dz|སཱཝ་དི་ ཨ་རེ་བྷི་ཡ
 SA|ee|Saudi Arabia nutome
 SA|el|Σαουδική Αραβία
 SA|en|*aa
-SA|eo|Saŭda Arabujo
+SA|eo|Sauda Arabujo
 SA|es|Arabia Saudí
 SA|et|Saudi Araabia
 SA|eu|*aa
@@ -36161,7 +36161,7 @@ SA|he|ערב הסעודית
 SA|hi|सऊदी अरब
 SA|ho|*aa
 SA|hr|*bs
-SA|ht|*aa
+SA|ht|*fr
 SA|hu|Szaúd-Arábia
 SA|hy|Սաուդյան Արաբիա
 SA|hz|*aa
@@ -36190,8 +36190,8 @@ SA|km|អារ៉ាប៊ីសាអូឌីត
 SA|kn|ಸೌದಿ ಅರೇಬಿಯಾ
 SA|ko|사우디아라비아
 SA|kr|*aa
-SA|ks|سوٗدی عربِیہ
-SA|ku|Erebistana Siyûdî
+SA|ks|سعودی عرب
+SA|ku|Erebistana Siûdî
 SA|kv|*aa
 SA|kw|*aa
 SA|ky|*kk
@@ -36206,14 +36206,14 @@ SA|lu|Alabu Nsawudi
 SA|lv|Saūda Arābija
 SA|mg|Arabia saodita
 SA|mh|*aa
-SA|mi|*aa
+SA|mi|Hauri Arāpia
 SA|mk|Саудиска Арабија
 SA|ml|സൗദി അറേബ്യ
 SA|mn|Саудын Араб
 SA|mo|Arabia Saudită
 SA|mr|सौदी अरब
 SA|ms|*id
-SA|mt|l-Arabia Sawdija
+SA|mt|l-Arabja Sawdija
 SA|my|ဆော်ဒီအာရေးဘီးယား
 SA|na|*aa
 SA|nb|*fi
@@ -36228,7 +36228,7 @@ SA|nv|*aa
 SA|ny|*aa
 SA|oc|*aa
 SA|oj|*aa
-SA|om|*aa
+SA|om|Saawud Arabiyaa
 SA|or|ସାଉଦି ଆରବିଆ
 SA|os|*aa
 SA|pa|ਸਾਊਦੀ ਅਰਬ
@@ -36243,7 +36243,7 @@ SA|ro|*mo
 SA|ru|Саудовская Аравия
 SA|rw|*aa
 SA|sa|*aa
-SA|sc|*aa
+SA|sc|Aràbia Saudita
 SA|sd|سعودي عرب
 SA|se|Saudi-Arábia
 SA|sg|Saûdi Arabïi
@@ -36260,7 +36260,7 @@ SA|st|*aa
 SA|su|*aa
 SA|sv|Saudiarabien
 SA|sw|Saudia
-SA|ta|சவூதி அரேபியா
+SA|ta|சவுதி அரேபியா
 SA|te|సౌదీ అరేబియా
 SA|tg|Арабистони Саудӣ
 SA|th|ซาอุดีอาระเบีย
@@ -36276,14 +36276,14 @@ SA|tw|*aa
 SA|ty|*aa
 SA|ug|سەئۇدىي ئەرەبىستان
 SA|uk|Саудівська Аравія
-SA|ur|سعودی عرب
+SA|ur|*ks
 SA|uz|Saudiya Arabistoni
 SA|ve|*aa
 SA|vi|Ả Rập Xê-út
 SA|vo|*aa
 SA|wa|*aa
 SA|wo|Arabi Sawudi
-SA|xh|*aa
+SA|xh|ESaudi Arabia
 SA|yi|*aa
 SA|yo|*aa
 SA|za|*aa
@@ -36293,8 +36293,8 @@ SB|aa|Solomon Islands
 SB|ab|*aa
 SB|ae|*aa
 SB|af|Salomonseilande
-SB|ak|*aa
-SB|am|ሰሎሞን ደሴት
+SB|ak|Solomɔn Aeland
+SB|am|ሰለሞን ደሴቶች
 SB|an|*aa
 SB|ar|جزر سليمان
 SB|as|চোলোমোন দ্বীপপুঞ্জ
@@ -36318,7 +36318,7 @@ SB|co|*aa
 SB|cr|*aa
 SB|cs|Šalamounovy ostrovy
 SB|cu|*aa
-SB|cv|*aa
+SB|cv|Соломон утравӗсем
 SB|cy|Ynysoedd Solomon
 SB|da|Salomonøerne
 SB|de|Salomonen
@@ -36338,7 +36338,7 @@ SB|fj|*aa
 SB|fo|Salomonoyggjar
 SB|fr|Îles Salomon
 SB|fy|Salomonseilannen
-SB|ga|Oileáin Sholomón
+SB|ga|Oileáin Sholaimh
 SB|gd|Eileanan Sholaimh
 SB|gl|Illas Salomón
 SB|gn|*aa
@@ -36348,8 +36348,8 @@ SB|ha|Tsibiran Salaman
 SB|he|איי שלמה
 SB|hi|सोलोमन द्वीपसमूह
 SB|ho|*aa
-SB|hr|Salomonski Otoci
-SB|ht|*aa
+SB|hr|Salomonovi Otoci
+SB|ht|*fr
 SB|hu|Salamon-szigetek
 SB|hy|Սողոմոնյան կղզիներ
 SB|hz|*aa
@@ -36379,7 +36379,7 @@ SB|kn|ಸಾಲೊಮನ್ ದ್ವೀಪಗಳು
 SB|ko|솔로몬 제도
 SB|kr|*aa
 SB|ks|سولامان جٔزیٖرٕ
-SB|ku|Giravên Salomon
+SB|ku|Giravên Solomonê
 SB|kv|*aa
 SB|kw|*aa
 SB|ky|*kk
@@ -36394,7 +36394,7 @@ SB|lu|Lutanda lua Solomu
 SB|lv|Zālamana salas
 SB|mg|Nosy Salomona
 SB|mh|*aa
-SB|mi|*aa
+SB|mi|Ngā Motu Horomona
 SB|mk|Соломонски Острови
 SB|ml|സോളമൻ ദ്വീപുകൾ
 SB|mn|Соломоны арлууд
@@ -36416,7 +36416,7 @@ SB|nv|*aa
 SB|ny|*aa
 SB|oc|*aa
 SB|oj|*aa
-SB|om|*aa
+SB|om|Odoloota Solomoon
 SB|or|ସୋଲୋମନ୍‌ ଦ୍ୱୀପପୁଞ୍ଜ
 SB|os|*aa
 SB|pa|ਸੋਲੋਮਨ ਟਾਪੂ
@@ -36428,10 +36428,10 @@ SB|qu|*es
 SB|rm|Inslas Salomonas
 SB|rn|Amazinga ya Salumoni
 SB|ro|*mo
-SB|ru|Соломоновы Острова
+SB|ru|Соломоновы о-ва
 SB|rw|*aa
 SB|sa|*aa
-SB|sc|*aa
+SB|sc|Ìsulas Salomone
 SB|sd|سولومون ٻيٽَ
 SB|se|Salomon-sullot
 SB|sg|Zûâ Salomöon
@@ -36452,7 +36452,7 @@ SB|ta|சாலமன் தீவுகள்
 SB|te|సోలమన్ దీవులు
 SB|tg|Ҷазираҳои Соломон
 SB|th|หมู่เกาะโซโลมอน
-SB|ti|*am
+SB|ti|ደሴታት ሰሎሞን
 SB|tk|Solomon adalary
 SB|tl|*aa
 SB|tn|*aa
@@ -36471,7 +36471,7 @@ SB|vi|Quần đảo Solomon
 SB|vo|*aa
 SB|wa|*aa
 SB|wo|Duni Salmoon
-SB|xh|*aa
+SB|xh|ESolomon Islands
 SB|yi|*ji
 SB|yo|Etikun Solomoni
 SB|za|*aa
@@ -36506,7 +36506,7 @@ SC|co|*aa
 SC|cr|*aa
 SC|cs|Seychely
 SC|cu|*aa
-SC|cv|*aa
+SC|cv|Сейшел утравӗсем
 SC|cy|*aa
 SC|da|Seychellerne
 SC|de|Seychellen
@@ -36582,7 +36582,7 @@ SC|lu|Seshele
 SC|lv|Seišelu salas
 SC|mg|Seyshela
 SC|mh|*aa
-SC|mi|*aa
+SC|mi|Heikere
 SC|mk|Сејшели
 SC|ml|സീഷെൽസ്
 SC|mn|Сейшелийн арлууд
@@ -36604,7 +36604,7 @@ SC|nv|*aa
 SC|ny|*aa
 SC|oc|*aa
 SC|oj|*aa
-SC|om|*aa
+SC|om|Siisheels
 SC|or|ସେଚେଲସ୍
 SC|os|*aa
 SC|pa|ਸੇਸ਼ਲਸ
@@ -36616,7 +36616,7 @@ SC|qu|*aa
 SC|rm|Seychellas
 SC|rn|Amazinga ya Seyisheli
 SC|ro|*aa
-SC|ru|Сейшельские Острова
+SC|ru|Сейшельские о-ва
 SC|rw|*aa
 SC|sa|*aa
 SC|sc|*aa
@@ -36640,7 +36640,7 @@ SC|ta|சீஷெல்ஸ்
 SC|te|సీషెల్స్
 SC|tg|Сейшел
 SC|th|เซเชลส์
-SC|ti|*am
+SC|ti|ሲሸልስ
 SC|tk|Seýşel adalary
 SC|tl|*aa
 SC|tn|*aa
@@ -36659,7 +36659,7 @@ SC|vi|*aa
 SC|vo|*aa
 SC|wa|*aa
 SC|wo|*ff
-SC|xh|*aa
+SC|xh|ESeychelles
 SC|yi|*ji
 SC|yo|Ṣeṣẹlẹsi
 SC|za|*aa
@@ -36694,7 +36694,7 @@ SD|co|*aa
 SD|cr|*aa
 SD|cs|Súdán
 SD|cu|*aa
-SD|cv|*aa
+SD|cv|*be
 SD|cy|Swdan
 SD|da|*aa
 SD|de|*aa
@@ -36714,9 +36714,9 @@ SD|fj|*aa
 SD|fo|*aa
 SD|fr|*br
 SD|fy|*af
-SD|ga|an tSúdáin
+SD|ga|An tSúdáin
 SD|gd|Sudàn
-SD|gl|O Sudán
+SD|gl|*es
 SD|gn|*aa
 SD|gu|સુદાન
 SD|gv|*aa
@@ -36725,7 +36725,7 @@ SD|he|סודן
 SD|hi|सूडान
 SD|ho|*aa
 SD|hr|*aa
-SD|ht|*aa
+SD|ht|*br
 SD|hu|Szudán
 SD|hy|Սուդան
 SD|hz|*aa
@@ -36770,7 +36770,7 @@ SD|lu|Suda
 SD|lv|Sudāna
 SD|mg|Sodan
 SD|mh|*aa
-SD|mi|*aa
+SD|mi|Hūtāne
 SD|mk|*be
 SD|ml|സുഡാൻ
 SD|mn|*be
@@ -36792,7 +36792,7 @@ SD|nv|*aa
 SD|ny|*aa
 SD|oc|*aa
 SD|oj|*aa
-SD|om|*aa
+SD|om|*et
 SD|or|ସୁଦାନ
 SD|os|*aa
 SD|pa|ਸੂਡਾਨ
@@ -36807,7 +36807,7 @@ SD|ro|*aa
 SD|ru|*be
 SD|rw|*aa
 SD|sa|*aa
-SD|sc|*aa
+SD|sc|*gd
 SD|sd|سوڊان
 SD|se|Davvisudan
 SD|sg|Sudäan
@@ -36847,7 +36847,7 @@ SD|vi|*aa
 SD|vo|*aa
 SD|wa|*aa
 SD|wo|*bm
-SD|xh|*aa
+SD|xh|ESudan
 SD|yi|*ji
 SD|yo|*ki
 SD|za|*aa
@@ -36882,7 +36882,7 @@ SE|co|*aa
 SE|cr|*aa
 SE|cs|Švédsko
 SE|cu|*aa
-SE|cv|*aa
+SE|cv|*ce
 SE|cy|*aa
 SE|da|Sverige
 SE|de|Schweden
@@ -36913,13 +36913,13 @@ SE|he|שוודיה
 SE|hi|स्वीडन
 SE|ho|*aa
 SE|hr|*bs
-SE|ht|*aa
+SE|ht|*fr
 SE|hu|Svédország
 SE|hy|Շվեդիա
 SE|hz|*aa
 SE|ia|Svedia
 SE|id|Swedia
-SE|ie|*aa
+SE|ie|*ia
 SE|ig|*aa
 SE|ii|*aa
 SE|ik|*aa
@@ -36942,7 +36942,7 @@ SE|km|ស៊ុយអែត
 SE|kn|ಸ್ವೀಡನ್
 SE|ko|스웨덴
 SE|kr|*aa
-SE|ks|سُوِڈَن
+SE|ks|سویڈن
 SE|ku|Swêd
 SE|kv|*aa
 SE|kw|*aa
@@ -36958,7 +36958,7 @@ SE|lu|Suwedi
 SE|lv|Zviedrija
 SE|mg|Soedy
 SE|mh|*aa
-SE|mi|*aa
+SE|mi|Huitene
 SE|mk|Шведска
 SE|ml|സ്വീഡൻ
 SE|mn|Швед
@@ -36980,8 +36980,8 @@ SE|nv|*aa
 SE|ny|*aa
 SE|oc|*aa
 SE|oj|*aa
-SE|om|*aa
-SE|or|ସ୍ୱେଡେନ୍
+SE|om|Siwiidin
+SE|or|ସ୍ୱିଡେନ୍‌
 SE|os|*aa
 SE|pa|ਸਵੀਡਨ
 SE|pi|*aa
@@ -36995,7 +36995,7 @@ SE|ro|*eu
 SE|ru|*bg
 SE|rw|*aa
 SE|sa|*aa
-SE|sc|*aa
+SE|sc|Isvètzia
 SE|sd|سوئيڊن
 SE|se|Ruoŧŧa
 SE|sg|Suêde
@@ -37016,7 +37016,7 @@ SE|ta|ஸ்வீடன்
 SE|te|స్వీడన్
 SE|tg|Шветсия
 SE|th|สวีเดน
-SE|ti|*am
+SE|ti|ሽወደን
 SE|tk|Şwesiýa
 SE|tl|*aa
 SE|tn|*aa
@@ -37028,14 +37028,14 @@ SE|tw|*aa
 SE|ty|*aa
 SE|ug|شىۋېتسىيە
 SE|uk|Швеція
-SE|ur|سویڈن
+SE|ur|*ks
 SE|uz|Shvetsiya
 SE|ve|*aa
 SE|vi|Thụy Điển
 SE|vo|*aa
 SE|wa|*aa
 SE|wo|Suwed
-SE|xh|*aa
+SE|xh|ESweden
 SE|yi|*ji
 SE|yo|Swidini
 SE|za|*aa
@@ -37070,7 +37070,7 @@ SG|co|*aa
 SG|cr|*aa
 SG|cs|*bs
 SG|cu|*aa
-SG|cv|*aa
+SG|cv|*bg
 SG|cy|*aa
 SG|da|*aa
 SG|de|*bs
@@ -37101,11 +37101,11 @@ SG|he|סינגפור
 SG|hi|सिंगापुर
 SG|ho|*aa
 SG|hr|*bs
-SG|ht|*aa
+SG|ht|*br
 SG|hu|Szingapúr
 SG|hy|Սինգապուր
 SG|hz|*aa
-SG|ia|*aa
+SG|ia|*bs
 SG|id|Singapura
 SG|ie|*aa
 SG|ig|*aa
@@ -37131,7 +37131,7 @@ SG|kn|ಸಿಂಗಪುರ್
 SG|ko|싱가포르
 SG|kr|*aa
 SG|ks|سِنگاپوٗر
-SG|ku|Singapûr
+SG|ku|Sîngapûr
 SG|kv|*aa
 SG|kw|*aa
 SG|ky|*bg
@@ -37146,7 +37146,7 @@ SG|lu|Singapure
 SG|lv|Singapūra
 SG|mg|Singaporo
 SG|mh|*aa
-SG|mi|*aa
+SG|mi|Hingapoa
 SG|mk|*bg
 SG|ml|സിംഗപ്പൂർ
 SG|mn|*bg
@@ -37168,7 +37168,7 @@ SG|nv|*aa
 SG|ny|*aa
 SG|oc|*aa
 SG|oj|*aa
-SG|om|*aa
+SG|om|Singaapoor
 SG|or|ସିଙ୍ଗାପୁର୍
 SG|os|*aa
 SG|pa|ਸਿੰਗਾਪੁਰ
@@ -37223,7 +37223,7 @@ SG|vi|*aa
 SG|vo|*aa
 SG|wa|*aa
 SG|wo|Singapuur
-SG|xh|*aa
+SG|xh|ESingapore
 SG|yi|*ji
 SG|yo|Singapo
 SG|za|*aa
@@ -37251,14 +37251,14 @@ SH|bn|সেন্ট হেলেনা
 SH|bo|*aa
 SH|br|Saint-Helena
 SH|bs|Sveta Helena
-SH|ca|*ak
+SH|ca|Santa Helena
 SH|ce|Сийлахьчу Еленин гӀайре
 SH|ch|*aa
 SH|co|*aa
 SH|cr|*aa
 SH|cs|Svatá Helena
 SH|cu|*aa
-SH|cv|*aa
+SH|cv|Сӑваплӑ Елена утравӗ
 SH|cy|*ak
 SH|da|*aa
 SH|de|*aa
@@ -37267,10 +37267,10 @@ SH|dz|སེནཊ་ ཧེ་ལི་ན
 SH|ee|Saint Helena nutome
 SH|el|Αγία Ελένη
 SH|en|*aa
-SH|eo|Sent-Heleno
+SH|eo|Sankta Heleno
 SH|es|Santa Elena
 SH|et|*ak
-SH|eu|Santa Helena
+SH|eu|*ca
 SH|fa|سنت هلن
 SH|ff|Sent Helen
 SH|fi|*ak
@@ -37280,7 +37280,7 @@ SH|fr|Sainte-Hélène
 SH|fy|Sint-Helena
 SH|ga|San Héilin
 SH|gd|Eilean Naomh Eilidh
-SH|gl|*eu
+SH|gl|*ca
 SH|gn|*aa
 SH|gu|સેંટ હેલેના
 SH|gv|*aa
@@ -37289,11 +37289,11 @@ SH|he|סנט הלנה
 SH|hi|सेंट हेलेना
 SH|ho|*aa
 SH|hr|*bs
-SH|ht|*aa
+SH|ht|*fr
 SH|hu|Szent Ilona
 SH|hy|Սուրբ Հեղինեի կղզի
 SH|hz|*aa
-SH|ia|*aa
+SH|ia|Sancte Helena
 SH|id|*ak
 SH|ie|*aa
 SH|ig|*aa
@@ -37319,7 +37319,7 @@ SH|kn|ಸೇಂಟ್ ಹೆಲೆನಾ
 SH|ko|세인트헬레나
 SH|kr|*aa
 SH|ks|سینٹ ہؠلِنا
-SH|ku|*aa
+SH|ku|*ak
 SH|kv|*aa
 SH|kw|*aa
 SH|ky|Ыйык Елена
@@ -37334,7 +37334,7 @@ SH|lu|Santu eleni
 SH|lv|Sv.Helēnas sala
 SH|mg|*fr
 SH|mh|*aa
-SH|mi|*aa
+SH|mi|Hato Hērena
 SH|mk|*bg
 SH|ml|സെന്റ് ഹെലീന
 SH|mn|Сент Хелена
@@ -37356,14 +37356,14 @@ SH|nv|*aa
 SH|ny|*aa
 SH|oc|*aa
 SH|oj|*aa
-SH|om|*aa
+SH|om|St. Helenaa
 SH|or|ସେଣ୍ଟ ହେଲେନା
 SH|os|*aa
 SH|pa|ਸੇਂਟ ਹੇਲੇਨਾ
 SH|pi|*aa
 SH|pl|Wyspa Świętej Heleny
 SH|ps|سینټ هیلینا
-SH|pt|*eu
+SH|pt|*ca
 SH|qu|*es
 SH|rm|Sontg’Elena
 SH|rn|Sehelene
@@ -37371,7 +37371,7 @@ SH|ro|*mo
 SH|ru|о-в Св. Елены
 SH|rw|*aa
 SH|sa|*aa
-SH|sc|*aa
+SH|sc|Santa Elene
 SH|sd|سينٽ ھيلينا
 SH|se|*ak
 SH|sg|Sênt-Helêna
@@ -37392,14 +37392,14 @@ SH|ta|செயின்ட் ஹெலெனா
 SH|te|సెయింట్ హెలెనా
 SH|tg|Сент Елена
 SH|th|เซนต์เฮเลนา
-SH|ti|*am
+SH|ti|ቅድስቲ ሄለና
 SH|tk|Keramatly Ýelena adasy
 SH|tl|*aa
 SH|tn|*aa
 SH|to|Sā Helena
 SH|tr|*ak
 SH|ts|*aa
-SH|tt|*aa
+SH|tt|Изге Елена утравы
 SH|tw|*aa
 SH|ty|*aa
 SH|ug|ساينىت ھېلېنا
@@ -37411,7 +37411,7 @@ SH|vi|*aa
 SH|vo|*aa
 SH|wa|*aa
 SH|wo|Saŋ Eleen
-SH|xh|*aa
+SH|xh|ESt. Helena
 SH|yi|*ji
 SH|yo|Hẹlena
 SH|za|*aa
@@ -37446,7 +37446,7 @@ SI|co|*aa
 SI|cr|*aa
 SI|cs|Slovinsko
 SI|cu|*aa
-SI|cv|*aa
+SI|cv|*ce
 SI|cy|Slofenia
 SI|da|Slovenien
 SI|de|Slowenien
@@ -37477,7 +37477,7 @@ SI|he|סלובניה
 SI|hi|स्लोवेनिया
 SI|ho|*aa
 SI|hr|*bs
-SI|ht|*aa
+SI|ht|*fr
 SI|hu|Szlovénia
 SI|hy|Սլովենիա
 SI|hz|*aa
@@ -37522,7 +37522,7 @@ SI|lu|*ln
 SI|lv|Slovēnija
 SI|mg|*aa
 SI|mh|*aa
-SI|mi|*aa
+SI|mi|Horowinia
 SI|mk|Словенија
 SI|ml|സ്ലോവേനിയ
 SI|mn|*ce
@@ -37544,7 +37544,7 @@ SI|nv|*aa
 SI|ny|*aa
 SI|oc|*aa
 SI|oj|*aa
-SI|om|*aa
+SI|om|Islooveeniyaa
 SI|or|ସ୍ଲୋଭେନିଆ
 SI|os|*aa
 SI|pa|ਸਲੋਵੇਨੀਆ
@@ -37559,7 +37559,7 @@ SI|ro|*aa
 SI|ru|*bg
 SI|rw|*aa
 SI|sa|*aa
-SI|sc|*aa
+SI|sc|Islovènia
 SI|sd|سلوینیا
 SI|se|*aa
 SI|sg|Solovenïi
@@ -37580,7 +37580,7 @@ SI|ta|ஸ்லோவேனியா
 SI|te|స్లోవేనియా
 SI|tg|*bg
 SI|th|สโลวีเนีย
-SI|ti|*am
+SI|ti|ስሎቬንያ
 SI|tk|Sloweniýa
 SI|tl|*aa
 SI|tn|*aa
@@ -37599,7 +37599,7 @@ SI|vi|*aa
 SI|vo|*aa
 SI|wa|*aa
 SI|wo|Esloweni
-SI|xh|*aa
+SI|xh|ESlovenia
 SI|yi|*ji
 SI|yo|Silofania
 SI|za|*aa
@@ -37609,7 +37609,7 @@ SJ|aa|Svalbard & Jan Mayen
 SJ|ab|*aa
 SJ|ae|*aa
 SJ|af|Spitsbergen en Jan Mayen
-SJ|ak|*aa
+SJ|ak|Svalbard ne Jan Mayen
 SJ|am|ስቫልባርድ እና ጃን ማየን
 SJ|an|*aa
 SJ|ar|سفالبارد وجان ماين
@@ -37626,15 +37626,15 @@ SJ|bm|*aa
 SJ|bn|স্বালবার্ড ও জান মেয়েন
 SJ|bo|*aa
 SJ|br|Svalbard
-SJ|bs|Svalbard i Jan Majen
-SJ|ca|Svalbard i Jan Mayen
+SJ|bs|Svalbard i Jan Mayen
+SJ|ca|*bs
 SJ|ce|Шпицберген а, Ян-Майен а
 SJ|ch|*aa
 SJ|co|*aa
 SJ|cr|*aa
 SJ|cs|Špicberky a Jan Mayen
 SJ|cu|*aa
-SJ|cv|*aa
+SJ|cv|Шпицберген тата Ян-Майен
 SJ|cy|Svalbard a Jan Mayen
 SJ|da|Svalbard og Jan Mayen
 SJ|de|Spitzbergen und Jan Mayen
@@ -37643,13 +37643,13 @@ SJ|dz|སྭཱལ་བྷརྡ་ ཨེནཌ་ ཇཱན་མ་ཡེན
 SJ|ee|Svalbard kple Yan Mayen nutome
 SJ|el|Σβάλμπαρντ και Γιαν Μαγιέν
 SJ|en|*aa
-SJ|eo|Svalbardo kaj Jan-Majen-insulo
+SJ|eo|Svalbardo kaj Janmajeno
 SJ|es|Svalbard y Jan Mayen
 SJ|et|Svalbard ja Jan Mayen
 SJ|eu|Svalbard eta Jan Mayen uharteak
 SJ|fa|سوالبارد و یان ماین
 SJ|ff|*aa
-SJ|fi|*et
+SJ|fi|Huippuvuoret ja Jan Mayen
 SJ|fj|*aa
 SJ|fo|*aa
 SJ|fr|Svalbard et Jan Mayen
@@ -37664,8 +37664,8 @@ SJ|ha|Svalbard da Jan Mayen
 SJ|he|סבאלברד ויאן מאיין
 SJ|hi|स्वालबार्ड और जान मायेन
 SJ|ho|*aa
-SJ|hr|*ca
-SJ|ht|*aa
+SJ|hr|*bs
+SJ|ht|*fr
 SJ|hu|Svalbard és Jan Mayen
 SJ|hy|Սվալբարդ և Յան Մայեն
 SJ|hz|*aa
@@ -37695,7 +37695,7 @@ SJ|kn|ಸ್ವಾಲ್ಬಾರ್ಡ್ ಮತ್ತು ಜಾನ್ ಮೆ�
 SJ|ko|스발바르제도-얀마웬섬
 SJ|kr|*aa
 SJ|ks|سَوالبریڑ تہٕ جان ماییڑ
-SJ|ku|*aa
+SJ|ku|Svalbard û Jan Mayen
 SJ|kv|*aa
 SJ|kw|*aa
 SJ|ky|Шпицберген жана Ян-Майен
@@ -37710,7 +37710,7 @@ SJ|lu|*aa
 SJ|lv|Svalbāra un Jana Majena sala
 SJ|mg|*aa
 SJ|mh|*aa
-SJ|mi|*aa
+SJ|mi|Heopara me Iana Maiana
 SJ|mk|Свалбард и Јан Мајен
 SJ|ml|സ്വാൽബാഡും ജാൻ മായേനും
 SJ|mn|Свалбард ба Ян Майен
@@ -37732,12 +37732,12 @@ SJ|nv|*aa
 SJ|ny|*aa
 SJ|oc|*aa
 SJ|oj|*aa
-SJ|om|*aa
+SJ|om|Isvaalbaard fi Jan Mayeen
 SJ|or|ସାଲବାର୍ଡ ଏବଂ ଜାନ୍‌ ମାୟେନ୍‌
 SJ|os|*aa
 SJ|pa|ਸਵਾਲਬਰਡ ਅਤੇ ਜਾਨ ਮਾਯੇਨ
 SJ|pi|*aa
-SJ|pl|*ca
+SJ|pl|*bs
 SJ|ps|سوالبارد او جان ميين
 SJ|pt|*gl
 SJ|qu|*es
@@ -37747,7 +37747,7 @@ SJ|ro|*mo
 SJ|ru|Шпицберген и Ян-Майен
 SJ|rw|*aa
 SJ|sa|*aa
-SJ|sc|*aa
+SJ|sc|*gl
 SJ|sd|سوالبارڊ ۽ جان ماین
 SJ|se|Svalbárda ja Jan Mayen
 SJ|sg|*aa
@@ -37787,9 +37787,9 @@ SJ|vi|Svalbard và Jan Mayen
 SJ|vo|*aa
 SJ|wa|*aa
 SJ|wo|Swalbaar ak Jan Mayen
-SJ|xh|*aa
+SJ|xh|ESvalbard & Jan Mayen
 SJ|yi|*aa
-SJ|yo|*aa
+SJ|yo|Sífábáàdì àti Jánì Máyẹ̀nì
 SJ|za|*aa
 SJ|zh|斯瓦尔巴和扬马延
 SJ|zu|i-Svalbard ne-Jan Mayen
@@ -37822,7 +37822,7 @@ SK|co|*aa
 SK|cr|*aa
 SK|cs|Slovensko
 SK|cu|*aa
-SK|cv|*aa
+SK|cv|*ce
 SK|cy|Slofacia
 SK|da|Slovakiet
 SK|de|Slowakei
@@ -37853,7 +37853,7 @@ SK|he|סלובקיה
 SK|hi|स्लोवाकिया
 SK|ho|*aa
 SK|hr|*bs
-SK|ht|*aa
+SK|ht|*fr
 SK|hu|Szlovákia
 SK|hy|Սլովակիա
 SK|hz|*aa
@@ -37898,7 +37898,7 @@ SK|lu|*ln
 SK|lv|Slovākija
 SK|mg|*aa
 SK|mh|*aa
-SK|mi|*aa
+SK|mi|Horowākia
 SK|mk|Словачка
 SK|ml|സ്ലോവാക്യ
 SK|mn|Словак
@@ -37920,7 +37920,7 @@ SK|nv|*aa
 SK|ny|*aa
 SK|oc|*aa
 SK|oj|*aa
-SK|om|*aa
+SK|om|Isloovaakiyaa
 SK|or|ସ୍ଲୋଭାକିଆ
 SK|os|*aa
 SK|pa|ਸਲੋਵਾਕੀਆ
@@ -37935,7 +37935,7 @@ SK|ro|*mo
 SK|ru|*bg
 SK|rw|*aa
 SK|sa|*aa
-SK|sc|*aa
+SK|sc|Islovàchia
 SK|sd|سلوواڪيا
 SK|se|Slovákia
 SK|sg|Solovakïi
@@ -37956,7 +37956,7 @@ SK|ta|ஸ்லோவாகியா
 SK|te|స్లొవేకియా
 SK|tg|*bg
 SK|th|สโลวะเกีย
-SK|ti|*am
+SK|ti|ስሎቫክያ
 SK|tk|Slowakiýa
 SK|tl|*aa
 SK|tn|*aa
@@ -37975,7 +37975,7 @@ SK|vi|*aa
 SK|vo|*aa
 SK|wa|*aa
 SK|wo|Eslowaki
-SK|xh|*aa
+SK|xh|ESlovakia
 SK|yi|*ji
 SK|yo|Silofakia
 SK|za|*aa
@@ -37985,7 +37985,7 @@ SL|aa|Sierra Leone
 SL|ab|*aa
 SL|ae|*aa
 SL|af|*aa
-SL|ak|*aa
+SL|ak|Sɛra Liɔn
 SL|am|ሴራሊዮን
 SL|an|*aa
 SL|ar|سيراليون
@@ -38010,7 +38010,7 @@ SL|co|*aa
 SL|cr|*aa
 SL|cs|*aa
 SL|cu|*aa
-SL|cv|*aa
+SL|cv|Сьерра-Леоне
 SL|cy|*aa
 SL|da|*aa
 SL|de|*aa
@@ -38019,7 +38019,7 @@ SL|dz|སི་ར་ ལི་འོན
 SL|ee|Sierra Leone nutome
 SL|el|Σιέρα Λεόνε
 SL|en|*aa
-SL|eo|Siera-Leono
+SL|eo|Sieraleono
 SL|es|Sierra Leona
 SL|et|*aa
 SL|eu|*es
@@ -38037,7 +38037,7 @@ SL|gn|*aa
 SL|gu|સીએરા લેઓન
 SL|gv|*aa
 SL|ha|Salewo
-SL|he|סיירה לאונה
+SL|he|סיירה לאון
 SL|hi|सिएरा लियोन
 SL|ho|*aa
 SL|hr|*bs
@@ -38064,17 +38064,17 @@ SL|ka|სიერა-ლეონე
 SL|kg|*aa
 SL|ki|Siera Leoni
 SL|kj|*aa
-SL|kk|Сьерра-Леоне
+SL|kk|*cv
 SL|kl|*aa
 SL|km|សៀរ៉ាឡេអូន
 SL|kn|ಸಿಯೆರ್ರಾ ಲಿಯೋನ್
 SL|ko|시에라리온
 SL|kr|*aa
-SL|ks|سیٖرالیوون
+SL|ks|سیرا لیون
 SL|ku|*aa
 SL|kv|*aa
 SL|kw|*aa
-SL|ky|*kk
+SL|ky|*cv
 SL|la|*aa
 SL|lb|*aa
 SL|lg|Siyeralewone
@@ -38086,10 +38086,10 @@ SL|lu|Siera Leone
 SL|lv|Sjerraleone
 SL|mg|*aa
 SL|mh|*aa
-SL|mi|*aa
+SL|mi|Te Araone
 SL|mk|*bg
 SL|ml|സിയെറ ലിയോൺ
-SL|mn|*kk
+SL|mn|*cv
 SL|mo|*aa
 SL|mr|सिएरा लिओन
 SL|ms|*aa
@@ -38108,7 +38108,7 @@ SL|nv|*aa
 SL|ny|*aa
 SL|oc|*aa
 SL|oj|*aa
-SL|om|*aa
+SL|om|Seeraaliyoon
 SL|or|ସିଏରା ଲିଓନ
 SL|os|*aa
 SL|pa|ਸਿਏਰਾ ਲਿਓਨ
@@ -38120,7 +38120,7 @@ SL|qu|*es
 SL|rm|*aa
 SL|rn|*lg
 SL|ro|*aa
-SL|ru|*kk
+SL|ru|*cv
 SL|rw|*aa
 SL|sa|*aa
 SL|sc|*aa
@@ -38144,14 +38144,14 @@ SL|ta|சியாரா லியோன்
 SL|te|సియెర్రా లియాన్
 SL|tg|Сиерра-Леоне
 SL|th|เซียร์ราลีโอน
-SL|ti|*am
+SL|ti|ሴራ ልዮን
 SL|tk|Sýerra-Leone
 SL|tl|*aa
 SL|tn|*aa
 SL|to|Siela Leone
 SL|tr|*aa
 SL|ts|*aa
-SL|tt|*kk
+SL|tt|*cv
 SL|tw|*aa
 SL|ty|*aa
 SL|ug|سېررالېئون
@@ -38163,7 +38163,7 @@ SL|vi|*aa
 SL|vo|*aa
 SL|wa|*aa
 SL|wo|Siyera Lewon
-SL|xh|*aa
+SL|xh|ESierra Leone
 SL|yi|*ji
 SL|yo|Siria looni
 SL|za|*aa
@@ -38198,7 +38198,7 @@ SM|co|*aa
 SM|cr|*aa
 SM|cs|*aa
 SM|cu|*aa
-SM|cv|*aa
+SM|cv|*ce
 SM|cy|*aa
 SM|da|*aa
 SM|de|*aa
@@ -38207,7 +38207,7 @@ SM|dz|སཱན་མ་རི་ནོ
 SM|ee|San Marino nutome
 SM|el|Άγιος Μαρίνος
 SM|en|*aa
-SM|eo|*az
+SM|eo|Sanmarino
 SM|es|*aa
 SM|et|*aa
 SM|eu|*aa
@@ -38229,13 +38229,13 @@ SM|he|סן מרינו
 SM|hi|सैन मेरीनो
 SM|ho|*aa
 SM|hr|*aa
-SM|ht|*aa
+SM|ht|*fr
 SM|hu|*aa
 SM|hy|Սան Մարինո
 SM|hz|*aa
 SM|ia|*aa
 SM|id|*aa
-SM|ie|*aa
+SM|ie|*az
 SM|ig|*aa
 SM|ii|*aa
 SM|ik|*aa
@@ -38274,7 +38274,7 @@ SM|lu|Santu Marine
 SM|lv|Sanmarīno
 SM|mg|*fr
 SM|mh|*aa
-SM|mi|*aa
+SM|mi|Hana Marino
 SM|mk|*bg
 SM|ml|സാൻ മറിനോ
 SM|mn|*ce
@@ -38296,7 +38296,7 @@ SM|nv|*aa
 SM|ny|*aa
 SM|oc|*aa
 SM|oj|*aa
-SM|om|*aa
+SM|om|Saan Mariinoo
 SM|or|ସାନ୍ ମାରିନୋ
 SM|os|*aa
 SM|pa|ਸੈਨ ਮਰੀਨੋ
@@ -38311,7 +38311,7 @@ SM|ro|*aa
 SM|ru|*ce
 SM|rw|*aa
 SM|sa|*aa
-SM|sc|*aa
+SM|sc|Santu Marinu
 SM|sd|سین مرینو
 SM|se|*aa
 SM|sg|Sên-Marëen
@@ -38351,7 +38351,7 @@ SM|vi|*aa
 SM|vo|*aa
 SM|wa|*aa
 SM|wo|*aa
-SM|xh|*aa
+SM|xh|ESan Marino
 SM|yi|*ji
 SM|yo|Sani Marino
 SM|za|*aa
@@ -38386,7 +38386,7 @@ SN|co|*aa
 SN|cr|*aa
 SN|cs|*aa
 SN|cu|*aa
-SN|cv|*aa
+SN|cv|*be
 SN|cy|*aa
 SN|da|*aa
 SN|de|*aa
@@ -38406,7 +38406,7 @@ SN|fj|*aa
 SN|fo|*aa
 SN|fr|Sénégal
 SN|fy|*aa
-SN|ga|an tSeineagáil
+SN|ga|An tSeineagáil
 SN|gd|Seanagal
 SN|gl|*aa
 SN|gn|*aa
@@ -38417,7 +38417,7 @@ SN|he|סנגל
 SN|hi|सेनेगल
 SN|ho|*aa
 SN|hr|*aa
-SN|ht|*aa
+SN|ht|*fr
 SN|hu|Szenegál
 SN|hy|Սենեգալ
 SN|hz|*aa
@@ -38462,7 +38462,7 @@ SN|lu|Senegale
 SN|lv|Senegāla
 SN|mg|*aa
 SN|mh|*aa
-SN|mi|*aa
+SN|mi|Henekara
 SN|mk|*be
 SN|ml|സെനഗൽ
 SN|mn|*be
@@ -38484,7 +38484,7 @@ SN|nv|*aa
 SN|ny|*aa
 SN|oc|*aa
 SN|oj|*aa
-SN|om|*aa
+SN|om|*ff
 SN|or|ସେନେଗାଲ୍
 SN|os|*aa
 SN|pa|ਸੇਨੇਗਲ
@@ -38520,7 +38520,7 @@ SN|ta|செனெகல்
 SN|te|సెనెగల్
 SN|tg|*be
 SN|th|เซเนกัล
-SN|ti|*am
+SN|ti|ሰነጋል
 SN|tk|*aa
 SN|tl|*aa
 SN|tn|*aa
@@ -38539,7 +38539,7 @@ SN|vi|*aa
 SN|vo|*aa
 SN|wa|*aa
 SN|wo|*ff
-SN|xh|*aa
+SN|xh|ESenegal
 SN|yi|*ji
 SN|yo|Sẹnẹga
 SN|za|*aa
@@ -38550,7 +38550,7 @@ SO|ab|*aa
 SO|ae|*aa
 SO|af|Somalië
 SO|ak|*aa
-SO|am|ሱማሌ
+SO|am|ሶማሊያ
 SO|an|*aa
 SO|ar|الصومال
 SO|as|চোমালিয়া
@@ -38574,7 +38574,7 @@ SO|co|*aa
 SO|cr|*aa
 SO|cs|Somálsko
 SO|cu|*aa
-SO|cv|*aa
+SO|cv|*ce
 SO|cy|*aa
 SO|da|*aa
 SO|de|*aa
@@ -38605,7 +38605,7 @@ SO|he|סומליה
 SO|hi|सोमालिया
 SO|ho|*aa
 SO|hr|*bs
-SO|ht|*aa
+SO|ht|*fr
 SO|hu|Szomália
 SO|hy|Սոմալի
 SO|hz|*aa
@@ -38650,7 +38650,7 @@ SO|lu|*az
 SO|lv|Somālija
 SO|mg|*aa
 SO|mh|*aa
-SO|mi|*aa
+SO|mi|Hūmārie
 SO|mk|Сомалија
 SO|ml|സോമാലിയ
 SO|mn|*ce
@@ -38672,7 +38672,7 @@ SO|nv|*aa
 SO|ny|*aa
 SO|oc|*aa
 SO|oj|*aa
-SO|om|*aa
+SO|om|Somaaliyaa
 SO|or|ସୋମାଲିଆ
 SO|os|*aa
 SO|pa|ਸੋਮਾਲੀਆ
@@ -38687,7 +38687,7 @@ SO|ro|*aa
 SO|ru|*ce
 SO|rw|*aa
 SO|sa|*aa
-SO|sc|*aa
+SO|sc|*ca
 SO|sd|سوماليا
 SO|se|*pt
 SO|sg|Somalïi
@@ -38708,7 +38708,7 @@ SO|ta|சோமாலியா
 SO|te|సోమాలియా
 SO|tg|Сомалӣ
 SO|th|โซมาเลีย
-SO|ti|*am
+SO|ti|ሶማልያ
 SO|tk|*az
 SO|tl|*aa
 SO|tn|*aa
@@ -38727,7 +38727,7 @@ SO|vi|*aa
 SO|vo|*aa
 SO|wa|*aa
 SO|wo|*az
-SO|xh|*aa
+SO|xh|ESomalia
 SO|yi|*ji
 SO|yo|*aa
 SO|za|*aa
@@ -38762,7 +38762,7 @@ SR|co|*aa
 SR|cr|*aa
 SR|cs|*az
 SR|cu|*aa
-SR|cv|*aa
+SR|cv|*bg
 SR|cy|*aa
 SR|da|*az
 SR|de|*aa
@@ -38823,7 +38823,7 @@ SR|kn|ಸುರಿನಾಮ್
 SR|ko|수리남
 SR|kr|*aa
 SR|ks|سُرِنام
-SR|ku|Sûrînam
+SR|ku|Surînam
 SR|kv|*aa
 SR|kw|*aa
 SR|ky|*bg
@@ -38838,7 +38838,7 @@ SR|lu|*aa
 SR|lv|Surinama
 SR|mg|Sorinam
 SR|mh|*aa
-SR|mi|*aa
+SR|mi|Huriname
 SR|mk|*bg
 SR|ml|സുരിനാം
 SR|mn|*bg
@@ -38915,7 +38915,7 @@ SR|vi|*aa
 SR|vo|*aa
 SR|wa|*aa
 SR|wo|Sirinam
-SR|xh|*aa
+SR|xh|ESuriname
 SR|yi|*ji
 SR|yo|*bm
 SR|za|*aa
@@ -38925,7 +38925,7 @@ SS|aa|South Sudan
 SS|ab|*aa
 SS|ae|*aa
 SS|af|Suid-Soedan
-SS|ak|*aa
+SS|ak|Sudan Anaafoɔ
 SS|am|ደቡብ ሱዳን
 SS|an|*aa
 SS|ar|جنوب السودان
@@ -38950,7 +38950,7 @@ SS|co|*aa
 SS|cr|*aa
 SS|cs|Jižní Súdán
 SS|cu|*aa
-SS|cv|*aa
+SS|cv|Кӑнтӑр Судан
 SS|cy|De Swdan
 SS|da|Sydsudan
 SS|de|Südsudan
@@ -38972,7 +38972,7 @@ SS|fr|Soudan du Sud
 SS|fy|Sûd-Soedan
 SS|ga|an tSúdáin Theas
 SS|gd|Sudàn a Deas
-SS|gl|O Sudán do Sur
+SS|gl|Sudán do Sur
 SS|gn|*aa
 SS|gu|દક્ષિણ સુદાન
 SS|gv|*aa
@@ -38981,7 +38981,7 @@ SS|he|דרום סודן
 SS|hi|दक्षिण सूडान
 SS|ho|*aa
 SS|hr|*bs
-SS|ht|*aa
+SS|ht|*fr
 SS|hu|Dél-Szudán
 SS|hy|Հարավային Սուդան
 SS|hz|*aa
@@ -39010,7 +39010,7 @@ SS|km|ស៊ូដង់​ខាង​ត្បូង
 SS|kn|ದಕ್ಷಿಣ ಸುಡಾನ್
 SS|ko|남수단
 SS|kr|*aa
-SS|ks|*aa
+SS|ks|جنوبی سوڈان
 SS|ku|Sûdana Başûr
 SS|kv|*aa
 SS|kw|*aa
@@ -39026,7 +39026,7 @@ SS|lu|*aa
 SS|lv|Dienvidsudāna
 SS|mg|*aa
 SS|mh|*aa
-SS|mi|*aa
+SS|mi|Hūtāne ki te Tonga
 SS|mk|Јужен Судан
 SS|ml|ദക്ഷിണ സുഡാൻ
 SS|mn|Өмнөд Судан
@@ -39048,7 +39048,7 @@ SS|nv|*aa
 SS|ny|*aa
 SS|oc|*aa
 SS|oj|*aa
-SS|om|*aa
+SS|om|Sudaan Kibbaa
 SS|or|ଦକ୍ଷିଣ ସୁଦାନ
 SS|os|*aa
 SS|pa|ਦੱਖਣ ਸੁਡਾਨ
@@ -39063,7 +39063,7 @@ SS|ro|*mo
 SS|ru|Южный Судан
 SS|rw|*aa
 SS|sa|*aa
-SS|sc|*aa
+SS|sc|Sudan de su Sud
 SS|sd|ڏکڻ سوڊان
 SS|se|Máttasudan
 SS|sg|*aa
@@ -39096,14 +39096,14 @@ SS|tw|*aa
 SS|ty|*aa
 SS|ug|جەنۇبىي سۇدان
 SS|uk|Південний Судан
-SS|ur|جنوبی سوڈان
+SS|ur|*ks
 SS|uz|Janubiy Sudan
 SS|ve|*aa
 SS|vi|Nam Sudan
 SS|vo|*aa
 SS|wa|*aa
 SS|wo|Sudaŋ di Sid
-SS|xh|*aa
+SS|xh|ESouth Sudan
 SS|yi|*ji
 SS|yo|Gúúsù Sudan
 SS|za|*aa
@@ -39113,7 +39113,7 @@ ST|aa|São Tomé & Príncipe
 ST|ab|*aa
 ST|ae|*aa
 ST|af|São Tomé en Príncipe
-ST|ak|São Tomé and Príncipe
+ST|ak|São Tomé ne Príncipe
 ST|am|ሳኦ ቶሜ እና ፕሪንሲፔ
 ST|an|*aa
 ST|ar|ساو تومي وبرينسيبي
@@ -39138,7 +39138,7 @@ ST|co|*aa
 ST|cr|*aa
 ST|cs|Svatý Tomáš a Princův ostrov
 ST|cu|*aa
-ST|cv|*aa
+ST|cv|Сан-Томе тата Принсипи
 ST|cy|São Tomé a Príncipe
 ST|da|São Tomé og Príncipe
 ST|de|São Tomé und Príncipe
@@ -39147,7 +39147,7 @@ ST|dz|སཝ་ ཊོ་མེ་ ཨེནཌ་ པྲྀན་སི་པ�
 ST|ee|São Tomé kple Príncipe nutome
 ST|el|Σάο Τομέ και Πρίνσιπε
 ST|en|*aa
-ST|eo|Sao-Tomeo kaj Principeo
+ST|eo|Santomeo kaj Principeo
 ST|es|Santo Tomé y Príncipe
 ST|et|São Tomé ja Príncipe
 ST|eu|Sao Tome eta Principe
@@ -39169,11 +39169,11 @@ ST|he|סאו טומה ופרינסיפה
 ST|hi|साओ टोम और प्रिंसिपे
 ST|ho|*aa
 ST|hr|Sveti Toma i Princip
-ST|ht|*aa
+ST|ht|*fr
 ST|hu|São Tomé és Príncipe
 ST|hy|Սան Տոմե և Փրինսիպի
 ST|hz|*aa
-ST|ia|*aa
+ST|ia|São Tomé e Príncipe
 ST|id|Sao Tome dan Principe
 ST|ie|*aa
 ST|ig|*aa
@@ -39182,7 +39182,7 @@ ST|ik|*aa
 ST|in|*id
 ST|io|*aa
 ST|is|Saó Tóme og Prinsípe
-ST|it|São Tomé e Príncipe
+ST|it|*ia
 ST|iu|*aa
 ST|iw|*he
 ST|ja|サントメ・プリンシペ
@@ -39214,8 +39214,8 @@ ST|lu|Sao Tome ne Presipɛ
 ST|lv|Santome un Prinsipi
 ST|mg|São Tomé-et-Príncipe
 ST|mh|*aa
-ST|mi|*aa
-ST|mk|Сао Томе и Принсипе
+ST|mi|Hato Tomei me Pirinipei
+ST|mk|Саун Томе и Принсип
 ST|ml|സാവോ ടോമും പ്രിൻസിപെയും
 ST|mn|Сан-Томе ба Принсипи
 ST|mo|São Tomé și Príncipe
@@ -39225,7 +39225,7 @@ ST|mt|São Tomé u Príncipe
 ST|my|ဆောင်တူမေးနှင့် ပရင်စီပီ
 ST|na|*aa
 ST|nb|*da
-ST|nd|*ak
+ST|nd|São Tomé and Príncipe
 ST|ne|साओ टोमे र प्रिन्सिप
 ST|ng|*aa
 ST|nl|*fy
@@ -39236,14 +39236,14 @@ ST|nv|*aa
 ST|ny|*aa
 ST|oc|*aa
 ST|oj|*aa
-ST|om|*aa
+ST|om|Sa’oo Toomee fi Prinsippee
 ST|or|ସାଓ ଟୋମେ ଏବଂ ପ୍ରିନସିପି
 ST|os|*aa
 ST|pa|ਸਾਓ ਟੋਮ ਅਤੇ ਪ੍ਰਿੰਸੀਪੇ
 ST|pi|*aa
 ST|pl|Wyspy Świętego Tomasza i Książęca
 ST|ps|ساو ټیم او پرنسیپ
-ST|pt|*it
+ST|pt|*ia
 ST|qu|*es
 ST|rm|*aa
 ST|rn|Sawotome na Perensipe
@@ -39251,7 +39251,7 @@ ST|ro|*mo
 ST|ru|Сан-Томе и Принсипи
 ST|rw|*aa
 ST|sa|*aa
-ST|sc|*aa
+ST|sc|*ia
 ST|sd|سائو ٽوم ۽ پرنسپیي
 ST|se|*et
 ST|sg|Sâô Tömê na Prinsîpe
@@ -39259,7 +39259,7 @@ ST|si|සාඕ තෝම් සහ ප්‍රින්සිප්
 ST|sk|Svätý Tomáš a Princov ostrov
 ST|sl|Sao Tome in Principe
 ST|sm|*aa
-ST|sn|*ak
+ST|sn|*nd
 ST|so|Sao Tome & Birincibal
 ST|sq|Sao-Tome e Principe
 ST|sr|Сао Томе и Принципе
@@ -39272,7 +39272,7 @@ ST|ta|சாவ் தோம் & ப்ரின்சிபி
 ST|te|సావో టోమ్ మరియు ప్రిన్సిపి
 ST|tg|Сан Томе ва Принсипи
 ST|th|เซาตูเมและปรินซิปี
-ST|ti|ሳኦ ቶሜን ፕሪንሲፔን
+ST|ti|ሳኦ ቶመን ፕሪንሲፐን
 ST|tk|San-Tome we Prinsipi
 ST|tl|*aa
 ST|tn|*aa
@@ -39291,7 +39291,7 @@ ST|vi|São Tomé và Príncipe
 ST|vo|*aa
 ST|wa|*aa
 ST|wo|Sawo Tome ak Pirinsipe
-ST|xh|*aa
+ST|xh|ESão Tomé & Príncipe
 ST|yi|*ji
 ST|yo|Sao tomi ati piriiṣipi
 ST|za|*aa
@@ -39326,7 +39326,7 @@ SV|co|*aa
 SV|cr|*aa
 SV|cs|*az
 SV|cu|*aa
-SV|cv|*aa
+SV|cv|*be
 SV|cy|*aa
 SV|da|*aa
 SV|de|*aa
@@ -39346,7 +39346,7 @@ SV|fj|*aa
 SV|fo|*aa
 SV|fr|*az
 SV|fy|*aa
-SV|ga|an tSalvadóir
+SV|ga|An tSalvadóir
 SV|gd|An Salbhador
 SV|gl|O Salvador
 SV|gn|*aa
@@ -39357,7 +39357,7 @@ SV|he|אל סלבדור
 SV|hi|अल सल्वाडोर
 SV|ho|*aa
 SV|hr|*az
-SV|ht|*aa
+SV|ht|*az
 SV|hu|*az
 SV|hy|Սալվադոր
 SV|hz|*aa
@@ -39386,7 +39386,7 @@ SV|km|អែលសាល់វ៉ាឌ័រ
 SV|kn|ಎಲ್ ಸಾಲ್ವೇಡಾರ್
 SV|ko|엘살바도르
 SV|kr|*aa
-SV|ks|اؠل سَلواڑور
+SV|ks|ایل سلویڈر
 SV|ku|*aa
 SV|kv|*aa
 SV|kw|*aa
@@ -39402,7 +39402,7 @@ SV|lu|Savadore
 SV|lv|Salvadora
 SV|mg|*aa
 SV|mh|*aa
-SV|mi|*aa
+SV|mi|Whakaora
 SV|mk|Ел Салвадор
 SV|ml|എൽ സാൽവദോർ
 SV|mn|Эль Сальвадор
@@ -39424,7 +39424,7 @@ SV|nv|*aa
 SV|ny|*aa
 SV|oc|*aa
 SV|oj|*aa
-SV|om|*aa
+SV|om|El Salvaadoor
 SV|or|ଏଲ୍ ସାଲଭାଡୋର୍
 SV|os|*aa
 SV|pa|ਅਲ ਸਲਵਾਡੋਰ
@@ -39479,7 +39479,7 @@ SV|vi|*aa
 SV|vo|*aa
 SV|wa|*aa
 SV|wo|El Salwadoor
-SV|xh|*aa
+SV|xh|E-El Salvador
 SV|yi|*ji
 SV|yo|Ẹẹsáfádò
 SV|za|*aa
@@ -39489,7 +39489,7 @@ SX|aa|Sint Maarten
 SX|ab|*aa
 SX|ae|*aa
 SX|af|*aa
-SX|ak|*aa
+SX|ak|Sint Maaten
 SX|am|ሲንት ማርተን
 SX|an|*aa
 SX|ar|سانت مارتن
@@ -39514,7 +39514,7 @@ SX|co|*aa
 SX|cr|*aa
 SX|cs|Svatý Martin (Nizozemsko)
 SX|cu|*aa
-SX|cv|*aa
+SX|cv|*ce
 SX|cy|*aa
 SX|da|*aa
 SX|de|*aa
@@ -39545,13 +39545,13 @@ SX|he|סנט מארטן
 SX|hi|सिंट मार्टिन
 SX|ho|*aa
 SX|hr|*aa
-SX|ht|*aa
+SX|ht|*fr
 SX|hu|*aa
 SX|hy|Սինտ Մարտեն
 SX|hz|*aa
-SX|ia|*aa
+SX|ia|Sancte Martino nederlandese
 SX|id|*aa
-SX|ie|*aa
+SX|ie|*fy
 SX|ig|*aa
 SX|ii|*aa
 SX|ik|*aa
@@ -39574,8 +39574,8 @@ SX|km|សីង​ម៉ាធីន
 SX|kn|ಸಿಂಟ್ ಮಾರ್ಟೆನ್
 SX|ko|신트마르턴
 SX|kr|*aa
-SX|ks|*aa
-SX|ku|*aa
+SX|ks|سِنٹ مارٹِن
+SX|ku|Sint Marteen
 SX|kv|*aa
 SX|kw|*aa
 SX|ky|*ce
@@ -39590,7 +39590,7 @@ SX|lu|*aa
 SX|lv|Sintmārtena
 SX|mg|*aa
 SX|mh|*aa
-SX|mi|*aa
+SX|mi|Hiti Mātene
 SX|mk|Свети Мартин
 SX|ml|സിന്റ് മാർട്ടെൻ
 SX|mn|*bg
@@ -39612,7 +39612,7 @@ SX|nv|*aa
 SX|ny|*aa
 SX|oc|*aa
 SX|oj|*aa
-SX|om|*aa
+SX|om|Siint Maarteen
 SX|or|ସିଣ୍ଟ ମାର୍ଟୀନ୍‌
 SX|os|*aa
 SX|pa|ਸਿੰਟ ਮਾਰਟੀਨ
@@ -39636,7 +39636,7 @@ SX|sk|Svätý Martin (hol.)
 SX|sl|*aa
 SX|sm|*aa
 SX|sn|*aa
-SX|so|Siint Maarteen
+SX|so|*om
 SX|sq|*az
 SX|sr|Свети Мартин (Холандија)
 SX|ss|*aa
@@ -39648,7 +39648,7 @@ SX|ta|சின்ட் மார்டென்
 SX|te|సింట్ మార్టెన్
 SX|tg|Синт-Маартен
 SX|th|ซินต์มาร์เทน
-SX|ti|ሲንት ማርቲን
+SX|ti|*am
 SX|tk|*az
 SX|tl|*aa
 SX|tn|*aa
@@ -39667,9 +39667,9 @@ SX|vi|*aa
 SX|vo|*aa
 SX|wa|*aa
 SX|wo|Sin Marten
-SX|xh|*aa
+SX|xh|ESint Maarten
 SX|yi|*aa
-SX|yo|*aa
+SX|yo|Síntì Mátẹ́ẹ̀nì
 SX|za|*aa
 SX|zh|荷属圣马丁
 SX|zu|i-Sint Maarten
@@ -39678,7 +39678,7 @@ SY|ab|*aa
 SY|ae|*aa
 SY|af|Sirië
 SY|ak|Siria
-SY|am|ሲሪያ
+SY|am|ሶሪያ
 SY|an|*aa
 SY|ar|سوريا
 SY|as|চিৰিয়া
@@ -39702,7 +39702,7 @@ SY|co|*aa
 SY|cr|*aa
 SY|cs|Sýrie
 SY|cu|*aa
-SY|cv|*aa
+SY|cv|Сири
 SY|cy|*aa
 SY|da|Syrien
 SY|de|*da
@@ -39733,7 +39733,7 @@ SY|he|סוריה
 SY|hi|सीरिया
 SY|ho|*aa
 SY|hr|*bs
-SY|ht|*aa
+SY|ht|*fr
 SY|hu|Szíria
 SY|hy|Սիրիա
 SY|hz|*aa
@@ -39763,7 +39763,7 @@ SY|kn|ಸಿರಿಯಾ
 SY|ko|시리아
 SY|kr|*aa
 SY|ks|شام
-SY|ku|Sûrî
+SY|ku|Sûrîye
 SY|kv|*aa
 SY|kw|*aa
 SY|ky|*bg
@@ -39778,10 +39778,10 @@ SY|lu|*bm
 SY|lv|Sīrija
 SY|mg|*aa
 SY|mh|*aa
-SY|mi|*aa
+SY|mi|Hiria
 SY|mk|Сирија
 SY|ml|സിറിയ
-SY|mn|Сири
+SY|mn|*cv
 SY|mo|*ak
 SY|mr|*hi
 SY|ms|*aa
@@ -39800,7 +39800,7 @@ SY|nv|*aa
 SY|ny|*aa
 SY|oc|*aa
 SY|oj|*aa
-SY|om|*aa
+SY|om|Sooriyaa
 SY|or|ସିରିଆ
 SY|os|*aa
 SY|pa|ਸੀਰੀਆ
@@ -39815,7 +39815,7 @@ SY|ro|*ak
 SY|ru|*bg
 SY|rw|*aa
 SY|sa|*aa
-SY|sc|*aa
+SY|sc|Sìria
 SY|sd|*ks
 SY|se|*aa
 SY|sg|Sirïi
@@ -39836,7 +39836,7 @@ SY|ta|சிரியா
 SY|te|సిరియా
 SY|tg|Сурия
 SY|th|ซีเรีย
-SY|ti|*am
+SY|ti|ሶርያ
 SY|tk|Siriýa
 SY|tl|*aa
 SY|tn|*aa
@@ -39855,7 +39855,7 @@ SY|vi|*aa
 SY|vo|*aa
 SY|wa|*aa
 SY|wo|*bm
-SY|xh|*aa
+SY|xh|ESiriya
 SY|yi|*ji
 SY|yo|*ak
 SY|za|*aa
@@ -39866,7 +39866,7 @@ SZ|ab|*aa
 SZ|ae|*aa
 SZ|af|*aa
 SZ|ak|Swaziland
-SZ|am|ሱዋዚላንድ
+SZ|am|ኤስዋቲኒ
 SZ|an|*aa
 SZ|ar|إسواتيني
 SZ|as|ইচ্চুটিনি
@@ -39883,14 +39883,14 @@ SZ|bn|ইসওয়াতিনি
 SZ|bo|*aa
 SZ|br|*aa
 SZ|bs|*az
-SZ|ca|eSwatini
+SZ|ca|*aa
 SZ|ce|Свазиленд
 SZ|ch|*aa
 SZ|co|*aa
 SZ|cr|*aa
 SZ|cs|*aa
 SZ|cu|*aa
-SZ|cv|*aa
+SZ|cv|Эсватини
 SZ|cy|*aa
 SZ|da|*aa
 SZ|de|*aa
@@ -39911,30 +39911,30 @@ SZ|fo|*az
 SZ|fr|*aa
 SZ|fy|Swazilân
 SZ|ga|eSuaitíní
-SZ|gd|*ca
+SZ|gd|eSwatini
 SZ|gl|*aa
 SZ|gn|*aa
 SZ|gu|એસ્વાટીની
 SZ|gv|*aa
 SZ|ha|*aa
 SZ|he|אסוואטיני
-SZ|hi|स्वाज़ीलैंड
+SZ|hi|एस्वाटिनी
 SZ|ho|*aa
 SZ|hr|*az
 SZ|ht|*aa
 SZ|hu|Szváziföld
 SZ|hy|Էսվատինի
 SZ|hz|*aa
-SZ|ia|*eu
-SZ|id|*ca
+SZ|ia|*aa
+SZ|id|*gd
 SZ|ie|*aa
 SZ|ig|*aa
 SZ|ii|*aa
 SZ|ik|*aa
-SZ|in|*ca
+SZ|in|*gd
 SZ|io|*aa
-SZ|is|Svasíland
-SZ|it|*ak
+SZ|is|Esvatíní
+SZ|it|*aa
 SZ|iu|*aa
 SZ|iw|*he
 SZ|ja|エスワティニ
@@ -39944,14 +39944,14 @@ SZ|ka|სვაზილენდი
 SZ|kg|*aa
 SZ|ki|Uswazi
 SZ|kj|*aa
-SZ|kk|*ce
+SZ|kk|*cv
 SZ|kl|*aa
 SZ|km|ស្វាស៊ីឡង់
-SZ|kn|ಸ್ವಾತಿನಿ
+SZ|kn|ಎಸ್ವಾಟಿನಿ
 SZ|ko|에스와티니
 SZ|kr|*aa
-SZ|ks|سُوزِلینڑ
-SZ|ku|Swazîlenda
+SZ|ks|ایسواتنی
+SZ|ku|Eswatînî
 SZ|kv|*aa
 SZ|kw|*aa
 SZ|ky|*ce
@@ -39966,14 +39966,14 @@ SZ|lu|*bm
 SZ|lv|Svatini
 SZ|mg|Soazilandy
 SZ|mh|*aa
-SZ|mi|*aa
+SZ|mi|Ehiwatini
 SZ|mk|*ce
 SZ|ml|സ്വാസിലൻഡ്
-SZ|mn|Эсватини
+SZ|mn|*cv
 SZ|mo|*aa
 SZ|mr|इस्वातिनी
-SZ|ms|*ak
-SZ|mt|is-Swaziland
+SZ|ms|*aa
+SZ|mt|l-Eswatini
 SZ|my|ဆွာဇီလန်
 SZ|na|*aa
 SZ|nb|*aa
@@ -39988,7 +39988,7 @@ SZ|nv|*aa
 SZ|ny|*aa
 SZ|oc|*aa
 SZ|oj|*aa
-SZ|om|*aa
+SZ|om|Iswaatinii
 SZ|or|ଇସ୍ୱାତିନୀ
 SZ|os|*aa
 SZ|pa|ਇਸਵਾਤੀਨੀ
@@ -39996,11 +39996,11 @@ SZ|pi|*aa
 SZ|pl|*aa
 SZ|ps|اسواټيني
 SZ|pt|Essuatíni
-SZ|qu|Suazilandia
+SZ|qu|*es
 SZ|rm|*aa
 SZ|rn|Suwazilandi
 SZ|ro|*aa
-SZ|ru|*mn
+SZ|ru|*cv
 SZ|rw|*aa
 SZ|sa|*aa
 SZ|sc|*aa
@@ -40018,13 +40018,13 @@ SZ|sr|*ce
 SZ|ss|*aa
 SZ|st|*aa
 SZ|su|*aa
-SZ|sv|*ak
+SZ|sv|*aa
 SZ|sw|*aa
 SZ|ta|எஸ்வாட்டீனி
 SZ|te|ఈస్వాటిని
-SZ|tg|*ce
+SZ|tg|*cv
 SZ|th|เอสวาตีนี
-SZ|ti|ኢስዋቲኒ
+SZ|ti|*am
 SZ|tk|*aa
 SZ|tl|*ak
 SZ|tn|*aa
@@ -40043,7 +40043,7 @@ SZ|vi|*aa
 SZ|vo|*aa
 SZ|wa|*aa
 SZ|wo|Suwasilànd
-SZ|xh|*aa
+SZ|xh|ESwatini
 SZ|yi|*ji
 SZ|yo|Saṣiland
 SZ|za|*aa
@@ -40078,7 +40078,7 @@ TC|co|*aa
 TC|cr|*aa
 TC|cs|Turks a Caicos
 TC|cu|*aa
-TC|cv|*aa
+TC|cv|Тёркс тата Кайкос утравӗсем
 TC|cy|Ynysoedd Turks a Caicos
 TC|da|Turks- og Caicosøerne
 TC|de|Turks- und Caicosinseln
@@ -40109,14 +40109,14 @@ TC|he|איי טרקס וקייקוס
 TC|hi|तुर्क और कैकोज़ द्वीपसमूह
 TC|ho|*aa
 TC|hr|Otoci Turks i Caicos
-TC|ht|*aa
+TC|ht|*fr
 TC|hu|Turks- és Caicos-szigetek
 TC|hy|Թըրքս և Կայկոս կղզիներ
 TC|hz|*aa
 TC|ia|Insulas Turcos e Caicos
 TC|id|Kepulauan Turks dan Caicos
-TC|ie|*aa
-TC|ig|Agwaetiti Turks na Caicos
+TC|ie|Turks e Caicos
+TC|ig|*aa
 TC|ii|*aa
 TC|ik|*aa
 TC|in|*id
@@ -40138,8 +40138,8 @@ TC|km|កោះ​ទួគ និង កៃកូស
 TC|kn|ಟರ್ಕ್ಸ್ ಮತ್ತು ಕೈಕೋಸ್ ದ್ವೀಪಗಳು
 TC|ko|터크스 케이커스 제도
 TC|kr|*aa
-TC|ks|تُرُک تہٕ کیکوس جٔزیٖرٕ
-TC|ku|Giravên Turk û Kaîkos
+TC|ks|تُرکس تٕہ کیکو جزیرٕ
+TC|ku|Giravên Turks û Kaîkosê
 TC|kv|*aa
 TC|kw|*aa
 TC|ky|Түркс жана Кайкос аралдары
@@ -40154,7 +40154,7 @@ TC|lu|Lutanda lua Tuluki ne Kaiko
 TC|lv|Tērksas un Kaikosas salas
 TC|mg|Nosy Turks sy Caïques
 TC|mh|*aa
-TC|mi|*aa
+TC|mi|Koru-Kākoa
 TC|mk|Острови Туркс и Каикос
 TC|ml|ടർക്ക്‌സും കെയ്‌ക്കോ ദ്വീപുകളും
 TC|mn|Турк ба Кайкосын Арлууд
@@ -40176,7 +40176,7 @@ TC|nv|*aa
 TC|ny|*aa
 TC|oc|*aa
 TC|oj|*aa
-TC|om|*aa
+TC|om|Turkis fi Odoloota Kaayikos
 TC|or|ତୁର୍କସ୍‌ ଏବଂ କାଇକୋସ୍‌ ଦ୍ୱୀପପୁଞ୍ଜ
 TC|os|*aa
 TC|pa|ਟੁਰਕਸ ਅਤੇ ਕੈਕੋਸ ਟਾਪੂ
@@ -40188,10 +40188,10 @@ TC|qu|*es
 TC|rm|Inslas Turks e Caicos
 TC|rn|Amazinga ya Turkisi na Cayikosi
 TC|ro|*mo
-TC|ru|о-ва Тёркс и Кайкос
+TC|ru|Тёркс и Кайкос
 TC|rw|*aa
 TC|sa|*aa
-TC|sc|*aa
+TC|sc|Ìsulas Turks e Caicos
 TC|sd|ترڪ ۽ ڪيڪوس ٻيٽ
 TC|se|Turks ja Caicos-sullot
 TC|sg|Âzûâ Turku na Kaîki
@@ -40212,7 +40212,7 @@ TC|ta|டர்க்ஸ் & கைகோஸ் தீவுகள்
 TC|te|టర్క్స్ మరియు కైకోస్ దీవులు
 TC|tg|Ҷазираҳои Теркс ва Кайкос
 TC|th|หมู่เกาะเติกส์และหมู่เกาะเคคอส
-TC|ti|ደሴታት ቱርክን ካይኮስን
+TC|ti|ደሴታት ቱርካትን ካይኮስን
 TC|tk|Terks we Kaýkos adalary
 TC|tl|*aa
 TC|tn|*aa
@@ -40231,7 +40231,7 @@ TC|vi|Quần đảo Turks và Caicos
 TC|vo|*aa
 TC|wa|*aa
 TC|wo|Duni Tirk ak Kaykos
-TC|xh|*aa
+TC|xh|ETurks & Caicos Islands
 TC|yi|*aa
 TC|yo|Tọọki ati Etikun Kakọsi
 TC|za|*aa
@@ -40266,7 +40266,7 @@ TD|co|*aa
 TD|cr|*aa
 TD|cs|*bs
 TD|cu|*aa
-TD|cv|*aa
+TD|cv|*be
 TD|cy|Tsiad
 TD|da|*br
 TD|de|Tschad
@@ -40297,13 +40297,13 @@ TD|he|צ׳אד
 TD|hi|चाड
 TD|ho|*aa
 TD|hr|*bs
-TD|ht|*aa
+TD|ht|*br
 TD|hu|Csád
 TD|hy|Չադ
 TD|hz|*aa
 TD|ia|*br
 TD|id|*aa
-TD|ie|*aa
+TD|ie|*br
 TD|ig|*aa
 TD|ii|*aa
 TD|ik|*aa
@@ -40342,7 +40342,7 @@ TD|lu|Tshadi
 TD|lv|Čada
 TD|mg|Tsady
 TD|mh|*aa
-TD|mi|*aa
+TD|mi|Kāta
 TD|mk|*be
 TD|ml|ഛാഡ്
 TD|mn|*be
@@ -40364,7 +40364,7 @@ TD|nv|*aa
 TD|ny|*aa
 TD|oc|*aa
 TD|oj|*aa
-TD|om|*aa
+TD|om|Chaad
 TD|or|ଚାଦ୍
 TD|os|*aa
 TD|pa|ਚਾਡ
@@ -40400,7 +40400,7 @@ TD|ta|சாட்
 TD|te|చాద్
 TD|tg|*be
 TD|th|ชาด
-TD|ti|ጫድ
+TD|ti|*am
 TD|tk|*az
 TD|tl|*aa
 TD|tn|*aa
@@ -40419,7 +40419,7 @@ TD|vi|*aa
 TD|vo|*aa
 TD|wa|*aa
 TD|wo|Càdd
-TD|xh|*aa
+TD|xh|EChad
 TD|yi|*ji
 TD|yo|Ṣààdì
 TD|za|*aa
@@ -40429,7 +40429,7 @@ TF|aa|French Southern Territories
 TF|ab|*aa
 TF|ae|*aa
 TF|af|Franse Suidelike Gebiede
-TF|ak|*aa
+TF|ak|Franse Anaafoɔ Nsaase
 TF|am|የፈረንሳይ ደቡባዊ ግዛቶች
 TF|an|*aa
 TF|ar|الأقاليم الجنوبية الفرنسية
@@ -40447,14 +40447,14 @@ TF|bn|ফরাসী দক্ষিণাঞ্চল
 TF|bo|*aa
 TF|br|Douaroù aostral Frañs
 TF|bs|Francuske Južne Teritorije
-TF|ca|Territoris Australs Francesos
+TF|ca|Terres Australs Antàrtiques Franceses
 TF|ce|Французийн къилба латтанаш
 TF|ch|*aa
 TF|co|*aa
 TF|cr|*aa
 TF|cs|Francouzská jižní území
 TF|cu|*aa
-TF|cv|*aa
+TF|cv|Франци Кӑнтӑр территорийӗсем
 TF|cy|Tiroedd Deheuol ac Antarctig Ffrainc
 TF|da|De Franske Besiddelser i Det Sydlige Indiske Ocean og Antarktis
 TF|de|Französische Süd- und Antarktisgebiete
@@ -40467,7 +40467,7 @@ TF|eo|*aa
 TF|es|Territorios Australes Franceses
 TF|et|Prantsuse Lõunaalad
 TF|eu|Hegoaldeko lurralde frantsesak
-TF|fa|سرزمین‌های جنوب فرانسه
+TF|fa|سرزمین‌های جنوبی فرانسه
 TF|ff|*aa
 TF|fi|Ranskan eteläiset ja antarktiset alueet
 TF|fj|*aa
@@ -40484,8 +40484,8 @@ TF|ha|Yankin Faransi ta Kudu
 TF|he|הטריטוריות הדרומיות של צרפת
 TF|hi|फ़्रांसीसी दक्षिणी क्षेत्र
 TF|ho|*aa
-TF|hr|Francuski južni i antarktički teritoriji
-TF|ht|*aa
+TF|hr|Francuski Južni Teritoriji
+TF|ht|*fr
 TF|hu|Francia Déli Területek
 TF|hy|Ֆրանսիական Հարավային Տարածքներ
 TF|hz|*aa
@@ -40498,7 +40498,7 @@ TF|ik|*aa
 TF|in|*id
 TF|io|*aa
 TF|is|Frönsku suðlægu landsvæðin
-TF|it|Terre australi francesi
+TF|it|Terre Australi Francesi
 TF|iu|*aa
 TF|iw|*he
 TF|ja|仏領極南諸島
@@ -40512,10 +40512,10 @@ TF|kk|Францияның оңтүстік аймақтары
 TF|kl|*aa
 TF|km|ដែនដី​បារាំង​នៅ​ភាគខាងត្បូង
 TF|kn|ಫ್ರೆಂಚ್ ದಕ್ಷಿಣ ಪ್ರದೇಶಗಳು
-TF|ko|프랑스 남부 지방
+TF|ko|프랑스령 남방 지역
 TF|kr|*aa
 TF|ks|فرانسِسی جَنوٗبی عَلاقہٕ
-TF|ku|*aa
+TF|ku|Herêmên Başûr ên Fransayê
 TF|kv|*aa
 TF|kw|*aa
 TF|ky|Франциянын Түштүктөгү аймактары
@@ -40524,13 +40524,13 @@ TF|lb|Franséisch Süd- an Antarktisgebidder
 TF|lg|*aa
 TF|li|*aa
 TF|ln|Terres australes et antarctiques françaises
-TF|lo|ເຂດແດນທາງໃຕ້ຂອຝຮັ່ງ
+TF|lo|ເຂດແດນທາງໃຕ້ຂອງຝຮັ່ງ
 TF|lt|Prancūzijos Pietų sritys
 TF|lu|*aa
 TF|lv|Francijas Dienvidjūru teritorija
 TF|mg|*aa
 TF|mh|*aa
-TF|mi|*aa
+TF|mi|Ngā Rohe o Wīwī ki te Tonga
 TF|mk|Француски Јужни Територии
 TF|ml|ഫ്രഞ്ച് ദക്ഷിണ ഭൂപ്രദേശം
 TF|mn|Францын өмнөд газар нутаг
@@ -40552,7 +40552,7 @@ TF|nv|*aa
 TF|ny|*aa
 TF|oc|*aa
 TF|oj|*aa
-TF|om|*aa
+TF|om|Daangaawwan Kibbaa Faransaay
 TF|or|ଫରାସୀ ଦକ୍ଷିଣ କ୍ଷେତ୍ର
 TF|os|*aa
 TF|pa|ਫਰੈਂਚ ਦੱਖਣੀ ਪ੍ਰਦੇਸ਼
@@ -40567,7 +40567,7 @@ TF|ro|*mo
 TF|ru|Французские Южные территории
 TF|rw|*aa
 TF|sa|*aa
-TF|sc|*aa
+TF|sc|Terras australes frantzesas
 TF|sd|فرانسيسي ڏاکڻي علائقا
 TF|se|*aa
 TF|sg|*aa
@@ -40588,7 +40588,7 @@ TF|ta|பிரெஞ்சு தெற்கு பிரதேசங்கள
 TF|te|ఫ్రెంచ్ దక్షిణ ప్రాంతాలు
 TF|tg|Минтақаҳои Ҷанубии Фаронса
 TF|th|เฟรนช์เซาเทิร์นเทร์ริทอรีส์
-TF|ti|ናይ ፈረንሳይ ደቡባዊ ግዝኣታት
+TF|ti|ፈረንሳዊ ደቡባዊ ግዝኣታት
 TF|tk|Fransuz günorta territoriýalary
 TF|tl|*aa
 TF|tn|*aa
@@ -40607,7 +40607,7 @@ TF|vi|Lãnh thổ phía Nam Thuộc Pháp
 TF|vo|*aa
 TF|wa|*aa
 TF|wo|Teer Ostraal gu Fraas
-TF|xh|*aa
+TF|xh|EFrench Southern Territories
 TF|yi|*aa
 TF|yo|Agbègbè Gúúsù Faranṣé
 TF|za|*aa
@@ -40642,7 +40642,7 @@ TG|co|*aa
 TG|cr|*aa
 TG|cs|*aa
 TG|cu|*aa
-TG|cv|*aa
+TG|cv|*bg
 TG|cy|*aa
 TG|da|*aa
 TG|de|*aa
@@ -40651,7 +40651,7 @@ TG|dz|ཊོ་གྷོ
 TG|ee|Togo nutome
 TG|el|Τόγκο
 TG|en|*aa
-TG|eo|Togolo
+TG|eo|Togolando
 TG|es|*aa
 TG|et|*aa
 TG|eu|*aa
@@ -40718,7 +40718,7 @@ TG|lu|Togu
 TG|lv|*aa
 TG|mg|*aa
 TG|mh|*aa
-TG|mi|*aa
+TG|mi|Toko
 TG|mk|*bg
 TG|ml|ടോഗോ
 TG|mn|*bg
@@ -40740,7 +40740,7 @@ TG|nv|*aa
 TG|ny|*aa
 TG|oc|*aa
 TG|oj|*aa
-TG|om|*aa
+TG|om|Toogoo
 TG|or|ଟୋଗୋ
 TG|os|*aa
 TG|pa|ਟੋਗੋ
@@ -40776,11 +40776,11 @@ TG|ta|டோகோ
 TG|te|టోగో
 TG|tg|*bg
 TG|th|โตโก
-TG|ti|*am
+TG|ti|ቶጎ
 TG|tk|*aa
 TG|tl|*aa
 TG|tn|*aa
-TG|to|Toko
+TG|to|*mi
 TG|tr|*aa
 TG|ts|*aa
 TG|tt|*bg
@@ -40795,7 +40795,7 @@ TG|vi|*aa
 TG|vo|*aa
 TG|wa|*aa
 TG|wo|*aa
-TG|xh|*aa
+TG|xh|ETogo
 TG|yi|*ji
 TG|yo|*aa
 TG|za|*aa
@@ -40830,7 +40830,7 @@ TH|co|*aa
 TH|cr|*aa
 TH|cs|Thajsko
 TH|cu|*aa
-TH|cv|*aa
+TH|cv|*ce
 TH|cy|Gwlad Thai
 TH|da|*aa
 TH|de|*aa
@@ -40861,9 +40861,9 @@ TH|he|תאילנד
 TH|hi|थाईलैंड
 TH|ho|*aa
 TH|hr|*bs
-TH|ht|*aa
+TH|ht|*fr
 TH|hu|Thaiföld
-TH|hy|Թայլանդ
+TH|hy|Թաիլանդ
 TH|hz|*aa
 TH|ia|*eu
 TH|id|*aa
@@ -40890,8 +40890,8 @@ TH|km|ថៃ
 TH|kn|ಥೈಲ್ಯಾಂಡ್
 TH|ko|태국
 TH|kr|*aa
-TH|ks|تھایلینڑ
-TH|ku|Taylenda
+TH|ks|تھائی لینڈ
+TH|ku|Tayland
 TH|kv|*aa
 TH|kw|*aa
 TH|ky|*be
@@ -40906,7 +40906,7 @@ TH|lu|Tayilanda
 TH|lv|Taizeme
 TH|mg|Thailandy
 TH|mh|*aa
-TH|mi|*aa
+TH|mi|Tairanga
 TH|mk|Тајланд
 TH|ml|തായ്‌ലാൻഡ്
 TH|mn|*be
@@ -40928,7 +40928,7 @@ TH|nv|*aa
 TH|ny|*aa
 TH|oc|*aa
 TH|oj|*aa
-TH|om|*aa
+TH|om|Taayilaand
 TH|or|ଥାଇଲ୍ୟାଣ୍ଡ
 TH|os|*aa
 TH|pa|ਥਾਈਲੈਂਡ
@@ -40943,7 +40943,7 @@ TH|ro|*mo
 TH|ru|*ce
 TH|rw|*aa
 TH|sa|*aa
-TH|sc|*aa
+TH|sc|*ca
 TH|sd|ٿائيليند
 TH|se|Thaieana
 TH|sg|Tailânde
@@ -40969,21 +40969,21 @@ TH|tk|Taýland
 TH|tl|*aa
 TH|tn|*aa
 TH|to|Tailani
-TH|tr|Tayland
+TH|tr|*ku
 TH|ts|*aa
 TH|tt|*be
 TH|tw|*aa
 TH|ty|*aa
 TH|ug|*ar
 TH|uk|Таїланд
-TH|ur|تھائی لینڈ
+TH|ur|*ks
 TH|uz|*az
 TH|ve|*aa
 TH|vi|Thái Lan
 TH|vo|*aa
 TH|wa|*aa
 TH|wo|Taylànd
-TH|xh|*aa
+TH|xh|EThailand
 TH|yi|*ji
 TH|yo|*ki
 TH|za|*aa
@@ -40993,7 +40993,7 @@ TJ|aa|Tajikistan
 TJ|ab|*aa
 TJ|ae|*aa
 TJ|af|Tadjikistan
-TJ|ak|*aa
+TJ|ak|Tagyikistan
 TJ|am|ታጃኪስታን
 TJ|an|*aa
 TJ|ar|طاجيكستان
@@ -41018,7 +41018,7 @@ TJ|co|*aa
 TJ|cr|*aa
 TJ|cs|Tádžikistán
 TJ|cu|*aa
-TJ|cv|*aa
+TJ|cv|*bg
 TJ|cy|Tajicistan
 TJ|da|Tadsjikistan
 TJ|de|Tadschikistan
@@ -41046,10 +41046,10 @@ TJ|gu|તાજીકિસ્તાન
 TJ|gv|*aa
 TJ|ha|*aa
 TJ|he|טג׳יקיסטן
-TJ|hi|ताज़िकिस्तान
+TJ|hi|ताजिकिस्तान
 TJ|ho|*aa
 TJ|hr|*bs
-TJ|ht|*aa
+TJ|ht|*af
 TJ|hu|Tádzsikisztán
 TJ|hy|Տաջիկստան
 TJ|hz|*aa
@@ -41094,19 +41094,19 @@ TJ|lu|Tazikisita
 TJ|lv|Tadžikistāna
 TJ|mg|*aa
 TJ|mh|*aa
-TJ|mi|*aa
+TJ|mi|Takiritānga
 TJ|mk|Таџикистан
 TJ|ml|താജിക്കിസ്ഥാൻ
 TJ|mn|Тажикистан
 TJ|mo|*af
-TJ|mr|ताजिकिस्तान
+TJ|mr|*hi
 TJ|ms|*aa
 TJ|mt|it-Taġikistan
 TJ|my|တာဂျီကစ္စတန်
 TJ|na|*aa
 TJ|nb|*da
 TJ|nd|*aa
-TJ|ne|*mr
+TJ|ne|*hi
 TJ|ng|*aa
 TJ|nl|*fy
 TJ|nn|*da
@@ -41116,7 +41116,7 @@ TJ|nv|*aa
 TJ|ny|*aa
 TJ|oc|*aa
 TJ|oj|*aa
-TJ|om|*aa
+TJ|om|*ff
 TJ|or|ତାଜିକିସ୍ଥାନ୍
 TJ|os|*aa
 TJ|pa|ਤਾਜਿਕਿਸਤਾਨ
@@ -41131,7 +41131,7 @@ TJ|ro|*af
 TJ|ru|*bg
 TJ|rw|*aa
 TJ|sa|*aa
-TJ|sc|*aa
+TJ|sc|Tagìkistan
 TJ|sd|تاجڪستان
 TJ|se|Tažikistan
 TJ|sg|Taazikiistäan
@@ -41152,7 +41152,7 @@ TJ|ta|தஜிகிஸ்தான்
 TJ|te|తజికిస్తాన్
 TJ|tg|Тоҷикистон
 TJ|th|ทาจิกิสถาน
-TJ|ti|*am
+TJ|ti|ታጂኪስታን
 TJ|tk|Täjigistan
 TJ|tl|*aa
 TJ|tn|*aa
@@ -41171,7 +41171,7 @@ TJ|vi|*aa
 TJ|vo|*aa
 TJ|wa|*aa
 TJ|wo|Tajikistaŋ
-TJ|xh|*aa
+TJ|xh|ETajikistan
 TJ|yi|*aa
 TJ|yo|Takisitani
 TJ|za|*aa
@@ -41184,7 +41184,7 @@ TK|af|*aa
 TK|ak|*aa
 TK|am|ቶክላው
 TK|an|*aa
-TK|ar|توكيلو
+TK|ar|توكيلاو
 TK|as|টোকেলাউ
 TK|av|*aa
 TK|ay|*aa
@@ -41206,7 +41206,7 @@ TK|co|*aa
 TK|cr|*aa
 TK|cs|*aa
 TK|cu|*aa
-TK|cv|*aa
+TK|cv|*bg
 TK|cy|*aa
 TK|da|*aa
 TK|de|*aa
@@ -41266,7 +41266,7 @@ TK|km|តូខេឡៅ
 TK|kn|ಟೊಕೆಲಾವ್
 TK|ko|토켈라우
 TK|kr|*aa
-TK|ks|توکیلاو
+TK|ks|ٹوکلو
 TK|ku|*aa
 TK|kv|*aa
 TK|kw|*aa
@@ -41282,7 +41282,7 @@ TK|lu|*aa
 TK|lv|*aa
 TK|mg|Tokelao
 TK|mh|*aa
-TK|mi|*aa
+TK|mi|Tokerau
 TK|mk|*bg
 TK|ml|ടോക്കെലൂ
 TK|mn|*bg
@@ -41340,7 +41340,7 @@ TK|ta|டோகேலோ
 TK|te|టోకెలావ్
 TK|tg|*bg
 TK|th|โตเกเลา
-TK|ti|*am
+TK|ti|ቶከላው
 TK|tk|*aa
 TK|tl|*aa
 TK|tn|*aa
@@ -41359,7 +41359,7 @@ TK|vi|*aa
 TK|vo|*aa
 TK|wa|*aa
 TK|wo|Tokoloo
-TK|xh|*aa
+TK|xh|ETokelau
 TK|yi|*aa
 TK|yo|*aa
 TK|za|*aa
@@ -41387,14 +41387,14 @@ TL|bn|তিমুর-লেস্তে
 TL|bo|*aa
 TL|br|*aa
 TL|bs|Istočni Timor
-TL|ca|Timor Oriental
+TL|ca|*aa
 TL|ce|Малхбален Тимор
 TL|ch|*aa
 TL|co|*aa
 TL|cr|*aa
 TL|cs|Východní Timor
 TL|cu|*aa
-TL|cv|*aa
+TL|cv|Хӗвелтухӑҫ Тимор
 TL|cy|*aa
 TL|da|*aa
 TL|de|*aa
@@ -41420,18 +41420,18 @@ TL|gl|Timor Leste
 TL|gn|*aa
 TL|gu|તિમોર-લેસ્તે
 TL|gv|*aa
-TL|ha|Timor Ta Gabas
+TL|ha|*aa
 TL|he|טימור-לסטה
 TL|hi|तिमोर-लेस्त
 TL|ho|*aa
 TL|hr|*aa
-TL|ht|*aa
+TL|ht|*fr
 TL|hu|Kelet-Timor
 TL|hy|Թիմոր Լեշտի
 TL|hz|*aa
 TL|ia|Timor del Est
 TL|id|*gl
-TL|ie|*aa
+TL|ie|Ost-Timor
 TL|ig|*aa
 TL|ii|*aa
 TL|ik|*aa
@@ -41442,7 +41442,7 @@ TL|it|Timor Est
 TL|iu|*aa
 TL|iw|*he
 TL|ja|東ティモール
-TL|ji|*aa
+TL|ji|מזרח טימאר
 TL|jv|*gl
 TL|ka|ტიმორ-ლესტე
 TL|kg|*aa
@@ -41451,11 +41451,11 @@ TL|kj|*aa
 TL|kk|Тимор-Лесте
 TL|kl|*aa
 TL|km|ទីម័រលេស្តេ
-TL|kn|ಪೂರ್ವ ತಿಮೋರ್
+TL|kn|ಟಿಮೋರ್ ಲೆಸ್ಟೆ
 TL|ko|동티모르
 TL|kr|*aa
-TL|ks|مَشرِقی تایمور
-TL|ku|Tîmora-Leste
+TL|ks|تیمور-لیسٹ
+TL|ku|Tîmor-Leste
 TL|kv|*aa
 TL|kw|*aa
 TL|ky|*kk
@@ -41470,7 +41470,7 @@ TL|lu|Timoru wa diboku
 TL|lv|Austrumtimora
 TL|mg|Timor Atsinanana
 TL|mh|*aa
-TL|mi|*aa
+TL|mi|Tīmoa ki te Rāwhiti
 TL|mk|*bg
 TL|ml|തിമോർ-ലെസ്റ്റെ
 TL|mn|*kk
@@ -41492,7 +41492,7 @@ TL|nv|*aa
 TL|ny|*aa
 TL|oc|*aa
 TL|oj|*aa
-TL|om|*aa
+TL|om|Tiimoor-Leestee
 TL|or|ତିମୋର୍-ଲେଷ୍ଟେ
 TL|os|*aa
 TL|pa|ਤਿਮੋਰ-ਲੇਸਤੇ
@@ -41507,7 +41507,7 @@ TL|ro|*aa
 TL|ru|Восточный Тимор
 TL|rw|*aa
 TL|sa|*aa
-TL|sc|*aa
+TL|sc|Timor-Est
 TL|sd|تيمور ليستي
 TL|se|Nuorta-Timor
 TL|sg|Timôro tî Tö
@@ -41516,7 +41516,7 @@ TL|sk|Východný Timor
 TL|sl|*aa
 TL|sm|*aa
 TL|sn|*nd
-TL|so|Timoor
+TL|so|*aa
 TL|sq|*aa
 TL|sr|Тимор-Лесте (Источни Тимор)
 TL|ss|*aa
@@ -41528,7 +41528,7 @@ TL|ta|திமோர்-லெஸ்தே
 TL|te|టిమోర్-లెస్టె
 TL|tg|*kk
 TL|th|ติมอร์-เลสเต
-TL|ti|ምብራቕ ቲሞር
+TL|ti|ቲሞር-ለስተ
 TL|tk|*aa
 TL|tl|*aa
 TL|tn|*aa
@@ -41539,7 +41539,7 @@ TL|tt|*kk
 TL|tw|*aa
 TL|ty|*aa
 TL|ug|شەرقىي تىمور
-TL|uk|Тімор-Лешті
+TL|uk|Тимор-Лешті
 TL|ur|تیمور لیسٹ
 TL|uz|*aa
 TL|ve|*aa
@@ -41547,9 +41547,9 @@ TL|vi|*aa
 TL|vo|*aa
 TL|wa|*aa
 TL|wo|*gl
-TL|xh|*aa
-TL|yi|*aa
-TL|yo|ÌlàOòrùn Tímọ̀
+TL|xh|ETimor-Leste
+TL|yi|*ji
+TL|yo|Tímọ̀ Lẹsiti
 TL|za|*aa
 TL|zh|东帝汶
 TL|zu|i-Timor-Leste
@@ -41582,7 +41582,7 @@ TM|co|*aa
 TM|cr|*aa
 TM|cs|Turkmenistán
 TM|cu|*aa
-TM|cv|*aa
+TM|cv|*bg
 TM|cy|Tyrcmenistan
 TM|da|*aa
 TM|de|*aa
@@ -41613,7 +41613,7 @@ TM|he|טורקמניסטן
 TM|hi|तुर्कमेनिस्तान
 TM|ho|*aa
 TM|hr|*aa
-TM|ht|*aa
+TM|ht|*fr
 TM|hu|Türkmenisztán
 TM|hy|Թուրքմենստան
 TM|hz|*aa
@@ -41642,7 +41642,7 @@ TM|km|តួកម៉េនីស្ថាន
 TM|kn|ತುರ್ಕಮೆನಿಸ್ತಾನ್
 TM|ko|투르크메니스탄
 TM|kr|*aa
-TM|ks|تُرمِنِستان
+TM|ks|تُرکمنستان
 TM|ku|Tirkmenistan
 TM|kv|*aa
 TM|kw|*aa
@@ -41658,7 +41658,7 @@ TM|lu|Tukemenisita
 TM|lv|Turkmenistāna
 TM|mg|Torkmenistan
 TM|mh|*aa
-TM|mi|*aa
+TM|mi|Tukumanatānga
 TM|mk|*bg
 TM|ml|തുർക്ക്മെനിസ്ഥാൻ
 TM|mn|*bg
@@ -41680,7 +41680,7 @@ TM|nv|*aa
 TM|ny|*aa
 TM|oc|*aa
 TM|oj|*aa
-TM|om|*aa
+TM|om|Turkimenistaan
 TM|or|ତୁର୍କମେନିସ୍ତାନ
 TM|os|*aa
 TM|pa|ਤੁਰਕਮੇਨਿਸਤਾਨ
@@ -41695,7 +41695,7 @@ TM|ro|*aa
 TM|ru|*bg
 TM|rw|*aa
 TM|sa|*aa
-TM|sc|*aa
+TM|sc|Turkmènistan
 TM|sd|ترڪمانستان
 TM|se|*aa
 TM|sg|Turkumenistäan
@@ -41716,7 +41716,7 @@ TM|ta|துர்க்மெனிஸ்தான்
 TM|te|టర్క్‌మెనిస్తాన్
 TM|tg|Туркманистон
 TM|th|เติร์กเมนิสถาน
-TM|ti|*am
+TM|ti|ቱርክመኒስታን
 TM|tk|*et
 TM|tl|*aa
 TM|tn|*aa
@@ -41735,9 +41735,9 @@ TM|vi|*aa
 TM|vo|*aa
 TM|wa|*aa
 TM|wo|Tirkmenistaŋ
-TM|xh|*aa
+TM|xh|ETurkmenistan
 TM|yi|*ji
-TM|yo|Tọọkimenisita
+TM|yo|Tọ́kìmẹ́nísítànì
 TM|za|*aa
 TM|zh|土库曼斯坦
 TM|zu|i-Turkmenistan
@@ -41770,7 +41770,7 @@ TN|co|*aa
 TN|cr|*aa
 TN|cs|Tunisko
 TN|cu|*aa
-TN|cv|*aa
+TN|cv|*bg
 TN|cy|Tiwnisia
 TN|da|Tunesien
 TN|de|*da
@@ -41790,7 +41790,7 @@ TN|fj|*aa
 TN|fo|Tunesia
 TN|fr|Tunisie
 TN|fy|Tunesië
-TN|ga|an Túinéis
+TN|ga|An Tuinéis
 TN|gd|Tuinisea
 TN|gl|*aa
 TN|gn|*aa
@@ -41801,7 +41801,7 @@ TN|he|תוניסיה
 TN|hi|ट्यूनीशिया
 TN|ho|*aa
 TN|hr|*az
-TN|ht|*aa
+TN|ht|*fr
 TN|hu|Tunézia
 TN|hy|Թունիս
 TN|hz|*aa
@@ -41846,7 +41846,7 @@ TN|lu|*ln
 TN|lv|Tunisija
 TN|mg|Tonizia
 TN|mh|*aa
-TN|mi|*aa
+TN|mi|Tūnihia
 TN|mk|*bg
 TN|ml|ടുണീഷ്യ
 TN|mn|*bg
@@ -41868,7 +41868,7 @@ TN|nv|*aa
 TN|ny|*aa
 TN|oc|*aa
 TN|oj|*aa
-TN|om|*aa
+TN|om|Tuniiziyaa
 TN|or|ଟ୍ୟୁନିସିଆ
 TN|os|*aa
 TN|pa|ਟਿਊਨੀਸ਼ੀਆ
@@ -41904,7 +41904,7 @@ TN|ta|டுனிசியா
 TN|te|ట్యునీషియా
 TN|tg|*bg
 TN|th|ตูนิเซีย
-TN|ti|*am
+TN|ti|ቱኒዝያ
 TN|tk|*az
 TN|tl|*aa
 TN|tn|*aa
@@ -41923,7 +41923,7 @@ TN|vi|*aa
 TN|vo|*aa
 TN|wa|*aa
 TN|wo|Tinisi
-TN|xh|*aa
+TN|xh|ETunisia
 TN|yi|*ji
 TN|yo|Tuniṣia
 TN|za|*aa
@@ -41958,7 +41958,7 @@ TO|co|*aa
 TO|cr|*aa
 TO|cs|*aa
 TO|cu|*aa
-TO|cv|*aa
+TO|cv|*be
 TO|cy|*aa
 TO|da|*aa
 TO|de|*aa
@@ -42111,13 +42111,13 @@ TO|vi|*aa
 TO|vo|*aa
 TO|wa|*aa
 TO|wo|*aa
-TO|xh|*aa
+TO|xh|ETonga
 TO|yi|*ji
 TO|yo|*aa
 TO|za|*aa
 TO|zh|汤加
 TO|zu|i-Tonga
-TR|aa|Turkey
+TR|aa|Türkiye
 TR|ab|*aa
 TR|ae|*aa
 TR|af|Turkye
@@ -42125,7 +42125,7 @@ TR|ak|Tɛɛki
 TR|am|ቱርክ
 TR|an|*aa
 TR|ar|تركيا
-TR|as|তুৰ্কি
+TR|as|তুৰ্কিয়ে
 TR|av|*aa
 TR|ay|*aa
 TR|az|Türkiyə
@@ -42146,7 +42146,7 @@ TR|co|*aa
 TR|cr|*aa
 TR|cs|Turecko
 TR|cu|*aa
-TR|cv|*aa
+TR|cv|Турци
 TR|cy|Twrci
 TR|da|Tyrkiet
 TR|de|Türkei
@@ -42170,14 +42170,14 @@ TR|ga|an Tuirc
 TR|gd|An Tuirc
 TR|gl|*es
 TR|gn|*aa
-TR|gu|તુર્કી
+TR|gu|તુર્કિયે
 TR|gv|*aa
 TR|ha|Turkiyya
 TR|he|טורקיה
-TR|hi|तुर्की
+TR|hi|तुर्किये
 TR|ho|*aa
 TR|hr|*bs
-TR|ht|*aa
+TR|ht|*fr
 TR|hu|Törökország
 TR|hy|Թուրքիա
 TR|hz|*aa
@@ -42203,11 +42203,11 @@ TR|kj|*aa
 TR|kk|Түркия
 TR|kl|*aa
 TR|km|តួកគី
-TR|kn|ಟರ್ಕಿ
-TR|ko|터키
+TR|kn|ತುರ್ಕಿಯೆ
+TR|ko|튀르키예
 TR|kr|*aa
 TR|ks|تُرکی
-TR|ku|Tirkiye
+TR|ku|Tirkîye
 TR|kv|*aa
 TR|kw|*aa
 TR|ky|*kk
@@ -42222,19 +42222,19 @@ TR|lu|Tuluki
 TR|lv|Turcija
 TR|mg|Torkia
 TR|mh|*aa
-TR|mi|*aa
+TR|mi|Tākei
 TR|mk|Турција
-TR|ml|തുർക്കി
+TR|ml|തുർക്കിയെ
 TR|mn|Турк
 TR|mo|Turcia
 TR|mr|*hi
-TR|ms|*id
+TR|ms|Turkiye
 TR|mt|it-Turkija
 TR|my|တူရကီ
 TR|na|*aa
 TR|nb|Tyrkia
 TR|nd|Thekhi
-TR|ne|टर्की
+TR|ne|*hi
 TR|ng|*aa
 TR|nl|*fy
 TR|nn|*nb
@@ -42244,7 +42244,7 @@ TR|nv|*aa
 TR|ny|*aa
 TR|oc|*aa
 TR|oj|*aa
-TR|om|*aa
+TR|om|Tarkiye
 TR|or|ତୁର୍କୀ
 TR|os|*aa
 TR|pa|ਤੁਰਕੀ
@@ -42259,15 +42259,15 @@ TR|ro|*mo
 TR|ru|*bg
 TR|rw|*aa
 TR|sa|*aa
-TR|sc|*aa
-TR|sd|ترڪي
+TR|sc|*ia
+TR|sd|ترڪييي
 TR|se|Durka
 TR|sg|Turukïi
 TR|si|තුර්කිය
 TR|sk|*cs
 TR|sl|Turčija
 TR|sm|*aa
-TR|sn|*aa
+TR|sn|Turkey
 TR|so|*id
 TR|sq|Turqi
 TR|sr|Турска
@@ -42276,30 +42276,30 @@ TR|st|*aa
 TR|su|*aa
 TR|sv|Turkiet
 TR|sw|*ki
-TR|ta|துருக்கி
-TR|te|టర్కీ
+TR|ta|துருக்கியே
+TR|te|తుర్కియె
 TR|tg|Туркия
 TR|th|ตุรกี
-TR|ti|*am
+TR|ti|ቱርኪ
 TR|tk|Türkiýe
 TR|tl|*aa
 TR|tn|*aa
 TR|to|Toake
-TR|tr|Türkiye
+TR|tr|*aa
 TR|ts|*aa
 TR|tt|Төркия
 TR|tw|*aa
 TR|ty|*aa
 TR|ug|تۈركىيە
 TR|uk|Туреччина
-TR|ur|ترکی
+TR|ur|ترکیہ
 TR|uz|Turkiya
 TR|ve|*aa
 TR|vi|Thổ Nhĩ Kỳ
 TR|vo|*aa
 TR|wa|*aa
 TR|wo|Tirki
-TR|xh|*aa
+TR|xh|ETurkey
 TR|yi|*ji
 TR|yo|Tọọki
 TR|za|*aa
@@ -42327,14 +42327,14 @@ TT|bn|ত্রিনিনাদ ও টোব্যাগো
 TT|bo|*aa
 TT|br|Trinidad ha Tobago
 TT|bs|Trinidad i Tobago
-TT|ca|Trinitat i Tobago
+TT|ca|*bs
 TT|ce|Тринидад а, Тобаго а
 TT|ch|*aa
 TT|co|*aa
 TT|cr|*aa
 TT|cs|Trinidad a Tobago
 TT|cu|*aa
-TT|cv|*aa
+TT|cv|Тринидад тата Тобаго
 TT|cy|*cs
 TT|da|Trinidad og Tobago
 TT|de|Trinidad und Tobago
@@ -42365,13 +42365,13 @@ TT|he|טרינידד וטובגו
 TT|hi|त्रिनिदाद और टोबैगो
 TT|ho|*aa
 TT|hr|*bs
-TT|ht|*aa
+TT|ht|*fr
 TT|hu|Trinidad és Tobago
 TT|hy|Տրինիդադ և Տոբագո
 TT|hz|*aa
 TT|ia|*gl
 TT|id|Trinidad dan Tobago
-TT|ie|*aa
+TT|ie|*gl
 TT|ig|Trinidad na Tobago
 TT|ii|*aa
 TT|ik|*aa
@@ -42410,7 +42410,7 @@ TT|lu|Tinidade ne Tobago
 TT|lv|Trinidāda un Tobāgo
 TT|mg|Trinidad sy Tobagô
 TT|mh|*aa
-TT|mi|*aa
+TT|mi|Tirinaki Tōpako
 TT|mk|*bg
 TT|ml|ട്രിനിഡാഡും ടുബാഗോയും
 TT|mn|Тринидад ба Тобаго
@@ -42432,7 +42432,7 @@ TT|nv|*aa
 TT|ny|*aa
 TT|oc|*aa
 TT|oj|*aa
-TT|om|*aa
+TT|om|Tirinidan fi Tobaagoo
 TT|or|ତ୍ରିନିଦାଦ୍ ଏବଂ ଟୋବାଗୋ
 TT|os|*aa
 TT|pa|ਟ੍ਰਿਨੀਡਾਡ ਅਤੇ ਟੋਬਾਗੋ
@@ -42447,7 +42447,7 @@ TT|ro|*mo
 TT|ru|*bg
 TT|rw|*aa
 TT|sa|*aa
-TT|sc|*aa
+TT|sc|*gl
 TT|sd|ٽريني ڊيڊ ۽ ٽوباگو ٻيٽ
 TT|se|*et
 TT|sg|Trinitùee na Tobagö
@@ -42487,7 +42487,7 @@ TT|vi|Trinidad và Tobago
 TT|vo|*aa
 TT|wa|*aa
 TT|wo|Tirinite ak Tobago
-TT|xh|*aa
+TT|xh|ETrinidad & Tobago
 TT|yi|*ji
 TT|yo|Tirinida ati Tobaga
 TT|za|*aa
@@ -42522,7 +42522,7 @@ TV|co|*aa
 TV|cr|*aa
 TV|cs|*aa
 TV|cu|*aa
-TV|cv|*aa
+TV|cv|*be
 TV|cy|*aa
 TV|da|*aa
 TV|de|*aa
@@ -42542,7 +42542,7 @@ TV|fj|*aa
 TV|fo|*aa
 TV|fr|*aa
 TV|fy|*aa
-TV|ga|*aa
+TV|ga|Túvalú
 TV|gd|Tubhalu
 TV|gl|*aa
 TV|gn|*aa
@@ -42565,7 +42565,7 @@ TV|ii|*aa
 TV|ik|*aa
 TV|in|*aa
 TV|io|*aa
-TV|is|Túvalú
+TV|is|*ga
 TV|it|*aa
 TV|iu|*aa
 TV|iw|*he
@@ -42598,7 +42598,7 @@ TV|lu|*aa
 TV|lv|*aa
 TV|mg|Tovalò
 TV|mh|*aa
-TV|mi|*aa
+TV|mi|Tūwaru
 TV|mk|*be
 TV|ml|ടുവാലു
 TV|mn|*be
@@ -42675,7 +42675,7 @@ TV|vi|*aa
 TV|vo|*aa
 TV|wa|*aa
 TV|wo|Tuwalo
-TV|xh|*aa
+TV|xh|ETuvalu
 TV|yi|*ji
 TV|yo|Tufalu
 TV|za|*aa
@@ -42710,7 +42710,7 @@ TW|co|*aa
 TW|cr|*aa
 TW|cs|Tchaj-wan
 TW|cu|*aa
-TW|cv|*aa
+TW|cv|*be
 TW|cy|*aa
 TW|da|*aa
 TW|de|*aa
@@ -42741,7 +42741,7 @@ TW|he|טייוואן
 TW|hi|ताइवान
 TW|ho|*aa
 TW|hr|*bs
-TW|ht|*aa
+TW|ht|*fr
 TW|hu|*bs
 TW|hy|Թայվան
 TW|hz|*aa
@@ -42786,7 +42786,7 @@ TW|lu|*ki
 TW|lv|Taivāna
 TW|mg|Taioana
 TW|mh|*aa
-TW|mi|*aa
+TW|mi|Taiwana
 TW|mk|Тајван
 TW|ml|തായ്‌വാൻ
 TW|mn|*be
@@ -42808,7 +42808,7 @@ TW|nv|*aa
 TW|ny|*aa
 TW|oc|*aa
 TW|oj|*aa
-TW|om|*aa
+TW|om|Taayiwwan
 TW|or|ତାଇୱାନ
 TW|os|*aa
 TW|pa|ਤਾਇਵਾਨ
@@ -42823,7 +42823,7 @@ TW|ro|*aa
 TW|ru|*be
 TW|rw|*aa
 TW|sa|*aa
-TW|sc|*aa
+TW|sc|Taiwàn
 TW|sd|تائیوان
 TW|se|*aa
 TW|sg|Tâiwâni
@@ -42863,7 +42863,7 @@ TW|vi|Đài Loan
 TW|vo|*aa
 TW|wa|*aa
 TW|wo|*ku
-TW|xh|*aa
+TW|xh|ETaiwan
 TW|yi|*aa
 TW|yo|*ki
 TW|za|*aa
@@ -42873,7 +42873,7 @@ TZ|aa|Tanzania
 TZ|ab|*aa
 TZ|ae|*aa
 TZ|af|Tanzanië
-TZ|ak|*aa
+TZ|ak|Tansania
 TZ|am|ታንዛኒያ
 TZ|an|*aa
 TZ|ar|تنزانيا
@@ -42898,10 +42898,10 @@ TZ|co|*aa
 TZ|cr|*aa
 TZ|cs|Tanzanie
 TZ|cu|*aa
-TZ|cv|*aa
+TZ|cv|*ce
 TZ|cy|*aa
 TZ|da|*aa
-TZ|de|Tansania
+TZ|de|*ak
 TZ|dv|*aa
 TZ|dz|ཊཱན་ཛཱ་ནི་ཡ
 TZ|ee|Tanzania nutome
@@ -42913,9 +42913,9 @@ TZ|et|Tansaania
 TZ|eu|*aa
 TZ|fa|تانزانیا
 TZ|ff|Tansanii
-TZ|fi|*de
+TZ|fi|*ak
 TZ|fj|*aa
-TZ|fo|*de
+TZ|fo|*ak
 TZ|fr|*cs
 TZ|fy|*aa
 TZ|ga|an Tansáin
@@ -42929,7 +42929,7 @@ TZ|he|טנזניה
 TZ|hi|तंज़ानिया
 TZ|ho|*aa
 TZ|hr|*bs
-TZ|ht|*aa
+TZ|ht|*cs
 TZ|hu|Tanzánia
 TZ|hy|Տանզանիա
 TZ|hz|*aa
@@ -42947,7 +42947,7 @@ TZ|iu|*aa
 TZ|iw|*he
 TZ|ja|タンザニア
 TZ|ji|טאַנזאַניע
-TZ|jv|*de
+TZ|jv|*ak
 TZ|ka|ტანზანია
 TZ|kg|*aa
 TZ|ki|*aa
@@ -42964,7 +42964,7 @@ TZ|kv|*aa
 TZ|kw|*aa
 TZ|ky|*bg
 TZ|la|*aa
-TZ|lb|*de
+TZ|lb|*ak
 TZ|lg|*az
 TZ|li|*aa
 TZ|ln|*bm
@@ -42974,7 +42974,7 @@ TZ|lu|*bm
 TZ|lv|Tanzānija
 TZ|mg|*aa
 TZ|mh|*aa
-TZ|mi|*aa
+TZ|mi|Tānahia
 TZ|mk|Танзанија
 TZ|ml|ടാൻസാനിയ
 TZ|mn|*ce
@@ -42996,7 +42996,7 @@ TZ|nv|*aa
 TZ|ny|*aa
 TZ|oc|*aa
 TZ|oj|*aa
-TZ|om|*aa
+TZ|om|Taanzaaniyaa
 TZ|or|ତାଞ୍ଜାନିଆ
 TZ|os|*aa
 TZ|pa|ਤਨਜ਼ਾਨੀਆ
@@ -43005,13 +43005,13 @@ TZ|pl|*aa
 TZ|ps|تنزانیا
 TZ|pt|Tanzânia
 TZ|qu|*aa
-TZ|rm|*de
+TZ|rm|*ak
 TZ|rn|*az
 TZ|ro|*aa
 TZ|ru|*bg
 TZ|rw|*aa
 TZ|sa|*aa
-TZ|sc|*aa
+TZ|sc|*ca
 TZ|sd|*ar
 TZ|se|*hu
 TZ|sg|Tanzanïi
@@ -43032,7 +43032,7 @@ TZ|ta|தான்சானியா
 TZ|te|టాంజానియా
 TZ|tg|*bg
 TZ|th|แทนซาเนีย
-TZ|ti|*am
+TZ|ti|ታንዛንያ
 TZ|tk|Tanzaniýa
 TZ|tl|*aa
 TZ|tn|*aa
@@ -43051,7 +43051,7 @@ TZ|vi|*aa
 TZ|vo|*aa
 TZ|wa|*aa
 TZ|wo|Taŋsani
-TZ|xh|*aa
+TZ|xh|ETanzania
 TZ|yi|*ji
 TZ|yo|Tàǹsáníà
 TZ|za|*aa
@@ -43086,7 +43086,7 @@ UA|co|*aa
 UA|cr|*aa
 UA|cs|*bs
 UA|cu|*aa
-UA|cv|*aa
+UA|cv|*ce
 UA|cy|Wcráin
 UA|da|*aa
 UA|de|*aa
@@ -43095,7 +43095,7 @@ UA|dz|ཡུ་ཀརེན
 UA|ee|Ukraine nutome
 UA|el|Ουκρανία
 UA|en|*aa
-UA|eo|Ukrajno
+UA|eo|Ukrainujo
 UA|es|Ucrania
 UA|et|*br
 UA|eu|*br
@@ -43123,7 +43123,7 @@ UA|hy|Ուկրաինա
 UA|hz|*aa
 UA|ia|*br
 UA|id|*br
-UA|ie|*aa
+UA|ie|*br
 UA|ig|*aa
 UA|ii|*aa
 UA|ik|*aa
@@ -43162,7 +43162,7 @@ UA|lu|Ukreni
 UA|lv|*br
 UA|mg|Okraina
 UA|mh|*aa
-UA|mi|*aa
+UA|mi|Ukareinga
 UA|mk|*ce
 UA|ml|ഉക്രെയ്‌ൻ
 UA|mn|Украин
@@ -43184,7 +43184,7 @@ UA|nv|*aa
 UA|ny|*aa
 UA|oc|*aa
 UA|oj|*aa
-UA|om|*aa
+UA|om|Yuukireen
 UA|or|ୟୁକ୍ରେନ୍
 UA|os|*aa
 UA|pa|ਯੂਕਰੇਨ
@@ -43199,7 +43199,7 @@ UA|ro|*it
 UA|ru|*ce
 UA|rw|*aa
 UA|sa|*aa
-UA|sc|*aa
+UA|sc|*it
 UA|sd|يوڪرين
 UA|se|*br
 UA|sg|Ukrêni
@@ -43239,7 +43239,7 @@ UA|vi|*br
 UA|vo|*aa
 UA|wa|*aa
 UA|wo|Ikeren
-UA|xh|*aa
+UA|xh|E-Ukraine
 UA|yi|*ji
 UA|yo|Ukarini
 UA|za|*aa
@@ -43249,7 +43249,7 @@ UG|aa|Uganda
 UG|ab|*aa
 UG|ae|*aa
 UG|af|*aa
-UG|ak|*aa
+UG|ak|Yuganda
 UG|am|ዩጋንዳ
 UG|an|*aa
 UG|ar|أوغندا
@@ -43274,7 +43274,7 @@ UG|co|*aa
 UG|cr|*aa
 UG|cs|*aa
 UG|cu|*aa
-UG|cv|*aa
+UG|cv|*be
 UG|cy|*aa
 UG|da|*aa
 UG|de|*aa
@@ -43300,12 +43300,12 @@ UG|gl|*aa
 UG|gn|*aa
 UG|gu|યુગાંડા
 UG|gv|*aa
-UG|ha|Yuganda
+UG|ha|*ak
 UG|he|אוגנדה
 UG|hi|युगांडा
 UG|ho|*aa
 UG|hr|*aa
-UG|ht|*aa
+UG|ht|*br
 UG|hu|*aa
 UG|hy|Ուգանդա
 UG|hz|*aa
@@ -43341,7 +43341,7 @@ UG|kw|*aa
 UG|ky|*be
 UG|la|*aa
 UG|lb|*aa
-UG|lg|*ha
+UG|lg|*ak
 UG|li|*aa
 UG|ln|*aa
 UG|lo|ອູການດາ
@@ -43350,7 +43350,7 @@ UG|lu|*aa
 UG|lv|*aa
 UG|mg|Oganda
 UG|mh|*aa
-UG|mi|*aa
+UG|mi|Ukānga
 UG|mk|*be
 UG|ml|ഉഗാണ്ട
 UG|mn|*be
@@ -43372,7 +43372,7 @@ UG|nv|*aa
 UG|ny|*aa
 UG|oc|*aa
 UG|oj|*aa
-UG|om|*aa
+UG|om|Ugaandaa
 UG|or|ଉଗାଣ୍ଡା
 UG|os|*aa
 UG|pa|ਯੂਗਾਂਡਾ
@@ -43408,7 +43408,7 @@ UG|ta|உகாண்டா
 UG|te|ఉగాండా
 UG|tg|*be
 UG|th|ยูกันดา
-UG|ti|*am
+UG|ti|ኡጋንዳ
 UG|tk|*aa
 UG|tl|*aa
 UG|tn|*aa
@@ -43427,7 +43427,7 @@ UG|vi|*aa
 UG|vo|*aa
 UG|wa|*aa
 UG|wo|Ugànda
-UG|xh|*aa
+UG|xh|E-Uganda
 UG|yi|*ji
 UG|yo|*aa
 UG|za|*aa
@@ -43437,7 +43437,7 @@ UM|aa|U.S. Outlying Islands
 UM|ab|*aa
 UM|ae|*aa
 UM|af|Klein afgeleë eilande van die VSA
-UM|ak|*aa
+UM|ak|U.S. Nkyɛnnkyɛn Supɔ Ahodoɔ
 UM|am|የዩ ኤስ ጠረፍ ላይ ያሉ ደሴቶች
 UM|an|*aa
 UM|ar|جزر الولايات المتحدة النائية
@@ -43455,14 +43455,14 @@ UM|bn|যুক্তরাষ্ট্রের পার্শ্ববর্�
 UM|bo|*aa
 UM|br|Inizi diabell ar Stadoù-Unanet
 UM|bs|Američka Vanjska Ostrva
-UM|ca|Illes Perifèriques Menors dels EUA
+UM|ca|Illes Menors Allunyades dels Estats Units
 UM|ce|АЦШн арахьара кегийн гӀайренаш
 UM|ch|*aa
 UM|co|*aa
 UM|cr|*aa
 UM|cs|Menší odlehlé ostrovy USA
 UM|cu|*aa
-UM|cv|*aa
+UM|cv|Тулашӗнчи утравӗсем (АПШ)
 UM|cy|Ynysoedd Pellennig UDA
 UM|da|Amerikanske oversøiske øer
 UM|de|Amerikanische Überseeinseln
@@ -43493,11 +43493,11 @@ UM|he|האיים המרוחקים הקטנים של ארה״ב
 UM|hi|यू॰एस॰ आउटलाइंग द्वीपसमूह
 UM|ho|*aa
 UM|hr|Mali udaljeni otoci SAD-a
-UM|ht|*aa
+UM|ht|*fr
 UM|hu|Az USA lakatlan külbirtokai
 UM|hy|Արտաքին կղզիներ (ԱՄՆ)
 UM|hz|*aa
-UM|ia|*aa
+UM|ia|Insulas peripheric del SUA
 UM|id|Kepulauan Terluar AS
 UM|ie|*aa
 UM|ig|Obere Agwaetiti Dị Na Mpụga U.S
@@ -43506,7 +43506,7 @@ UM|ik|*aa
 UM|in|*id
 UM|io|*aa
 UM|is|Smáeyjar Bandaríkjanna
-UM|it|Altre isole americane del Pacifico
+UM|it|Isole Minori Esterne degli Stati Uniti
 UM|iu|*aa
 UM|iw|*he
 UM|ja|合衆国領有小離島
@@ -43523,7 +43523,7 @@ UM|kn|ಯುಎಸ್‌ ಔಟ್‌ಲೇಯಿಂಗ್ ದ್ವೀಪಗಳ
 UM|ko|미국령 해외 제도
 UM|kr|*aa
 UM|ks|یوٗنایٹِڑ سِٹیٹِس ماینَر آوُٹلییِنگ جٔزیٖرٕ
-UM|ku|*aa
+UM|ku|Giravên Biçûk ên Derveyî DYAyê
 UM|kv|*aa
 UM|kw|*aa
 UM|ky|АКШнын сырткы аралдары
@@ -43538,7 +43538,7 @@ UM|lu|*aa
 UM|lv|ASV Mazās Aizjūras salas
 UM|mg|*aa
 UM|mh|*aa
-UM|mi|*aa
+UM|mi|Ngā Moutere Amerika o Waho
 UM|mk|Американски територии во Пацификот
 UM|ml|യു.എസ്. ദ്വീപസമൂഹങ്ങൾ
 UM|mn|Америкийн Нэгдсэн Улсын бага арлууд
@@ -43560,7 +43560,7 @@ UM|nv|*aa
 UM|ny|*aa
 UM|oc|*aa
 UM|oj|*aa
-UM|om|*aa
+UM|om|U.S. Odoloota Alaa
 UM|or|ଯୁକ୍ତରାଷ୍ଟ୍ର ଆଉଟ୍‌ଲାଇଙ୍ଗ ଦ୍ଵୀପପୁଞ୍ଜ
 UM|os|*aa
 UM|pa|ਯੂ.ਐੱਸ. ਦੂਰ-ਦੁਰਾਡੇ ਟਾਪੂ
@@ -43575,7 +43575,7 @@ UM|ro|*mo
 UM|ru|Внешние малые о-ва (США)
 UM|rw|*aa
 UM|sa|*aa
-UM|sc|*aa
+UM|sc|Ìsulas perifèricas de sos Istados Unidos
 UM|sd|آمريڪي خارجي ٻيٽ
 UM|se|*aa
 UM|sg|*aa
@@ -43596,7 +43596,7 @@ UM|ta|யூ.எஸ். வெளிப்புறத் தீவுகள்
 UM|te|సంయుక్త రాజ్య అమెరికా బయట ఉన్న దీవులు
 UM|tg|Ҷазираҳои Хурди Дурдасти ИМА
 UM|th|หมู่เกาะรอบนอกของสหรัฐอเมริกา
-UM|ti|ናይ ኣሜሪካ ፍንትት ዝበሉ ደሴታት
+UM|ti|ካብ ኣመሪካ ርሒቐን ንኣሽቱ ደሴታት
 UM|tk|ABŞ-nyň daşarky adalary
 UM|tl|*aa
 UM|tn|*aa
@@ -43615,12 +43615,12 @@ UM|vi|Các tiểu đảo xa của Hoa Kỳ
 UM|vo|*aa
 UM|wa|*aa
 UM|wo|Duni Amerig Utar meer
-UM|xh|*aa
+UM|xh|I-U.S. Outlying Islands
 UM|yi|*aa
 UM|yo|Àwọn Erékùsù Kékèké Agbègbè US
 UM|za|*aa
 UM|zh|美国本土外小岛屿
-UM|zu|I-U.S. Outlying Islands
+UM|zu|*xh
 US|aa|United States
 US|ab|*aa
 US|ae|*aa
@@ -43634,7 +43634,7 @@ US|av|*aa
 US|ay|*aa
 US|az|Amerika Birləşmiş Ştatları
 US|ba|*aa
-US|be|Злучаныя Штаты
+US|be|Злучаныя Штаты Амерыкі
 US|bg|Съединени щати
 US|bh|*aa
 US|bi|*aa
@@ -43650,7 +43650,7 @@ US|co|*aa
 US|cr|*aa
 US|cs|Spojené státy
 US|cu|*aa
-US|cv|*aa
+US|cv|Пӗрлешӗннӗ Штатсем
 US|cy|Yr Unol Daleithiau
 US|da|USA
 US|de|Vereinigte Staaten
@@ -43672,7 +43672,7 @@ US|fr|États-Unis
 US|fy|Ferienigde Staten
 US|ga|Stáit Aontaithe Mheiriceá
 US|gd|Na Stàitean Aonaichte
-US|gl|Os Estados Unidos
+US|gl|*es
 US|gn|*aa
 US|gu|યુનાઇટેડ સ્ટેટ્સ
 US|gv|*aa
@@ -43681,7 +43681,7 @@ US|he|ארצות הברית
 US|hi|संयुक्त राज्य
 US|ho|*aa
 US|hr|Sjedinjene Američke Države
-US|ht|*aa
+US|ht|*fr
 US|hu|Egyesült Államok
 US|hy|Միացյալ Նահանգներ
 US|hz|*aa
@@ -43748,7 +43748,7 @@ US|nv|*aa
 US|ny|*aa
 US|oc|*aa
 US|oj|*aa
-US|om|*aa
+US|om|Yiinaayitid Isteet
 US|or|ଯୁକ୍ତ ରାଷ୍ଟ୍ର
 US|os|АИШ
 US|pa|ਸੰਯੁਕਤ ਰਾਜ
@@ -43763,7 +43763,7 @@ US|ro|*mo
 US|ru|Соединенные Штаты
 US|rw|*aa
 US|sa|संयुक्त राज्य:
-US|sc|*aa
+US|sc|Istados Unidos
 US|sd|آمريڪا جون گڏيل رياستون
 US|se|Amerihká ovttastuvvan stáhtat
 US|sg|ÂLeaa-Ôko tî Amerika
@@ -43784,7 +43784,7 @@ US|ta|அமெரிக்கா
 US|te|యునైటెడ్ స్టేట్స్
 US|tg|Иёлоти Муттаҳида
 US|th|สหรัฐอเมริกา
-US|ti|አሜሪካ
+US|ti|ኣመሪካ
 US|tk|Amerikanyň Birleşen Ştatlary
 US|tl|*es
 US|tn|*aa
@@ -43803,7 +43803,7 @@ US|vi|Hoa Kỳ
 US|vo|*aa
 US|wa|*aa
 US|wo|Etaa Sini
-US|xh|*aa
+US|xh|EMelika
 US|yi|*ji
 US|yo|Amẹrikà
 US|za|*aa
@@ -43838,7 +43838,7 @@ UY|co|*aa
 UY|cr|*aa
 UY|cs|*aa
 UY|cu|*aa
-UY|cv|*aa
+UY|cv|*be
 UY|cy|*aa
 UY|da|*aa
 UY|de|*aa
@@ -43860,7 +43860,7 @@ UY|fr|*aa
 UY|fy|*aa
 UY|ga|Uragua
 UY|gd|Uruguaidh
-UY|gl|O Uruguai
+UY|gl|*ca
 UY|gn|*aa
 UY|gu|ઉરુગ્વે
 UY|gv|*aa
@@ -43914,7 +43914,7 @@ UY|lu|*ln
 UY|lv|Urugvaja
 UY|mg|Orogoay
 UY|mh|*aa
-UY|mi|*aa
+UY|mi|Urukoi
 UY|mk|Уругвај
 UY|ml|ഉറുഗ്വേ
 UY|mn|*be
@@ -43936,7 +43936,7 @@ UY|nv|*aa
 UY|ny|*aa
 UY|oc|*aa
 UY|oj|*aa
-UY|om|*aa
+UY|om|Yuraagaay
 UY|or|ଉରୁଗୁଏ
 UY|os|*aa
 UY|pa|ਉਰੂਗਵੇ
@@ -43951,7 +43951,7 @@ UY|ro|*aa
 UY|ru|*be
 UY|rw|*aa
 UY|sa|*aa
-UY|sc|*aa
+UY|sc|Uruguày
 UY|sd|يوروگوءِ
 UY|se|*aa
 UY|sg|Uruguëe
@@ -43991,9 +43991,9 @@ UY|vi|*aa
 UY|vo|*aa
 UY|wa|*aa
 UY|wo|Uruge
-UY|xh|*aa
+UY|xh|E-Uruguay
 UY|yi|*ji
-UY|yo|Nruguayi
+UY|yo|Úrúgúwè
 UY|za|*aa
 UY|zh|乌拉圭
 UY|zu|i-Uruguay
@@ -44001,7 +44001,7 @@ UZ|aa|Uzbekistan
 UZ|ab|*aa
 UZ|ae|*aa
 UZ|af|Oesbekistan
-UZ|ak|Uzbɛkistan
+UZ|ak|Usbɛkistan
 UZ|am|ኡዝቤኪስታን
 UZ|an|*aa
 UZ|ar|أوزبكستان
@@ -44026,7 +44026,7 @@ UZ|co|*aa
 UZ|cr|*aa
 UZ|cs|Uzbekistán
 UZ|cu|*aa
-UZ|cv|*aa
+UZ|cv|*bg
 UZ|cy|*aa
 UZ|da|Usbekistan
 UZ|de|*da
@@ -44057,7 +44057,7 @@ UZ|he|אוזבקיסטן
 UZ|hi|उज़्बेकिस्तान
 UZ|ho|*aa
 UZ|hr|*aa
-UZ|ht|*aa
+UZ|ht|*fr
 UZ|hu|Üzbegisztán
 UZ|hy|Ուզբեկստան
 UZ|hz|*aa
@@ -44087,7 +44087,7 @@ UZ|kn|ಉಜ್ಬೇಕಿಸ್ಥಾನ್
 UZ|ko|우즈베키스탄
 UZ|kr|*aa
 UZ|ks|اُزبِکِستان
-UZ|ku|Ûzbêkistan
+UZ|ku|Ozbekistan
 UZ|kv|*aa
 UZ|kw|*aa
 UZ|ky|*kk
@@ -44100,9 +44100,9 @@ UZ|lo|ອຸສເບກິສະຖານ
 UZ|lt|Uzbekistanas
 UZ|lu|Uzibekisita
 UZ|lv|Uzbekistāna
-UZ|mg|Ozbekistan
+UZ|mg|*ku
 UZ|mh|*aa
-UZ|mi|*aa
+UZ|mi|Uhipeketāne
 UZ|mk|*bg
 UZ|ml|ഉസ്‌ബെക്കിസ്ഥാൻ
 UZ|mn|*bg
@@ -44124,7 +44124,7 @@ UZ|nv|*aa
 UZ|ny|*aa
 UZ|oc|*aa
 UZ|oj|*aa
-UZ|om|*aa
+UZ|om|Uzbeekistaan
 UZ|or|ଉଜବେକିସ୍ତାନ
 UZ|os|*aa
 UZ|pa|ਉਜ਼ਬੇਕਿਸਤਾਨ
@@ -44139,7 +44139,7 @@ UZ|ro|*aa
 UZ|ru|*bg
 UZ|rw|*aa
 UZ|sa|*aa
-UZ|sc|*aa
+UZ|sc|Uzbèkistan
 UZ|sd|ازبڪستان
 UZ|se|*da
 UZ|sg|Uzbekistäan
@@ -44160,7 +44160,7 @@ UZ|ta|உஸ்பெகிஸ்தான்
 UZ|te|ఉజ్బెకిస్తాన్
 UZ|tg|Ӯзбекистон
 UZ|th|อุซเบกิสถาน
-UZ|ti|ዩዝበኪስታን
+UZ|ti|ኡዝበኪስታን
 UZ|tk|Özbegistan
 UZ|tl|*aa
 UZ|tn|*aa
@@ -44179,7 +44179,7 @@ UZ|vi|*aa
 UZ|vo|*aa
 UZ|wa|*aa
 UZ|wo|Usbekistaŋ
-UZ|xh|*aa
+UZ|xh|E-Uzbekistan
 UZ|yi|*aa
 UZ|yo|Nṣibẹkisitani
 UZ|za|*aa
@@ -44214,7 +44214,7 @@ VA|co|*aa
 VA|cr|*aa
 VA|cs|Vatikán
 VA|cu|*aa
-VA|cv|*aa
+VA|cv|*bg
 VA|cy|Y Fatican
 VA|da|Vatikanstaten
 VA|de|Vatikanstadt
@@ -44240,12 +44240,12 @@ VA|gl|Cidade do Vaticano
 VA|gn|*aa
 VA|gu|વેટિકન સિટી
 VA|gv|*aa
-VA|ha|Batikan
+VA|ha|Birnin Batikan
 VA|he|הוותיקן
 VA|hi|वेटिकन सिटी
 VA|ho|*aa
-VA|hr|Vatikanski Grad
-VA|ht|*aa
+VA|hr|*az
+VA|ht|*fr
 VA|hu|*cs
 VA|hy|Վատիկան
 VA|hz|*aa
@@ -44290,7 +44290,7 @@ VA|lu|Nvatika
 VA|lv|Vatikāns
 VA|mg|Firenen’i Vatikana
 VA|mh|*aa
-VA|mi|*aa
+VA|mi|Te Poho-o-Pita
 VA|mk|*bg
 VA|ml|വത്തിക്കാൻ
 VA|mn|Ватикан хот улс
@@ -44312,7 +44312,7 @@ VA|nv|*aa
 VA|ny|*aa
 VA|oc|*aa
 VA|oj|*aa
-VA|om|*aa
+VA|om|Vaatikaan Siitii
 VA|or|ଭାଟିକାନ୍ ସିଟି
 VA|os|*aa
 VA|pa|ਵੈਟੀਕਨ ਸਿਟੀ
@@ -44327,7 +44327,7 @@ VA|ro|*mo
 VA|ru|*bg
 VA|rw|*aa
 VA|sa|*aa
-VA|sc|*aa
+VA|sc|Tzitade de su Vaticanu
 VA|sd|ويٽڪين سٽي
 VA|se|Vatikána
 VA|sg|Letëe tî Vatikäan
@@ -44336,7 +44336,7 @@ VA|sk|*cs
 VA|sl|*az
 VA|sm|*aa
 VA|sn|*nd
-VA|so|Faatikaan
+VA|so|Magaalada Faatikaan
 VA|sq|*az
 VA|sr|*bg
 VA|ss|*aa
@@ -44348,14 +44348,14 @@ VA|ta|வாடிகன் நகரம்
 VA|te|వాటికన్ నగరం
 VA|tg|Шаҳри Вотикон
 VA|th|นครวาติกัน
-VA|ti|ቫቲካን
+VA|ti|ከተማ ቫቲካን
 VA|tk|Watikan
 VA|tl|*aa
 VA|tn|*aa
 VA|to|Kolo Vatikani
 VA|tr|*az
 VA|ts|*aa
-VA|tt|*aa
+VA|tt|*bg
 VA|tw|*aa
 VA|ty|*aa
 VA|ug|ۋاتىكان
@@ -44367,7 +44367,7 @@ VA|vi|Thành Vatican
 VA|vo|*aa
 VA|wa|*aa
 VA|wo|Site bu Watikaa
-VA|xh|*aa
+VA|xh|EVatican City
 VA|yi|*ji
 VA|yo|Ìlú Vatican
 VA|za|*aa
@@ -44378,7 +44378,7 @@ VC|ab|*aa
 VC|ae|*aa
 VC|af|Sint Vincent en die Grenadine
 VC|ak|Saint Vincent ne Grenadines
-VC|am|ቅዱስ ቪንሴንት እና ግሬናዲንስ
+VC|am|ሴንት ቪንሴንት እና ግሬናዲንስ
 VC|an|*aa
 VC|ar|سانت فنسنت وجزر غرينادين
 VC|as|ছেইণ্ট ভিনচেণ্ট আৰু গ্ৰীণাডাইনছ
@@ -44402,7 +44402,7 @@ VC|co|*aa
 VC|cr|*aa
 VC|cs|Svatý Vincenc a Grenadiny
 VC|cu|*aa
-VC|cv|*aa
+VC|cv|Сент-Винсент тата Гренадины
 VC|cy|Saint Vincent a’r Grenadines
 VC|da|Saint Vincent og Grenadinerne
 VC|de|St. Vincent und die Grenadinen
@@ -44411,7 +44411,7 @@ VC|dz|སེནཊ་ཝིན་སེནཌ྄ ཨེནཌ་ གི་རེ
 VC|ee|Saint Vincent kple Grenadine nutome
 VC|el|Άγιος Βικέντιος και Γρεναδίνες
 VC|en|*aa
-VC|eo|Sent-Vincento kaj la Grenadinoj
+VC|eo|Sankta Vincento kaj Grenadinoj
 VC|es|San Vicente y las Granadinas
 VC|et|Saint Vincent ja Grenadiinid
 VC|eu|Saint Vincent eta Grenadinak
@@ -44424,7 +44424,7 @@ VC|fr|Saint-Vincent-et-les Grenadines
 VC|fy|Saint Vincent en de Grenadines
 VC|ga|San Uinseann agus na Greanáidíní
 VC|gd|Naomh Bhionsant agus Eileanan Greanadach
-VC|gl|San Vicente e As Granadinas
+VC|gl|San Vicente e as Granadinas
 VC|gn|*aa
 VC|gu|સેંટ વિન્સેંટ અને ગ્રેનેડાઇંસ
 VC|gv|*aa
@@ -44433,14 +44433,14 @@ VC|he|סנט וינסנט והגרנדינים
 VC|hi|सेंट विंसेंट और ग्रेनाडाइंस
 VC|ho|*aa
 VC|hr|Sveti Vincent i Grenadini
-VC|ht|*aa
+VC|ht|*fr
 VC|hu|Saint Vincent és a Grenadine-szigetek
 VC|hy|Սենթ Վինսենթ և Գրենադիններ
 VC|hz|*aa
 VC|ia|Sancte Vincente e le Grenadinas
 VC|id|Saint Vincent dan Grenadine
 VC|ie|*aa
-VC|ig|Vincent na Grenadines Dị nsọ
+VC|ig|*aa
 VC|ii|*aa
 VC|ik|*aa
 VC|in|*id
@@ -44463,7 +44463,7 @@ VC|kn|ಸೇಂಟ್. ವಿನ್ಸೆಂಟ್ ಮತ್ತು ಗ್ರೆ�
 VC|ko|세인트빈센트그레나딘
 VC|kr|*aa
 VC|ks|سینٹ وینسؠٹ تہٕ گریناڑاینٕز
-VC|ku|Saint Vincent û Giravên Grenadîn
+VC|ku|Saint Vincent û Giravên Grenadînê
 VC|kv|*aa
 VC|kw|*aa
 VC|ky|Сент-Винсент жана Гренадиндер
@@ -44478,7 +44478,7 @@ VC|lu|Santu vesa ne Ngelenadine
 VC|lv|Sentvinsenta un Grenadīnas
 VC|mg|*fr
 VC|mh|*aa
-VC|mi|*aa
+VC|mi|Hato Wēneti me Keretīni
 VC|mk|Сент Винсент и Гренадини
 VC|ml|സെന്റ് വിൻസെന്റും ഗ്രനെഡൈൻസും
 VC|mn|Сент-Винсент ба Гренадин
@@ -44500,8 +44500,8 @@ VC|nv|*aa
 VC|ny|*aa
 VC|oc|*aa
 VC|oj|*aa
-VC|om|*aa
-VC|or|ସେଣ୍ଟ ଭିନସେଣ୍ଟ ଏବଂ ଦି ଗ୍ରେନାଡିସ୍
+VC|om|St. Vinseet fi Gireenadines
+VC|or|ସେଣ୍ଟ ଭିନସେଣ୍ଟ ଏବଂ ଗ୍ରେନାଡାଇନ୍ସ
 VC|os|*aa
 VC|pa|ਸੇਂਟ ਵਿਨਸੈਂਟ ਐਂਡ ਗ੍ਰੇਨਾਡੀਨਸ
 VC|pi|*aa
@@ -44515,7 +44515,7 @@ VC|ro|*mo
 VC|ru|Сент-Винсент и Гренадины
 VC|rw|*aa
 VC|sa|*aa
-VC|sc|*aa
+VC|sc|Santu Vissente e sas Grenadinas
 VC|sd|سینٽ ونسنت ۽ گریناڊینز
 VC|se|Saint Vincent ja Grenadine
 VC|sg|Sên-Vensäan na âGrenadîni
@@ -44536,7 +44536,7 @@ VC|ta|செயின்ட் வின்சென்ட் & கிரென�
 VC|te|సెయింట్ విన్సెంట్ మరియు గ్రెనడీన్స్
 VC|tg|Сент-Винсент ва Гренадина
 VC|th|เซนต์วินเซนต์และเกรนาดีนส์
-VC|ti|ቅዱስ ቪንሴንትን ግሬናዲንስን
+VC|ti|ቅዱስ ቪንሰንትን ግረነዲነዝን
 VC|tk|Sent-Winsent we Grenadinler
 VC|tl|*aa
 VC|tn|*aa
@@ -44555,7 +44555,7 @@ VC|vi|St. Vincent và Grenadines
 VC|vo|*aa
 VC|wa|*aa
 VC|wo|Saŋ Weesaa ak Garanadin
-VC|xh|*aa
+VC|xh|ESt. Vincent & Grenadines
 VC|yi|*aa
 VC|yo|Fisẹnnti ati Genadina
 VC|za|*aa
@@ -44590,7 +44590,7 @@ VE|co|*aa
 VE|cr|*aa
 VE|cs|*aa
 VE|cu|*aa
-VE|cv|*aa
+VE|cv|*be
 VE|cy|*aa
 VE|da|*aa
 VE|de|*aa
@@ -44666,7 +44666,7 @@ VE|lu|*aa
 VE|lv|Venecuēla
 VE|mg|Venezoelà
 VE|mh|*aa
-VE|mi|*aa
+VE|mi|Penehūera
 VE|mk|*bg
 VE|ml|വെനിസ്വേല
 VE|mn|Венесуэл
@@ -44688,7 +44688,7 @@ VE|nv|*aa
 VE|ny|*aa
 VE|oc|*aa
 VE|oj|*aa
-VE|om|*aa
+VE|om|Veenzuweelaa
 VE|or|ଭେନେଜୁଏଲା
 VE|os|*aa
 VE|pa|ਵੇਨੇਜ਼ੂਏਲਾ
@@ -44703,7 +44703,7 @@ VE|ro|*aa
 VE|ru|*be
 VE|rw|*aa
 VE|sa|*aa
-VE|sc|*aa
+VE|sc|Venetzuela
 VE|sd|وينزويلا
 VE|se|*aa
 VE|sg|Venezueläa
@@ -44724,7 +44724,7 @@ VE|ta|வெனிசுலா
 VE|te|వెనిజులా
 VE|tg|*be
 VE|th|เวเนซุเอลา
-VE|ti|*am
+VE|ti|ቬኔዝዌላ
 VE|tk|Wenesuela
 VE|tl|*aa
 VE|tn|*aa
@@ -44743,7 +44743,7 @@ VE|vi|*aa
 VE|vo|*aa
 VE|wa|*aa
 VE|wo|Wenesiyela
-VE|xh|*aa
+VE|xh|EVenezuela
 VE|yi|*ji
 VE|yo|Fẹnẹṣuẹla
 VE|za|*aa
@@ -44753,7 +44753,7 @@ VG|aa|British Virgin Islands
 VG|ab|*aa
 VG|ae|*aa
 VG|af|Britse Maagde-eilande
-VG|ak|Britainfo Virgin Islands
+VG|ak|Ngresifoɔ Virgin Island
 VG|am|የእንግሊዝ ቨርጂን ደሴቶች
 VG|an|*aa
 VG|ar|جزر فيرجن البريطانية
@@ -44778,7 +44778,7 @@ VG|co|*aa
 VG|cr|*aa
 VG|cs|Britské Panenské ostrovy
 VG|cu|*aa
-VG|cv|*aa
+VG|cv|Британин Виргини утравӗсем
 VG|cy|Ynysoedd Gwyryf Prydain
 VG|da|De Britiske Jomfruøer
 VG|de|Britische Jungferninseln
@@ -44808,15 +44808,15 @@ VG|ha|Tsibirin Birjin Na Birtaniya
 VG|he|איי הבתולה הבריטיים
 VG|hi|ब्रिटिश वर्जिन द्वीपसमूह
 VG|ho|*aa
-VG|hr|Britanski Djevičanski otoci
-VG|ht|*aa
+VG|hr|Britanski Djevičanski Otoci
+VG|ht|*fr
 VG|hu|Brit Virgin-szigetek
 VG|hy|Բրիտանական Վիրջինյան կղզիներ
 VG|hz|*aa
-VG|ia|*aa
+VG|ia|Insulas Virgine britannic
 VG|id|Kepulauan Virgin Britania Raya
 VG|ie|*aa
-VG|ig|Agwaetiti British Virgin
+VG|ig|*aa
 VG|ii|*aa
 VG|ik|*aa
 VG|in|*id
@@ -44839,7 +44839,7 @@ VG|kn|ಬ್ರಿಟಿಷ್ ವರ್ಜಿನ್ ದ್ವೀಪಗಳು
 VG|ko|영국령 버진아일랜드
 VG|kr|*aa
 VG|ks|بَرطانوی ؤرجِن جٔزیٖرٕ
-VG|ku|*aa
+VG|ku|Giravên Vîrjînê yên Brîtanyayê
 VG|kv|*aa
 VG|kw|*aa
 VG|ky|Виргин аралдары (Британия)
@@ -44854,7 +44854,7 @@ VG|lu|Lutanda lua Vierzi wa Angeletele
 VG|lv|Britu Virdžīnas
 VG|mg|Nosy britanika virijiny
 VG|mh|*aa
-VG|mi|*aa
+VG|mi|Ngā Moutere Puhi Piritene
 VG|mk|Британски Девствени Острови
 VG|ml|ബ്രിട്ടീഷ് വെർജിൻ ദ്വീപുകൾ
 VG|mn|Британийн Виржиний арлууд
@@ -44876,7 +44876,7 @@ VG|nv|*aa
 VG|ny|*aa
 VG|oc|*aa
 VG|oj|*aa
-VG|om|*aa
+VG|om|Odoloota Varjiin Biritish
 VG|or|ବ୍ରିଟିଶ୍‌ ଭର୍ଜିନ୍ ଦ୍ୱୀପପୁଞ୍ଜ
 VG|os|*aa
 VG|pa|ਬ੍ਰਿਟਿਸ਼ ਵਰਜਿਨ ਟਾਪੂ
@@ -44891,7 +44891,7 @@ VG|ro|*mo
 VG|ru|Виргинские о-ва (Великобритания)
 VG|rw|*aa
 VG|sa|*aa
-VG|sc|*aa
+VG|sc|Ìsulas Vèrgines Britànnicas
 VG|sd|برطانوي ورجن ٻيٽ
 VG|se|Brittania Virgin-sullot
 VG|sg|Âzôâ Viîrîggo tî Anglëe
@@ -44912,7 +44912,7 @@ VG|ta|பிரிட்டீஷ் கன்னித் தீவுகள்
 VG|te|బ్రిటిష్ వర్జిన్ దీవులు
 VG|tg|Ҷазираҳои Виргини Британия
 VG|th|หมู่เกาะบริติชเวอร์จิน
-VG|ti|ደሴታት ቨርጂን ብሪጣኒያ
+VG|ti|ደሴታት ደናግል ብሪጣንያ
 VG|tk|Britan Wirgin adalary
 VG|tl|*aa
 VG|tn|*aa
@@ -44931,7 +44931,7 @@ VG|vi|Quần đảo Virgin thuộc Anh
 VG|vo|*aa
 VG|wa|*aa
 VG|wo|Duni Wirsin yu Brëtaañ
-VG|xh|*aa
+VG|xh|EBritish Virgin Islands
 VG|yi|*aa
 VG|yo|Etíkun Fágínì ti ìlú Bírítísì
 VG|za|*aa
@@ -44944,7 +44944,7 @@ VI|af|VSA se Maagde-eilande
 VI|ak|Amɛrika Virgin Islands
 VI|am|የአሜሪካ ቨርጂን ደሴቶች
 VI|an|*aa
-VI|ar|جزر فيرجن التابعة للولايات المتحدة
+VI|ar|جزر فيرجن الأمريكية
 VI|as|ইউ. এছ. ভাৰ্জিন দ্বীপপুঞ্জ
 VI|av|*aa
 VI|ay|*aa
@@ -44955,18 +44955,18 @@ VI|bg|Американски Вирджински острови
 VI|bh|*aa
 VI|bi|*aa
 VI|bm|Ameriki ka Sungurunnin Gun
-VI|bn|মার্কিন যুক্তরাষ্ট্রের ভার্জিন দ্বীপপুঞ্জ
+VI|bn|মার্কিন যুক্তরাষ্ট্রীয় ভার্জিন দ্বীপপুঞ্জ
 VI|bo|*aa
 VI|br|Inizi Gwercʼh ar Stadoù-Unanet
 VI|bs|Američka Djevičanska ostrva
-VI|ca|Illes Verges Nord-americanes
+VI|ca|Illes Verges dels Estats Units
 VI|ce|Виргинийн гӀайренаш (АЦШ)
 VI|ch|*aa
 VI|co|*aa
 VI|cr|*aa
 VI|cs|Americké Panenské ostrovy
 VI|cu|*aa
-VI|cv|*aa
+VI|cv|Виргини утравӗсем (АПШ)
 VI|cy|Ynysoedd Gwyryf yr Unol Daleithiau
 VI|da|De Amerikanske Jomfruøer
 VI|de|Amerikanische Jungferninseln
@@ -44996,15 +44996,15 @@ VI|ha|Tsibiran Birjin Ta Amurka
 VI|he|איי הבתולה של ארצות הברית
 VI|hi|यू॰एस॰ वर्जिन द्वीपसमूह
 VI|ho|*aa
-VI|hr|Američki Djevičanski otoci
-VI|ht|*aa
+VI|hr|Američki Djevičanski Otoci
+VI|ht|*fr
 VI|hu|Amerikai Virgin-szigetek
 VI|hy|ԱՄՆ Վիրջինյան կղզիներ
 VI|hz|*aa
-VI|ia|*aa
+VI|ia|Insulas Virgine statounitese
 VI|id|Kepulauan Virgin Amerika Serikat
 VI|ie|*aa
-VI|ig|Agwaetiti Virgin nke US
+VI|ig|*aa
 VI|ii|*aa
 VI|ik|*aa
 VI|in|*id
@@ -45027,7 +45027,7 @@ VI|kn|ಯು.ಎಸ್. ವರ್ಜಿನ್ ದ್ವೀಪಗಳು
 VI|ko|미국령 버진아일랜드
 VI|kr|*aa
 VI|ks|یوٗ ایس ؤرجِن جٔزیٖرٕ
-VI|ku|*aa
+VI|ku|Giravên Vîrjînê yên Amerîkayê
 VI|kv|*aa
 VI|kw|*aa
 VI|ky|Виргин аралдары (АКШ)
@@ -45042,7 +45042,7 @@ VI|lu|Lutanda lua Vierzi wa Ameriki
 VI|lv|ASV Virdžīnas
 VI|mg|Nosy Virijiny Etazonia
 VI|mh|*aa
-VI|mi|*aa
+VI|mi|Ngā Moutere Puhi Amerika
 VI|mk|Американски Девствени Острови
 VI|ml|യു.എസ്. വെർജിൻ ദ്വീപുകൾ
 VI|mn|АНУ-ын Виржиний арлууд
@@ -45064,8 +45064,8 @@ VI|nv|*aa
 VI|ny|*aa
 VI|oc|*aa
 VI|oj|*aa
-VI|om|*aa
-VI|or|ଯୁକ୍ତରାଷ୍ଟ୍ର ଭିର୍ଜିନ୍ ଦ୍ଵୀପପୁଞ୍ଜ
+VI|om|U.S. Odoloota Varjiin
+VI|or|ଯୁକ୍ତରାଷ୍ଟ୍ର ଭର୍ଜିନ୍ ଦ୍ଵୀପପୁଞ୍ଜ
 VI|os|*aa
 VI|pa|ਯੂ ਐੱਸ ਵਰਜਿਨ ਟਾਪੂ
 VI|pi|*aa
@@ -45079,7 +45079,7 @@ VI|ro|*mo
 VI|ru|Виргинские о-ва (США)
 VI|rw|*aa
 VI|sa|*aa
-VI|sc|*aa
+VI|sc|Ìsulas Vèrgines de sos Istados Unidos
 VI|sd|آمريڪي ورجن ٻيٽ
 VI|se|AOS Virgin-sullot
 VI|sg|Âzûâ Virîgo tî Amerîka
@@ -45100,7 +45100,7 @@ VI|ta|யூ.எஸ். கன்னித் தீவுகள்
 VI|te|యు.ఎస్. వర్జిన్ దీవులు
 VI|tg|Ҷазираҳои Виргини ИМА
 VI|th|หมู่เกาะเวอร์จินของสหรัฐอเมริกา
-VI|ti|ቨርጂን ደሴታት ኣሜሪካ
+VI|ti|ደሴታት ደናግል ኣመሪካ
 VI|tk|ABŞ-nyň Wirgin adalary
 VI|tl|*aa
 VI|tn|*aa
@@ -45119,7 +45119,7 @@ VI|vi|Quần đảo Virgin thuộc Hoa Kỳ
 VI|vo|*aa
 VI|wa|*aa
 VI|wo|Duni Wirsin yu Etaa-sini
-VI|xh|*aa
+VI|xh|E-U.S. Virgin Islands
 VI|yi|*aa
 VI|yo|Etikun Fagini ti Amẹrika
 VI|za|*aa
@@ -45154,7 +45154,7 @@ VN|co|*aa
 VN|cr|*aa
 VN|cs|*aa
 VN|cu|*aa
-VN|cv|*aa
+VN|cv|*ce
 VN|cy|Fietnam
 VN|da|*aa
 VN|de|*aa
@@ -45185,7 +45185,7 @@ VN|he|וייטנאם
 VN|hi|वियतनाम
 VN|ho|*aa
 VN|hr|*bs
-VN|ht|*aa
+VN|ht|*br
 VN|hu|Vietnám
 VN|hy|Վիետնամ
 VN|hz|*aa
@@ -45214,8 +45214,8 @@ VN|km|វៀតណាម
 VN|kn|ವಿಯೆಟ್ನಾಮ್
 VN|ko|베트남
 VN|kr|*aa
-VN|ks|ویٹِنام
-VN|ku|Viyetnam
+VN|ks|*fa
+VN|ku|Vîetnam
 VN|kv|*aa
 VN|kw|*aa
 VN|ky|*ce
@@ -45230,7 +45230,7 @@ VN|lu|Viyetiname
 VN|lv|Vjetnama
 VN|mg|*aa
 VN|mh|*aa
-VN|mi|*aa
+VN|mi|Whitināmu
 VN|mk|*bg
 VN|ml|വിയറ്റ്നാം
 VN|mn|*ce
@@ -45252,7 +45252,7 @@ VN|nv|*aa
 VN|ny|*aa
 VN|oc|*aa
 VN|oj|*aa
-VN|om|*aa
+VN|om|Veetinaam
 VN|or|ଭିଏତନାମ୍
 VN|os|*aa
 VN|pa|ਵੀਅਤਨਾਮ
@@ -45307,7 +45307,7 @@ VN|vi|Việt Nam
 VN|vo|*aa
 VN|wa|*aa
 VN|wo|Wiyetnam
-VN|xh|*aa
+VN|xh|EVietnam
 VN|yi|*ji
 VN|yo|Fẹtinami
 VN|za|*aa
@@ -45342,7 +45342,7 @@ VU|co|*aa
 VU|cr|*aa
 VU|cs|*aa
 VU|cu|*aa
-VU|cv|*aa
+VU|cv|*be
 VU|cy|*aa
 VU|da|*aa
 VU|de|*aa
@@ -45418,7 +45418,7 @@ VU|lu|*aa
 VU|lv|*aa
 VU|mg|Vanoatò
 VU|mh|*aa
-VU|mi|*aa
+VU|mi|Whenuatū
 VU|mk|*be
 VU|ml|വന്വാതു
 VU|mn|*be
@@ -45440,7 +45440,7 @@ VU|nv|*aa
 VU|ny|*aa
 VU|oc|*aa
 VU|oj|*aa
-VU|om|*aa
+VU|om|Vanuwaatu
 VU|or|ଭାନୁଆତୁ
 VU|os|*aa
 VU|pa|ਵਾਨੂਆਟੂ
@@ -45476,7 +45476,7 @@ VU|ta|வனுவாட்டு
 VU|te|వనాటు
 VU|tg|*be
 VU|th|วานูอาตู
-VU|ti|*am
+VU|ti|ቫንዋቱ
 VU|tk|Wanuatu
 VU|tl|*aa
 VU|tn|*aa
@@ -45495,7 +45495,7 @@ VU|vi|*aa
 VU|vo|*aa
 VU|wa|*aa
 VU|wo|*tk
-VU|xh|*aa
+VU|xh|EVanuatu
 VU|yi|*ji
 VU|yo|Faniatu
 VU|za|*aa
@@ -45530,7 +45530,7 @@ WF|co|*aa
 WF|cr|*aa
 WF|cs|Wallis a Futuna
 WF|cu|*aa
-WF|cv|*aa
+WF|cv|Уоллис тата Футуна
 WF|cy|*cs
 WF|da|Wallis og Futuna
 WF|de|Wallis und Futuna
@@ -45561,11 +45561,11 @@ WF|he|איי ווליס ופוטונה
 WF|hi|वालिस और फ़्यूचूना
 WF|ho|*aa
 WF|hr|*ca
-WF|ht|*aa
+WF|ht|*fr
 WF|hu|Wallis és Futuna
 WF|hy|Ուոլիս և Ֆուտունա
 WF|hz|*aa
-WF|ia|*aa
+WF|ia|*gl
 WF|id|Kepulauan Wallis dan Futuna
 WF|ie|*aa
 WF|ig|*aa
@@ -45606,7 +45606,7 @@ WF|lu|Walise ne Futuna
 WF|lv|Volisa un Futunas salas
 WF|mg|Wallis sy Futuna
 WF|mh|*aa
-WF|mi|*aa
+WF|mi|Warihi me Whutuna
 WF|mk|Валис и Футуна
 WF|ml|വാലിസ് ആന്റ് ഫ്യൂച്യുന
 WF|mn|Уоллис ба Футуна
@@ -45628,7 +45628,7 @@ WF|nv|*aa
 WF|ny|*aa
 WF|oc|*aa
 WF|oj|*aa
-WF|om|*aa
+WF|om|Waalis fi Futtuuna
 WF|or|ୱାଲିସ୍ ଏବଂ ଫୁତୁନା
 WF|os|*aa
 WF|pa|ਵਾਲਿਸ ਅਤੇ ਫੂਟੂਨਾ
@@ -45643,7 +45643,7 @@ WF|ro|*mo
 WF|ru|Уоллис и Футуна
 WF|rw|*aa
 WF|sa|*aa
-WF|sc|*aa
+WF|sc|*gl
 WF|sd|والس ۽ فتونا
 WF|se|*et
 WF|sg|Walîsi na Futuna
@@ -45683,7 +45683,7 @@ WF|vi|Wallis và Futuna
 WF|vo|*aa
 WF|wa|*aa
 WF|wo|Walis ak Futuna
-WF|xh|*aa
+WF|xh|EWallis & Futuna
 WF|yi|*aa
 WF|yo|Wali ati futuna
 WF|za|*aa
@@ -45718,7 +45718,7 @@ WS|co|*aa
 WS|cr|*aa
 WS|cs|*aa
 WS|cu|*aa
-WS|cv|*aa
+WS|cv|*be
 WS|cy|*aa
 WS|da|*aa
 WS|de|*aa
@@ -45778,7 +45778,7 @@ WS|km|សាម័រ
 WS|kn|ಸಮೋವಾ
 WS|ko|사모아
 WS|kr|*aa
-WS|ks|سیمووا
+WS|ks|سامو
 WS|ku|*aa
 WS|kv|*aa
 WS|kw|*aa
@@ -45794,7 +45794,7 @@ WS|lu|*aa
 WS|lv|*aa
 WS|mg|*aa
 WS|mh|*aa
-WS|mi|*aa
+WS|mi|Hāmoa
 WS|mk|*be
 WS|ml|സമോവ
 WS|mn|*be
@@ -45816,7 +45816,7 @@ WS|nv|*aa
 WS|ny|*aa
 WS|oc|*aa
 WS|oj|*aa
-WS|om|*aa
+WS|om|Saamowa
 WS|or|ସାମୋଆ
 WS|os|*aa
 WS|pa|ਸਾਮੋਆ
@@ -45852,7 +45852,7 @@ WS|ta|சமோவா
 WS|te|సమోవా
 WS|tg|*be
 WS|th|ซามัว
-WS|ti|*am
+WS|ti|ሳሞኣ
 WS|tk|*aa
 WS|tl|*aa
 WS|tn|*aa
@@ -45871,7 +45871,7 @@ WS|vi|*aa
 WS|vo|*aa
 WS|wa|*aa
 WS|wo|*bm
-WS|xh|*aa
+WS|xh|ESamoa
 WS|yi|*ji
 WS|yo|Samọ
 WS|za|*aa
@@ -45881,7 +45881,7 @@ YE|aa|Yemen
 YE|ab|*aa
 YE|ae|*aa
 YE|af|Jemen
-YE|ak|Yɛmen
+YE|ak|Yɛmɛn
 YE|am|የመን
 YE|an|*aa
 YE|ar|اليمن
@@ -45906,7 +45906,7 @@ YE|co|*aa
 YE|cr|*aa
 YE|cs|*af
 YE|cu|*aa
-YE|cv|*aa
+YE|cv|*bg
 YE|cy|*aa
 YE|da|*aa
 YE|de|*af
@@ -45928,16 +45928,16 @@ YE|fr|Yémen
 YE|fy|*af
 YE|ga|Éimin
 YE|gd|An Eaman
-YE|gl|O Iemen
+YE|gl|*ca
 YE|gn|*aa
 YE|gu|યમન
 YE|gv|*aa
-YE|ha|Yamal
+YE|ha|Yamen
 YE|he|תימן
 YE|hi|यमन
 YE|ho|*aa
 YE|hr|*af
-YE|ht|*aa
+YE|ht|*fr
 YE|hu|*af
 YE|hy|Եմեն
 YE|hz|*aa
@@ -45982,7 +45982,7 @@ YE|lu|Yemenu
 YE|lv|Jemena
 YE|mg|*aa
 YE|mh|*aa
-YE|mi|*aa
+YE|mi|Īmene
 YE|mk|Јемен
 YE|ml|യെമൻ
 YE|mn|*bg
@@ -46059,7 +46059,7 @@ YE|vi|*aa
 YE|vo|*aa
 YE|wa|*aa
 YE|wo|*id
-YE|xh|*aa
+YE|xh|EYemen
 YE|yi|*he
 YE|yo|*ki
 YE|za|*aa
@@ -46094,7 +46094,7 @@ YT|co|*aa
 YT|cr|*aa
 YT|cs|*aa
 YT|cu|*aa
-YT|cv|*aa
+YT|cv|*ce
 YT|cy|*aa
 YT|da|*aa
 YT|de|*aa
@@ -46170,7 +46170,7 @@ YT|lu|Mayote
 YT|lv|Majota
 YT|mg|Mayôty
 YT|mh|*aa
-YT|mi|*aa
+YT|mi|Māiota
 YT|mk|Мајот
 YT|ml|മയോട്ടി
 YT|mn|*ce
@@ -46192,7 +46192,7 @@ YT|nv|*aa
 YT|ny|*aa
 YT|oc|*aa
 YT|oj|*aa
-YT|om|*aa
+YT|om|Maayootee
 YT|or|ମାୟୋଟେ
 YT|os|*aa
 YT|pa|ਮਾਯੋਟੀ
@@ -46228,7 +46228,7 @@ YT|ta|மயோட்
 YT|te|మాయొట్
 YT|tg|*ce
 YT|th|มายอต
-YT|ti|*am
+YT|ti|ማዮት
 YT|tk|Maýotta
 YT|tl|*aa
 YT|tn|*aa
@@ -46247,7 +46247,7 @@ YT|vi|*aa
 YT|vo|*aa
 YT|wa|*aa
 YT|wo|*az
-YT|xh|*aa
+YT|xh|EMayotte
 YT|yi|*ji
 YT|yo|*lu
 YT|za|*aa
@@ -46257,7 +46257,7 @@ ZA|aa|South Africa
 ZA|ab|*aa
 ZA|ae|*aa
 ZA|af|Suid-Afrika
-ZA|ak|Afrika Anaafo
+ZA|ak|Abibirem Anaafoɔ
 ZA|am|ደቡብ አፍሪካ
 ZA|an|*aa
 ZA|ar|جنوب أفريقيا
@@ -46275,14 +46275,14 @@ ZA|bn|*as
 ZA|bo|*aa
 ZA|br|Suafrika
 ZA|bs|Južnoafrička Republika
-ZA|ca|República de Sud-àfrica
+ZA|ca|Sud-àfrica
 ZA|ce|Къилба-Африкин Республика
 ZA|ch|*aa
 ZA|co|*aa
 ZA|cr|*aa
 ZA|cs|Jihoafrická republika
 ZA|cu|*aa
-ZA|cv|*aa
+ZA|cv|Кӑнтӑр Африка Республики
 ZA|cy|De Affrica
 ZA|da|Sydafrika
 ZA|de|Südafrika
@@ -46313,11 +46313,11 @@ ZA|he|דרום אפריקה
 ZA|hi|दक्षिण अफ़्रीका
 ZA|ho|*aa
 ZA|hr|*bs
-ZA|ht|*aa
+ZA|ht|*fr
 ZA|hu|Dél-afrikai Köztársaság
 ZA|hy|Հարավաֆրիկյան Հանրապետություն
 ZA|hz|*aa
-ZA|ia|Sudafrica
+ZA|ia|Africa del Sud
 ZA|id|Afrika Selatan
 ZA|ie|*aa
 ZA|ig|*aa
@@ -46326,7 +46326,7 @@ ZA|ik|*aa
 ZA|in|*id
 ZA|io|*aa
 ZA|is|Suður-Afríka
-ZA|it|*ia
+ZA|it|Sudafrica
 ZA|iu|*aa
 ZA|iw|*he
 ZA|ja|南アフリカ
@@ -46336,13 +46336,13 @@ ZA|ka|სამხრეთ აფრიკის რესპუბლიკა
 ZA|kg|*aa
 ZA|ki|Afrika Kusini
 ZA|kj|*aa
-ZA|kk|Оңтүстік Африка Республикасы
+ZA|kk|Оңтүстік Африка
 ZA|kl|*aa
 ZA|km|អាហ្វ្រិកខាងត្បូង
 ZA|kn|ದಕ್ಷಿಣ ಆಫ್ರಿಕಾ
 ZA|ko|남아프리카
 ZA|kr|*aa
-ZA|ks|جَنوٗبی اَفریٖکا
+ZA|ks|جنوبی افریقہ
 ZA|ku|Afrîkaya Başûr
 ZA|kv|*aa
 ZA|kw|*aa
@@ -46358,7 +46358,7 @@ ZA|lu|Afrika ya Súdi
 ZA|lv|Dienvidāfrikas Republika
 ZA|mg|Afrika Atsimo
 ZA|mh|*aa
-ZA|mi|*aa
+ZA|mi|Āwherika ki te Tonga
 ZA|mk|Јужноафриканска Република
 ZA|ml|ദക്ഷിണാഫ്രിക്ക
 ZA|mn|Өмнөд Африк
@@ -46380,7 +46380,7 @@ ZA|nv|*aa
 ZA|ny|*aa
 ZA|oc|*aa
 ZA|oj|*aa
-ZA|om|*aa
+ZA|om|Afrikaa Kibbaa
 ZA|or|ଦକ୍ଷିଣ ଆଫ୍ରିକା
 ZA|os|*aa
 ZA|pa|ਦੱਖਣੀ ਅਫਰੀਕਾ
@@ -46395,7 +46395,7 @@ ZA|ro|*mo
 ZA|ru|Южно-Африканская Республика
 ZA|rw|*aa
 ZA|sa|*aa
-ZA|sc|*aa
+ZA|sc|Sudàfrica
 ZA|sd|ڏکڻ آفريقا
 ZA|se|Mátta-Afrihká
 ZA|sg|Mbongo-Afrîka
@@ -46408,7 +46408,7 @@ ZA|so|Koonfur Afrika
 ZA|sq|Afrika e Jugut
 ZA|sr|Јужноафричка Република
 ZA|ss|*aa
-ZA|st|*aa
+ZA|st|Afrika Borwa
 ZA|su|*aa
 ZA|sv|*da
 ZA|sw|*ki
@@ -46416,10 +46416,10 @@ ZA|ta|தென் ஆப்பிரிக்கா
 ZA|te|దక్షిణ ఆఫ్రికా
 ZA|tg|Африкаи Ҷанубӣ
 ZA|th|แอฟริกาใต้
-ZA|ti|*am
+ZA|ti|ደቡብ ኣፍሪቃ
 ZA|tk|Günorta Afrika
 ZA|tl|*aa
-ZA|tn|*aa
+ZA|tn|Aforika Borwa
 ZA|to|ʻAfilika tonga
 ZA|tr|Güney Afrika
 ZA|ts|*aa
@@ -46428,14 +46428,14 @@ ZA|tw|*aa
 ZA|ty|*aa
 ZA|ug|جەنۇبىي ئافرىقا
 ZA|uk|Південно-Африканська Республіка
-ZA|ur|جنوبی افریقہ
+ZA|ur|*ks
 ZA|uz|Janubiy Afrika Respublikasi
 ZA|ve|*aa
 ZA|vi|Nam Phi
 ZA|vo|*aa
 ZA|wa|*aa
 ZA|wo|Afrik di Sid
-ZA|xh|eMzantsi Afrika
+ZA|xh|EMzantsi Afrika
 ZA|yi|*ji
 ZA|yo|Gúúṣù Áfíríkà
 ZA|za|*aa
@@ -46470,7 +46470,7 @@ ZM|co|*aa
 ZM|cr|*aa
 ZM|cs|Zambie
 ZM|cu|*aa
-ZM|cv|*aa
+ZM|cv|*ce
 ZM|cy|*aa
 ZM|da|*aa
 ZM|de|Sambia
@@ -46501,7 +46501,7 @@ ZM|he|זמביה
 ZM|hi|ज़ाम्बिया
 ZM|ho|*aa
 ZM|hr|*bs
-ZM|ht|*aa
+ZM|ht|*cs
 ZM|hu|*aa
 ZM|hy|Զամբիա
 ZM|hz|*aa
@@ -46530,8 +46530,8 @@ ZM|km|សំប៊ី
 ZM|kn|ಜಾಂಬಿಯ
 ZM|ko|잠비아
 ZM|kr|*aa
-ZM|ks|جامبِیا
-ZM|ku|*az
+ZM|ks|زیمبیا
+ZM|ku|Zambîya
 ZM|kv|*aa
 ZM|kw|*aa
 ZM|ky|*bg
@@ -46546,7 +46546,7 @@ ZM|lu|*ln
 ZM|lv|*bs
 ZM|mg|*aa
 ZM|mh|*aa
-ZM|mi|*aa
+ZM|mi|Tāmipia
 ZM|mk|Замбија
 ZM|ml|സാംബിയ
 ZM|mn|*ce
@@ -46568,13 +46568,13 @@ ZM|nv|*aa
 ZM|ny|*aa
 ZM|oc|*aa
 ZM|oj|*aa
-ZM|om|*aa
+ZM|om|Zaambiyaa
 ZM|or|ଜାମ୍ବିଆ
 ZM|os|*aa
 ZM|pa|ਜ਼ਾਮਬੀਆ
 ZM|pi|*aa
 ZM|pl|*aa
-ZM|ps|زیمبیا
+ZM|ps|*ks
 ZM|pt|Zâmbia
 ZM|qu|*aa
 ZM|rm|*de
@@ -46583,7 +46583,7 @@ ZM|ro|*aa
 ZM|ru|*bg
 ZM|rw|*aa
 ZM|sa|*aa
-ZM|sc|*aa
+ZM|sc|*ca
 ZM|sd|زيمبيا
 ZM|se|*aa
 ZM|sg|Zambïi
@@ -46604,7 +46604,7 @@ ZM|ta|ஜாம்பியா
 ZM|te|జాంబియా
 ZM|tg|*bg
 ZM|th|แซมเบีย
-ZM|ti|*am
+ZM|ti|ዛምብያ
 ZM|tk|Zambiýa
 ZM|tl|*aa
 ZM|tn|*aa
@@ -46623,7 +46623,7 @@ ZM|vi|*aa
 ZM|vo|*aa
 ZM|wa|*aa
 ZM|wo|Sàmbi
-ZM|xh|*aa
+ZM|xh|EZambia
 ZM|yi|*ji
 ZM|yo|Ṣamibia
 ZM|za|*aa
@@ -46633,7 +46633,7 @@ ZW|aa|Zimbabwe
 ZW|ab|*aa
 ZW|ae|*aa
 ZW|af|*aa
-ZW|ak|Zembabwe
+ZW|ak|Zimbabue
 ZW|am|ዚምቧቤ
 ZW|an|*aa
 ZW|ar|زيمبابوي
@@ -46658,7 +46658,7 @@ ZW|co|*aa
 ZW|cr|*aa
 ZW|cs|*aa
 ZW|cu|*aa
-ZW|cv|*aa
+ZW|cv|*bg
 ZW|cy|*aa
 ZW|da|*aa
 ZW|de|Simbabwe
@@ -46668,7 +46668,7 @@ ZW|ee|Zimbabwe nutome
 ZW|el|Ζιμπάμπουε
 ZW|en|*aa
 ZW|eo|Zimbabvo
-ZW|es|Zimbabue
+ZW|es|*ak
 ZW|et|*aa
 ZW|eu|*aa
 ZW|fa|زیمبابوه
@@ -46734,7 +46734,7 @@ ZW|lu|*aa
 ZW|lv|*az
 ZW|mg|Zimbaboe
 ZW|mh|*aa
-ZW|mi|*aa
+ZW|mi|Timuwawe
 ZW|mk|*bg
 ZW|ml|സിംബാബ്‌വേ
 ZW|mn|*bg
@@ -46756,7 +46756,7 @@ ZW|nv|*aa
 ZW|ny|*aa
 ZW|oc|*aa
 ZW|oj|*aa
-ZW|om|*aa
+ZW|om|Zimbaabuwee
 ZW|or|ଜିମ୍ବାୱେ
 ZW|os|*aa
 ZW|pa|ਜ਼ਿੰਬਾਬਵੇ
@@ -46764,7 +46764,7 @@ ZW|pi|*aa
 ZW|pl|*aa
 ZW|ps|زیمبابوی
 ZW|pt|Zimbábue
-ZW|qu|*es
+ZW|qu|*ak
 ZW|rm|*de
 ZW|rn|*aa
 ZW|ro|*aa
@@ -46792,7 +46792,7 @@ ZW|ta|ஜிம்பாப்வே
 ZW|te|జింబాబ్వే
 ZW|tg|*bg
 ZW|th|ซิมบับเว
-ZW|ti|*am
+ZW|ti|ዚምባብዌ
 ZW|tk|*aa
 ZW|tl|*aa
 ZW|tn|*aa
@@ -46811,7 +46811,7 @@ ZW|vi|*aa
 ZW|vo|*aa
 ZW|wa|*aa
 ZW|wo|*de
-ZW|xh|*aa
+ZW|xh|EZimbabwe
 ZW|yi|*ji
 ZW|yo|Ṣimibabe
 ZW|za|*aa


### PR DESCRIPTION
The jdk is a silent input to the shipped country names, so bumping the pin and regenerating the
data belong in the same reviewable diff. Generated with temurin 25.0.4 on the CI runner, so it
matches what the pinned workflow will produce.

What changes: 2,237 entries resolve to a different name, across 149 languages. Counts are
unchanged at 249 countries and 46,812 entries, and no aliases dangle.

In English only `TR` moves, `Turkey` -> `Türkiye` (CLDR 42, Oct 2022). The rest is mostly newly
available translations — Chuvash, Haitian, Māori, Oromo, Xhosa and others previously fell back to
the English name and now have real ones — plus refinements to existing translations.

No test changes: every name the tests assert is unchanged.