### PR TITLE
internal: BinaryPrimitives in ByteBuffer, volatile singleton instance

### DIFF
--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/csharp/PhoneNumbers/FlyweightMapStorage.cs
+++ b/csharp/PhoneNumbers/FlyweightMapStorage.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -177,29 +178,22 @@ namespace PhoneNumbers
 
             public void PutShort(int offset, short value)
             {
-                bytes[offset] = (byte)value;
-                bytes[offset + 1] = (byte)(value >> 8);
+                BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(offset), value);
             }
 
             public void PutInt(int offset, int value)
             {
-                bytes[offset] = (byte)value;
-                bytes[offset + 1] = (byte)(value >> 8);
-                bytes[offset + 2] = (byte)(value >> 16);
-                bytes[offset + 3] = (byte)(value >> 24);
+                BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset), value);
             }
 
             public short GetShort(int offset)
             {
-                return (short)(bytes[offset] | (bytes[offset + 1] << 8));
+                return BinaryPrimitives.ReadInt16LittleEndian(bytes.AsSpan(offset));
             }
 
             public int GetInt(int offset)
             {
-                return bytes[offset]
-                    | (bytes[offset + 1] << 8)
-                    | (bytes[offset + 2] << 16)
-                    | (bytes[offset + 3] << 24);
+                return BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset));
             }
 
             public int GetCapacity()

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -367,7 +367,7 @@ namespace PhoneNumbers
         internal static Regex ValidPhoneNumber() => _validPhoneNumber;
 #endif
 
-        private static PhoneNumberUtil instance;
+        private static volatile PhoneNumberUtil instance;
 
         // Lazy, cached resolver for region metadata. Replaces the eager Dictionary that used to
         // be populated at construction by parsing the entire XML file: now we resolve a region's

--- a/csharp/PhoneNumbers/PhoneNumbers.csproj
+++ b/csharp/PhoneNumbers/PhoneNumbers.csproj
@@ -225,6 +225,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections.Immutable" />
+    <!-- FlyweightMapStorage's ByteBuffer uses System.Buffers.Binary.BinaryPrimitives and
+         byte[].AsSpan(), neither of which netstandard2.0 has without this package. -->
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Two small, internal-only, non-breaking cleanups from the "explicitly not blocked" section of #375:

- `FlyweightMapStorage`'s internal `ByteBuffer` had already moved off `MemoryStream`/`BinaryReader`/`BinaryWriter` onto a plain `byte[]` (see `fadb2dfa`), so no disposable fields remain and it was never `IDisposable`. This swaps its manual little-endian bit-shifting for `System.Buffers.Binary.BinaryPrimitives.{Read,Write}{Int16,Int32}LittleEndian`, matching #375's suggestion of "rewritten over `BinaryPrimitives` on a plain `byte[]`" — same behavior, same endianness, no public/internal signature changes.
- `PhoneNumberUtil.instance` is now `volatile`, matching the double-checked lock in `GetInstance()`. The `??=` inside the lock is untouched — #375 notes `CA1508` flags it as dead code, but that's a documented false positive; removing it would reintroduce the race.

## Test plan
- [x] `dotnet build csharp --no-restore` — 0 warnings, 0 errors
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 864 tests passed (net8.0 + net10.0)
- [x] `PhoneNumbers.PerformanceTest` geocoder benchmark run locally as a sanity check (no crash, no obvious regression); CI's `run_performance_tests.yml` will do the real base-vs-PR comparison