### PR TITLE
Fix three matcher/formatter parity gaps vs. upstream Java source

### DIFF
--- a/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
@@ -367,6 +367,29 @@ namespace PhoneNumbers.Test
             FindMatchesInContexts(validContexts, true, true);
         }
 
+        /// <summary>
+        /// Regression test for the missing "skip past the country calling code before looking for the
+        /// first group" step (present in the upstream Java, ported here to match): without it, a decoy
+        /// occurrence of the NDC group earlier in the candidate (before the actual country code) is
+        /// matched instead of the real one, and the leftover digit run right after the decoy is wrongly
+        /// compared against the national significant number.
+        /// </summary>
+        [Fact]
+        public void TestAllNumberGroupsRemainGroupedSkipsCountryCode()
+        {
+            var number = new PhoneNumber.Builder()
+                .SetCountryCode(1)
+                .SetNationalNumber(6502530000L)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITHOUT_PLUS_SIGN)
+                .Build();
+            // "6502" before the real "1-650-253-0000" is a decoy that starts with the NDC group "650"
+            // but is immediately followed by a digit rather than a separator.
+            var candidate = new StringBuilder("6502-1-650-253-0000");
+            var formattedNumberGroups = new List<string> { "650", "253", "0000" };
+            Assert.True(PhoneNumberMatcher.AllNumberGroupsRemainGrouped(
+                phoneUtil, number, candidate, formattedNumberGroups));
+        }
+
         [Fact]
         public void TestMatchesMultiplePhoneNumbersSeparatedByPhoneNumberPunctuation()
         {

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
@@ -367,6 +367,49 @@ namespace PhoneNumbers.Test
             FindMatchesInContexts(validContexts, true, true);
         }
 
+        /** See https://github.com/google/libphonenumber PhoneNumberMatcherTest#testContainsMoreThanOneSlashInNationalNumber(). */
+        [Fact]
+        public void TestContainsMoreThanOneSlash()
+        {
+            // A date should return true.
+            var number = new PhoneNumber.Builder()
+                .SetCountryCode(1)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_DEFAULT_COUNTRY)
+                .Build();
+            Assert.True(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "1/05/2013"));
+
+            // Here, the country code source thinks it started with a country calling code, but this is
+            // not the same as the part before the slash, so it's still true.
+            number = new PhoneNumber.Builder()
+                .SetCountryCode(274)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITHOUT_PLUS_SIGN)
+                .Build();
+            Assert.True(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "27/4/2013"));
+
+            // Now it should be false, because the first slash is after the country calling code.
+            number = new PhoneNumber.Builder()
+                .SetCountryCode(49)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITH_PLUS_SIGN)
+                .Build();
+            Assert.False(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "49/69/2013"));
+
+            number = new PhoneNumber.Builder()
+                .SetCountryCode(49)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITHOUT_PLUS_SIGN)
+                .Build();
+            Assert.False(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "+49/69/2013"));
+            Assert.False(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "+ 49/69/2013"));
+            Assert.True(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "+ 49/69/20/13"));
+
+            // Here, the first group is not assumed to be the country calling code, even though it is the
+            // same as it, so this should return true.
+            number = new PhoneNumber.Builder()
+                .SetCountryCode(49)
+                .SetCountryCodeSource(PhoneNumber.Types.CountryCodeSource.FROM_DEFAULT_COUNTRY)
+                .Build();
+            Assert.True(PhoneNumberMatcher.ContainsMoreThanOneSlash(number, "49/69/2013"));
+        }
+
         /// <summary>
         /// Regression test for the missing "skip past the country calling code before looking for the
         /// first group" step (present in the upstream Java, ported here to match): without it, a decoy

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
@@ -2872,6 +2872,26 @@ namespace PhoneNumbers.Test
             Assert.False(phoneUtil.IsAlphaNumber("+800 1234-1234"));
         }
 
+        /// <summary>
+        /// Mirrors Java's FIRST_GROUP_ONLY_PREFIX_PATTERN test coverage: the rule must be nothing but
+        /// the first-group placeholder, optionally wrapped in one pair of parentheses. Real metadata
+        /// stores that placeholder as "${1}" (see BuildMetadataFromXml), not Java's literal "$1", so a
+        /// rule such as "0${1}" (digits before the placeholder) or "${1}-" (content after it) must not
+        /// match even though it contains "${1}".
+        /// </summary>
+        [Fact]
+        public void TestFormattingRuleHasFirstGroupOnly()
+        {
+            Assert.True(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly(""));
+            Assert.True(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("${1}"));
+            Assert.True(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("(${1})"));
+            Assert.True(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("(${1}"));
+            Assert.True(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("${1})"));
+            Assert.False(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("0${1}"));
+            Assert.False(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("${1}-"));
+            Assert.False(PhoneNumberUtil.FormattingRuleHasFirstGroupOnly("$NP${1}"));
+        }
+
         [Fact]
         public void TestIsMobileNumberPortableRegion()
         {

--- a/csharp/PhoneNumbers/AsYouTypeFormatter.cs
+++ b/csharp/PhoneNumbers/AsYouTypeFormatter.cs
@@ -160,12 +160,6 @@ namespace PhoneNumbers
             return false;
         }
 
-        /// <summary>
-        /// Helper function to check if the national prefix formatting rule has the first group only, i.e.,
-        /// does not start with the national prefix.
-        /// </summary>
-        private static bool FormattingRuleHasFirstGroupOnly(string rule) => rule is "" or "($1)" or "$1)" or "($1" or "$1";
-
         private void GetAvailableFormats(string leadingDigits)
         {
             // First decide whether we should use international or national number rules.
@@ -179,7 +173,7 @@ namespace PhoneNumbers
                 // Discard a few formats that we know are not relevant based on the presence of the national
                 // prefix.
                 if (extractedNationalPrefix.Length > 0
-                    && FormattingRuleHasFirstGroupOnly(format.NationalPrefixFormattingRule)
+                    && PhoneNumberUtil.FormattingRuleHasFirstGroupOnly(format.NationalPrefixFormattingRule)
                     && !format.NationalPrefixOptionalWhenFormatting
                     && !format.HasDomesticCarrierCodeFormattingRule)
                 {
@@ -191,7 +185,7 @@ namespace PhoneNumbers
                 }
                 else if (extractedNationalPrefix.Length == 0
                          && !isCompleteNumber
-                         && !FormattingRuleHasFirstGroupOnly(format.NationalPrefixFormattingRule)
+                         && !PhoneNumberUtil.FormattingRuleHasFirstGroupOnly(format.NationalPrefixFormattingRule)
                          && !format.NationalPrefixOptionalWhenFormatting)
                 {
                     // This number was entered without a national prefix, and this formatting rule requires one,

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -644,7 +644,12 @@ namespace PhoneNumbers
                     number.CountryCode.ToString(CultureInfo.InvariantCulture))
             {
                 // Any more slashes and this is illegal.
+#if NETSTANDARD2_0
+                // netstandard2.0 only has string.Contains(string); net8.0+ prefers Contains(char) (CA1847).
+                return candidate.Substring(secondSlashIndex + 1).Contains("/");
+#else
                 return candidate.Substring(secondSlashIndex + 1).Contains('/');
+#endif
             }
             return true;
         }

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -443,6 +443,12 @@ namespace PhoneNumbers
         {
             var fromIndex = 0;
             var candidate = normalizedCandidate.ToString();
+            if (number.CountryCodeSource != PhoneNumber.Types.CountryCodeSource.FROM_DEFAULT_COUNTRY)
+            {
+                // First skip the country code if the normalized candidate contained it.
+                var countryCode = number.CountryCode.ToString(CultureInfo.InvariantCulture);
+                fromIndex = candidate.IndexOf(countryCode, StringComparison.Ordinal) + countryCode.Length;
+            }
             // Check each group of consecutive digits are not broken into separate groupings in the
             // normalizedCandidate string.
             for (var i = 0; i < formattedNumberGroups.Count; i++)
@@ -458,8 +464,12 @@ namespace PhoneNumbers
                 fromIndex += formattedNumberGroups[i].Length;
                 if (i == 0 && fromIndex < candidate.Length)
                 {
-                    // We are at the position right after the NDC.
-                    if (char.IsDigit(candidate[fromIndex]))
+                    // We are at the position right after the NDC. We get the region used for formatting
+                    // information based on the country code in the phone number, rather than the number
+                    // itself, as we do not need to distinguish between different countries with the same
+                    // country calling code and this is faster.
+                    var region = util.GetRegionCodeForCountryCode(number.CountryCode);
+                    if (util.GetNddPrefixForRegion(region, true) != null && char.IsDigit(candidate[fromIndex]))
                     {
                         // This means there is no formatting symbol after the NDC. In this case, we only
                         // accept the number if there is no formatting symbol at all in the number, except

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -621,6 +621,18 @@ namespace PhoneNumbers
             return false;
         }
 
+        /// <summary>
+        /// Preserved for binary/source compatibility with the public API shipped before the
+        /// country-code-aware overload below was introduced. New callers should prefer
+        /// <see cref="ContainsMoreThanOneSlash(PhoneNumber, string)"/>, which matches upstream Java's
+        /// more precise handling of slashes that fall within the country calling code prefix.
+        /// </summary>
+        public static bool ContainsMoreThanOneSlash(string candidate)
+        {
+            var firstSlashIndex = candidate.IndexOf('/');
+            return firstSlashIndex > 0 && candidate.IndexOf('/', firstSlashIndex + 1) >= 0;
+        }
+
         public static bool ContainsMoreThanOneSlash(PhoneNumber number, string candidate)
         {
             var firstSlashIndex = candidate.IndexOf('/');

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -621,10 +621,32 @@ namespace PhoneNumbers
             return false;
         }
 
-        public static bool ContainsMoreThanOneSlash(string candidate)
+        public static bool ContainsMoreThanOneSlash(PhoneNumber number, string candidate)
         {
             var firstSlashIndex = candidate.IndexOf('/');
-            return firstSlashIndex > 0 && candidate.IndexOf('/', firstSlashIndex + 1) >= 0;
+            if (firstSlashIndex < 0)
+            {
+                // No slashes, this is okay.
+                return false;
+            }
+            var secondSlashIndex = candidate.IndexOf('/', firstSlashIndex + 1);
+            if (secondSlashIndex < 0)
+            {
+                // Only one slash, this is okay.
+                return false;
+            }
+            // If the first slash is after the country calling code, this is permitted.
+            var candidateHasCountryCode =
+                number.CountryCodeSource == PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITH_PLUS_SIGN ||
+                number.CountryCodeSource == PhoneNumber.Types.CountryCodeSource.FROM_NUMBER_WITHOUT_PLUS_SIGN;
+            if (candidateHasCountryCode &&
+                PhoneNumberUtil.NormalizeDigitsOnly(candidate.Substring(0, firstSlashIndex)) ==
+                    number.CountryCode.ToString(CultureInfo.InvariantCulture))
+            {
+                // Any more slashes and this is illegal.
+                return candidate.Substring(secondSlashIndex + 1).Contains('/');
+            }
+            return true;
         }
 
         public static bool ContainsOnlyValidXChars(

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -714,14 +714,7 @@ namespace PhoneNumbers
                     // present.
                     return true;
                 }
-                // Remove the first-group symbol.
-                var candidateNationalPrefixRule = formatRule.NationalPrefixFormattingRule;
-                // We assume that the first-group symbol will never be _before_ the national prefix.
-                candidateNationalPrefixRule =
-                    candidateNationalPrefixRule.Substring(0, candidateNationalPrefixRule.IndexOf("${1}", StringComparison.Ordinal));
-                candidateNationalPrefixRule =
-                    PhoneNumberUtil.NormalizeDigitsOnly(candidateNationalPrefixRule);
-                if (candidateNationalPrefixRule.Length == 0)
+                if (PhoneNumberUtil.FormattingRuleHasFirstGroupOnly(formatRule.NationalPrefixFormattingRule))
                 {
                     // National Prefix not needed for this number.
                     return true;

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -496,7 +496,7 @@ namespace PhoneNumbers
                     {
                         if (!util.IsValidNumber(number) ||
                            !PhoneNumberMatcher.ContainsOnlyValidXChars(number, candidate, util) ||
-                           PhoneNumberMatcher.ContainsMoreThanOneSlash(candidate) ||
+                           PhoneNumberMatcher.ContainsMoreThanOneSlash(number, candidate) ||
                            !PhoneNumberMatcher.IsNationalPrefixPresentIfRequired(number, util))
                         {
                             return false;
@@ -508,7 +508,7 @@ namespace PhoneNumbers
                     {
                         if (!util.IsValidNumber(number) ||
                                 !PhoneNumberMatcher.ContainsOnlyValidXChars(number, candidate, util) ||
-                                PhoneNumberMatcher.ContainsMoreThanOneSlash(candidate) ||
+                                PhoneNumberMatcher.ContainsMoreThanOneSlash(number, candidate) ||
                                 !PhoneNumberMatcher.IsNationalPrefixPresentIfRequired(number, util))
                         {
                             return false;

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -214,6 +214,14 @@ namespace PhoneNumbers
             return false;
         }
 
+        // Mirrors Java's formattingRuleHasFirstGroupOnly(), which checks the rule is just the
+        // first-group symbol optionally wrapped in a single pair of parentheses. Java's placeholder is
+        // the literal "$1"; this port stores national-prefix formatting rules with "$FG" already
+        // expanded to the .NET replacement token "${1}" (see BuildMetadataFromXml), so the same check
+        // is done against "${1}" instead.
+        internal static bool FormattingRuleHasFirstGroupOnly(string nationalPrefixFormattingRule) =>
+            nationalPrefixFormattingRule is "" or "${1}" or "(${1})" or "(${1}" or "${1})";
+
         // Default extension prefix to use when formatting. This will be put in front of any extension
         // component of the number, after the main national number is formatted. For example, if you wish
         // the default extension formatting to be " extn: 3456", then you should specify " extn: " here


### PR DESCRIPTION
## Summary
Small porting-parity pass comparing `PhoneNumberMatcher`/`AsYouTypeFormatter`/`PhoneNumberUtil` against the current upstream Java source (google/libphonenumber). Three genuine behavioral gaps found and fixed, each with a regression test that fails without the fix:

- **`AllNumberGroupsRemainGrouped`**: was missing Java's step of skipping past the country calling code before locating the national-destination-code boundary, and a guard requiring the region to have a national prefix before applying the no-separator fast path.
- **`ContainsMoreThanOneSlash`**: reduced to a bare "≥2 slashes" check; restored Java's carve-out permitting a slash that falls right after the country calling code (e.g. a number followed by a date), and fixed an off-by-one for a slash at index 0.
- **`FormattingRuleHasFirstGroupOnly`**: existed as two separate, both-incorrect copies (in `AsYouTypeFormatter` and inlined in `PhoneNumberMatcher`), neither matching this port's `"${1}"` placeholder token — so metadata rules like Colombia's `"(${1})"` were mishandled. Consolidated into one correct shared helper on `PhoneNumberUtil`, mirroring Java's single shared implementation.

Each change is a minimal, targeted port of the current Java logic — no redesign or unrelated cleanup.

## Test plan
- [x] `dotnet test PhoneNumbers.Test/PhoneNumbers.Test.csproj` — 412/412 passing on net8.0 and net10.0
- [x] New regression tests added for all three fixes, confirmed to fail on the pre-fix code