### PR TITLE
ci: attest build provenance for the published packages

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -25,8 +25,10 @@ jobs:
     permissions:
       contents: read
       # NuGet/login exchanges this workflow's OIDC token for a short-lived
-      # nuget.org api key, so no push secret is stored in the repo.
+      # nuget.org api key, so no push secret is stored in the repo. The same token
+      # signs the build provenance below.
       id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -60,6 +62,14 @@ jobs:
             -p:VersionPrefix="${VERSION}" -o artifacts
           dotnet pack csharp/PhoneNumbers.Extensions -c Release --no-restore \
             -p:VersionPrefix="${VERSION}" -o artifacts
+
+      # Signed, verifiable provenance for what is about to be pushed: which workflow, at which
+      # commit, produced these exact bytes. Runs before the push so nothing is published without
+      # it. Verify with: gh attestation verify <file> --repo twcclegg/libphonenumber-csharp
+      - name: Attest package provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: 'artifacts/*.nupkg'
 
       - name: Upload packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Generates signed SLSA build provenance for both `.nupkg`s before they are pushed, so a consumer
can verify which workflow, at which commit, produced those exact bytes:

    gh attestation verify libphonenumber-csharp.9.0.37.nupkg --repo twcclegg/libphonenumber-csharp

Uses the OIDC token already present for `NuGet/login`, so it adds `attestations: write` and
nothing else — `contents` stays `read`.

Note this may not move Scorecard's `Signed-Releases`, which looks for signature files attached to
a GitHub release. Attaching the attestation bundle there would need `contents: write` on this job,
which would trade away the least-privilege that currently scores Token-Permissions 10. Worth doing
separately if the check matters more than the permission.