### PR TITLE
fix: NumberParseException instead of ArgumentOutOfRangeException on malformed RFC3966 phone-context ordering

### DIFF
--- a/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
@@ -2413,6 +2413,9 @@ namespace PhoneNumbers.Test
             VerifyFailure("tel:555-1234;phone-context=1-331", RegionCode.ZZ, ErrorType.NOT_A_NUMBER);
             // Only the phone-context symbol is present, but no data.
             VerifyFailure(";phone-context=", RegionCode.ZZ, ErrorType.NOT_A_NUMBER);
+            // The "tel:" prefix appears after the phone-context marker instead of before it, so there is no
+            // valid national-number substring between them.
+            VerifyFailure(";phone-context=example.com;tel:1234", RegionCode.ZZ, ErrorType.NOT_A_NUMBER);
         }
 
         [Fact]

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -3005,6 +3005,14 @@ namespace PhoneNumbers
                 var indexOfRfc3966Prefix = numberToParse.IndexOf(RFC3966_PREFIX, StringComparison.Ordinal);
                 var indexOfNationalNumber =
                     indexOfRfc3966Prefix >= 0 ? indexOfRfc3966Prefix + RFC3966_PREFIX.Length : 0;
+                if (indexOfNationalNumber > indexOfPhoneContext)
+                {
+                    // The "tel:" prefix (if any) is supposed to precede the phone-context marker; if it
+                    // doesn't, the input isn't well-formed RFC3966 and there's no sensible national-number
+                    // substring to extract, e.g. ";phone-context=example.com;tel:1234".
+                    throw new NumberParseException(ErrorType.NOT_A_NUMBER,
+                        "the phone-context value is invalid.");
+                }
                 nationalNumber.Append(numberToParse, indexOfNationalNumber, indexOfPhoneContext - indexOfNationalNumber);
             }
             else


### PR DESCRIPTION
## Summary
`BuildNationalNumberForParsing` assumed the `"tel:"` prefix, if present anywhere in the input, always occurs *before* the `";phone-context="` marker. When it occurs after — e.g. `";phone-context=example.com;tel:1234"` — `indexOfPhoneContext - indexOfNationalNumber` goes negative, and `StringBuilder.Append(string, int, int)` throws an unchecked `ArgumentOutOfRangeException` straight out of the public `PhoneNumberUtil.Parse` API, instead of the documented `NumberParseException`.

Found via code review of #401 (narrowing `PhoneNumbers.Extensions.PhoneNumber.TryParse`'s `catch` to `catch (NumberParseException)`) — that narrowing is correct, but it stopped silently swallowing this pre-existing bug. It's reachable directly through `PhoneNumberUtil.Parse` with no dependency on #401, and is worse combined with #405's new `[PhoneNumber]` `ValidationAttribute`: a `ValidationAttribute.IsValid` is conventionally expected to never throw on arbitrary/untrusted input, so this could crash model validation on a crafted string.

Fix: guard the ordering assumption and throw `NumberParseException(NOT_A_NUMBER, ...)` instead, matching the error this method already throws just above for other malformed phone-context input.

Recommend merging this before/alongside #401 and #405.

## Test plan
- [x] Reproduced standalone: `PhoneNumberUtil.GetInstance().Parse(";phone-context=example.com;tel:1234", null)` threw `ArgumentOutOfRangeException` before this fix.
- [x] Added a regression case to the existing `TestFailedParseOnInvalidNumbers` (`VerifyFailure(";phone-context=example.com;tel:1234", RegionCode.ZZ, ErrorType.NOT_A_NUMBER)`), alongside the other phone-context failure cases.
- [x] `dotnet build csharp --no-restore` — 0 warnings/errors
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 864 tests passed (net8.0 + net10.0)