### PR TITLE
docs: reconcile stale Todo sections with current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,6 @@ Therefore, we recommend you keep this nuget package as up to date as possible us
 
 For more information on metadata usage, please refer to the [main repository faq](https://github.com/google/libphonenumber/blob/master/FAQ.md#metadata)
 
-## ToDo
-
-* update / add / port new unit tests and logging from java source
-
-## How to unfold automatic generated files
-
-* Install Jetbrains - Resharper for Visual Studio
-* File by file, right click and "Cleanup code"
-* Check the unfolded file
-
 ## Running tests locally
 
 ```bash

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -44,9 +44,9 @@ Known Issues
   and embedded in the assembly. No zip files or text files are needed to run the library or its
   tests.
 
-
-Todo
-----
-
-- Restore the Java logging calls?
-- Find a suitable replace for Java CharSequence in phone numbers parsing API.
+- Java's public API accepts `CharSequence` in several entry points (e.g.
+  `PhoneNumberMatcher`'s constructor, `isViablePhoneNumber`), letting callers pass a `String`,
+  `StringBuilder`, or `StringBuffer` without copying. The C# port takes `string` in the
+  equivalent spots (`PhoneNumberMatcher(PhoneNumberUtil, string, ...)`,
+  `PhoneNumberUtil.IsViablePhoneNumber(string)`) instead of a comparable abstraction, so a
+  caller building up a number in a `StringBuilder` has to call `.ToString()` first.


### PR DESCRIPTION
## Summary
- `csharp/README.md`: moved the CharSequence divergence out of a vague "Todo" bullet into "Known Issues" (with an actual explanation), matching what CLAUDE.md already claims is documented there. Dropped "Restore the Java logging calls?" — no logging abstraction exists anywhere in this offline library, and none is planned; the question was stale.
- Root `README.md`: removed the "ToDo" bullet about porting tests/logging (test porting is already routine practice, e.g. #399) and the "How to unfold automatic generated files" ReSharper section, which no longer applies to anything in the repo — locale data moved to binary resources in #395, and the one remaining hand-noted generated file (`CountryCodeToRegionCodeMap.cs`) is already fully formatted (max line length 85, one entry per line).

## Test plan
- [x] `dotnet restore csharp && dotnet build csharp --no-restore` — clean, 0 warnings/errors (doc-only change, no code touched)