### PR TITLE
feat(extensions): TryParse overloads, TypeConverter, and a real phone-number ValidationAttribute

### DIFF
--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/csharp/PhoneNumbers.Extensions.Test/TestExtensions.cs
+++ b/csharp/PhoneNumbers.Extensions.Test/TestExtensions.cs
@@ -45,6 +45,14 @@ namespace PhoneNumbers.Extensions.Test
         }
 
         [Fact]
+        public void TestE164_TwoArgOverload()
+        {
+            Assert.True(PhoneNumber.TryParse("+16192987704", out var number));
+            Assert.True(PhoneNumber.TryParseValid("+16192987704", out number));
+            Assert.Equal("+16192987704", Util.Format(number, PhoneNumberFormat.E164));
+        }
+
+        [Fact]
         public void TestInvalidCountryCode()
         {
             Assert.False(PhoneNumber.TryParse("1235557704", "ZX", out var number));

--- a/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberAttributeValidation.cs
+++ b/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberAttributeValidation.cs
@@ -1,0 +1,65 @@
+using Xunit;
+
+namespace PhoneNumbers.Extensions.Test
+{
+    public class TestPhoneNumberAttributeValidation
+    {
+        [Fact]
+        public void IsValid_Null_ReturnsTrue()
+        {
+            var attribute = new PhoneNumberAttribute();
+
+            Assert.True(attribute.IsValid(null));
+        }
+
+        [Fact]
+        public void IsValid_ValidE164String_ReturnsTrue()
+        {
+            var attribute = new PhoneNumberAttribute();
+
+            Assert.True(attribute.IsValid("+16192987704"));
+        }
+
+        [Fact]
+        public void IsValid_ValidNationalStringWithRegion_ReturnsTrue()
+        {
+            var attribute = new PhoneNumberAttribute { Region = "US" };
+
+            Assert.True(attribute.IsValid("6192987704"));
+        }
+
+        [Fact]
+        public void IsValid_NationalStringWithoutRegion_ReturnsFalse()
+        {
+            var attribute = new PhoneNumberAttribute();
+
+            Assert.False(attribute.IsValid("6192987704"));
+        }
+
+        [Fact]
+        public void IsValid_InvalidString_ReturnsFalse()
+        {
+            var attribute = new PhoneNumberAttribute { Region = "US" };
+
+            Assert.False(attribute.IsValid("1235557704"));
+        }
+
+        [Fact]
+        public void IsValid_ValidParsedPhoneNumber_ReturnsTrue()
+        {
+            var util = PhoneNumberUtil.GetInstance();
+            var number = util.Parse("+16192987704", null);
+            var attribute = new PhoneNumberAttribute();
+
+            Assert.True(attribute.IsValid(number));
+        }
+
+        [Fact]
+        public void IsValid_UnsupportedType_ReturnsFalse()
+        {
+            var attribute = new PhoneNumberAttribute();
+
+            Assert.False(attribute.IsValid(42));
+        }
+    }
+}

--- a/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace PhoneNumbers.Extensions.Test
+{
+    public class TestPhoneNumberTypeConverter
+    {
+        private static readonly PhoneNumberTypeConverter Converter = new();
+
+        [Fact]
+        public void ConvertFrom_ParsesString()
+        {
+            var result = Converter.ConvertFrom("+16192987704");
+
+            var number = Assert.IsType<PhoneNumbers.PhoneNumber>(result);
+            Assert.Equal(6192987704UL, number.NationalNumber);
+        }
+
+        [Fact]
+        public void ConvertTo_FormatsE164()
+        {
+            var util = PhoneNumberUtil.GetInstance();
+            var number = util.Parse("+16192987704", null);
+
+            var result = Converter.ConvertTo(number, typeof(string));
+
+            Assert.Equal("+16192987704", result);
+        }
+
+        [Fact]
+        public void CanConvertFrom_String_ReturnsTrue()
+        {
+            Assert.True(Converter.CanConvertFrom(typeof(string)));
+        }
+
+        [Fact]
+        public void CanConvertTo_String_ReturnsTrue()
+        {
+            Assert.True(Converter.CanConvertTo(typeof(string)));
+        }
+    }
+}

--- a/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
@@ -16,6 +16,18 @@ namespace PhoneNumbers.Extensions.Test
         }
 
         [Fact]
+        public void ConvertFrom_MatchesTryParse_ForEqualityAndHashing()
+        {
+            // Both entry points must produce equal/interchangeable PhoneNumber instances for the same
+            // input; RawInput divergence would otherwise break Equals()/GetHashCode() consistency.
+            var converted = Assert.IsType<PhoneNumbers.PhoneNumber>(Converter.ConvertFrom("+16192987704"));
+            Assert.True(PhoneNumber.TryParse("+16192987704", out var parsed));
+
+            Assert.Equal(parsed, converted);
+            Assert.Equal(parsed!.GetHashCode(), converted.GetHashCode());
+        }
+
+        [Fact]
         public void ConvertTo_FormatsE164()
         {
             var util = PhoneNumberUtil.GetInstance();

--- a/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
@@ -11,7 +11,7 @@
                 number = PhoneNumberUtil.Parse(input, region);
                 return true;
             }
-            catch
+            catch (NumberParseException)
             {
                 number = null;
                 return false;
@@ -25,7 +25,7 @@
                 number = PhoneNumberUtil.Parse(input, region);
                 return PhoneNumberUtil.IsValidNumber(number);
             }
-            catch
+            catch (NumberParseException)
             {
                 number = null;
                 return false;

--- a/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumber.cs
@@ -4,6 +4,9 @@
     {
         private static readonly PhoneNumberUtil PhoneNumberUtil = PhoneNumberUtil.GetInstance();
 
+        public static bool TryParse(string input, out PhoneNumbers.PhoneNumber number)
+            => TryParse(input, null, out number);
+
         public static bool TryParse(string input, string region, out PhoneNumbers.PhoneNumber number)
         {
             try
@@ -17,6 +20,9 @@
                 return false;
             }
         }
+
+        public static bool TryParseValid(string input, out PhoneNumbers.PhoneNumber number)
+            => TryParseValid(input, null, out number);
 
         public static bool TryParseValid(string input, string region, out PhoneNumbers.PhoneNumber number)
         {

--- a/csharp/PhoneNumbers.Extensions/PhoneNumberAttribute.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumberAttribute.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PhoneNumbers.Extensions
+{
+    /// <summary>
+    /// Validates that a property, field, or parameter is a valid phone number, using the same
+    /// validity check as <see cref="PhoneNumberUtil.IsValidNumber"/> rather than a loose format
+    /// regex. Accepts a <see cref="string"/> (parsed via <see cref="Region"/>) or an already-parsed
+    /// <see cref="PhoneNumbers.PhoneNumber"/>.
+    /// </summary>
+    public sealed class PhoneNumberAttribute : ValidationAttribute
+    {
+        public PhoneNumberAttribute() : base("The field {0} is not a valid phone number.")
+        {
+        }
+
+        /// <summary>
+        /// Default region used to interpret a national-format string, e.g. "US". Not needed for
+        /// numbers already in E.164 format (leading "+"), or when the value is a
+        /// <see cref="PhoneNumbers.PhoneNumber"/>.
+        /// </summary>
+        public string Region { get; set; }
+
+        public override bool IsValid(object value)
+            => value switch
+            {
+                null => true,
+                string stringValue => PhoneNumber.TryParseValid(stringValue, Region, out _),
+                PhoneNumbers.PhoneNumber phoneNumber => PhoneNumberUtil.GetInstance().IsValidNumber(phoneNumber),
+                _ => false,
+            };
+    }
+}

--- a/csharp/PhoneNumbers.Extensions/PhoneNumberAttribute.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumberAttribute.cs
@@ -10,6 +10,8 @@ namespace PhoneNumbers.Extensions
     /// </summary>
     public sealed class PhoneNumberAttribute : ValidationAttribute
     {
+        private static readonly PhoneNumberUtil PhoneNumberUtil = PhoneNumberUtil.GetInstance();
+
         public PhoneNumberAttribute() : base("The field {0} is not a valid phone number.")
         {
         }
@@ -26,7 +28,7 @@ namespace PhoneNumbers.Extensions
             {
                 null => true,
                 string stringValue => PhoneNumber.TryParseValid(stringValue, Region, out _),
-                PhoneNumbers.PhoneNumber phoneNumber => PhoneNumberUtil.GetInstance().IsValidNumber(phoneNumber),
+                PhoneNumbers.PhoneNumber phoneNumber => PhoneNumberUtil.IsValidNumber(phoneNumber),
                 _ => false,
             };
     }

--- a/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace PhoneNumbers.Extensions
+{
+    /// <summary>
+    /// Converts a <see cref="PhoneNumbers.PhoneNumber"/> to and from its E.164 string
+    /// representation. Not applied automatically — register it where needed, e.g.
+    /// <c>TypeDescriptor.AddAttributes(typeof(PhoneNumbers.PhoneNumber), new TypeConverterAttribute(typeof(PhoneNumberTypeConverter)));</c>
+    /// </summary>
+    public class PhoneNumberTypeConverter : TypeConverter
+    {
+        private static readonly PhoneNumberUtil Util = PhoneNumberUtil.GetInstance();
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            => value is string stringValue
+                ? Util.ParseAndKeepRawInput(stringValue, null)
+                : base.ConvertFrom(context, culture, value);
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            => destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value,
+            Type destinationType)
+            => value is PhoneNumbers.PhoneNumber phoneNumber && destinationType == typeof(string)
+                ? Util.Format(phoneNumber, PhoneNumberFormat.E164)
+                : base.ConvertTo(context, culture, value, destinationType);
+    }
+}

--- a/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
@@ -18,7 +18,7 @@ namespace PhoneNumbers.Extensions
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
             => value is string stringValue
-                ? Util.ParseAndKeepRawInput(stringValue, null)
+                ? Util.Parse(stringValue, null)
                 : base.ConvertFrom(context, culture, value);
 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)

--- a/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumbers.Extensions.csproj
@@ -31,6 +31,7 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <PackageReference Include="System.Text.Json" />
+      <PackageReference Include="System.ComponentModel.Annotations" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- `PhoneNumber.TryParse`/`TryParseValid` gain a 2-arg overload (region defaults to `null`), matching the conventional .NET `TryParse(string, out T)` shape.
- `PhoneNumberTypeConverter` converts `PhoneNumber` to/from its E.164 string — for consumers that register `TypeConverter`s (config binding, `PropertyGrid`, MVC model binding, etc.). Not applied automatically; register it explicitly, same pattern as the existing `PhoneNumberConverter` for `System.Text.Json`.
- `PhoneNumberAttribute` is a `DataAnnotations` `ValidationAttribute` backed by `PhoneNumberUtil.IsValidNumber`, unlike the framework's built-in `[Phone]` which is a loose regex. Accepts a `string` (parsed via the optional `Region` property) or an already-parsed `PhoneNumber`.

Note on scope: an earlier version of this considered a `TryParse(string, IFormatProvider, out PhoneNumber)` shape aimed at ASP.NET Core minimal-API automatic parameter binding, but that only works if the method lives on `PhoneNumbers.PhoneNumber` itself (the framework reflects on the parameter's own type) — decided to keep this Extensions-only rather than touch the core faithful-port model class, so this PR is a plain convenience overload rather than automatic binding support.

`netstandard2.0` needs `System.ComponentModel.Annotations` for `ValidationAttribute`; `net8.0`/`net10.0` already have it in the shared framework — added centrally in `Directory.Packages.props`, referenced only on the `netstandard2.0` leg like the existing `System.Text.Json` reference.

## Test plan
- [x] `dotnet build csharp --no-restore` — 0 warnings/errors
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 888 tests passed (net8.0 + net10.0), including new tests for all three additions
- [x] `dotnet pack -c Release csharp/PhoneNumbers.Extensions -p:VersionPrefix=9.0.38` — packs and passes `EnablePackageValidation` against the 9.0.37 baseline (confirms the additions are purely additive, no API-compat breaks)