### PR TITLE
fix: narrow TryParse/TryParseValid catch to NumberParseException

### DIFF
--- a/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
@@ -11,7 +11,7 @@
                 number = PhoneNumberUtil.Parse(input, region);
                 return true;
             }
-            catch
+            catch (NumberParseException)
             {
                 number = null;
                 return false;
@@ -25,7 +25,7 @@
                 number = PhoneNumberUtil.Parse(input, region);
                 return PhoneNumberUtil.IsValidNumber(number);
             }
-            catch
+            catch (NumberParseException)
             {
                 number = null;
                 return false;


### PR DESCRIPTION
## Summary
- `PhoneNumbers.Extensions.PhoneNumber.TryParse`/`TryParseValid` used a bare `catch { }`, silently swallowing any exception (not just parse failures) and masking bugs.
- Narrows both to `catch (NumberParseException)`, matching the exception type `PhoneNumberUtil.Parse` actually throws.

## Test plan
- [x] `dotnet build csharp --no-restore` — clean, 0 warnings/errors
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 864 tests passed (net8.0 + net10.0), including the existing `TryParse("1235557704", "ZX", ...)` case that already exercises the narrowed exception path