### PR TITLE
style: small idiomatic-C# cleanups (no behavior change)

### DIFF
--- a/csharp/PhoneNumbers/AreaCodeMap.cs
+++ b/csharp/PhoneNumbers/AreaCodeMap.cs
@@ -31,10 +31,7 @@ namespace PhoneNumbers
 
         private AreaCodeMapStorageStrategy areaCodeMapStorage;
 
-        public AreaCodeMapStorageStrategy GetAreaCodeMapStorage()
-        {
-            return areaCodeMapStorage;
-        }
+        public AreaCodeMapStorageStrategy GetAreaCodeMapStorage() => areaCodeMapStorage;
 
         /// <summary>
         /// Gets the size of the provided area code map storage. The map storage passed-in will be filled
@@ -203,9 +200,6 @@ namespace PhoneNumbers
         /// Dumps the mappings contained in the area code map.
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
-        {
-            return areaCodeMapStorage.ToString();
-        }
+        public override string ToString() => areaCodeMapStorage.ToString();
     }
 }

--- a/csharp/PhoneNumbers/MappingFileProvider.cs
+++ b/csharp/PhoneNumbers/MappingFileProvider.cs
@@ -112,9 +112,7 @@ namespace PhoneNumbers
                     // BuildGeocodingBins target in PhoneNumbers.csproj). The legacy ".txt" suffix
                     // was dropped when the runtime switched from text/zip parsing to direct
                     // binary reads.
-                    var fileName = new StringBuilder();
-                    fileName.Append(languageCode).Append('.').Append(countryCallingCode);
-                    return fileName.ToString();
+                    return $"{languageCode}.{countryCallingCode}";
                 }
             }
             return "";
@@ -125,10 +123,9 @@ namespace PhoneNumbers
         {
             var fullLocale = ConstructFullLocale(language, script, region);
             var fullLocaleStr = fullLocale.ToString();
-            string normalizedLocale;
-            if (LocaleNormalizationMap.TryGetValue(fullLocaleStr, out normalizedLocale))
-                if (setOfLangs.Contains(normalizedLocale))
-                    return normalizedLocale;
+            if (LocaleNormalizationMap.TryGetValue(fullLocaleStr, out var normalizedLocale) &&
+                setOfLangs.Contains(normalizedLocale))
+                return normalizedLocale;
             if (setOfLangs.Contains(fullLocaleStr))
                 return fullLocaleStr;
 

--- a/csharp/PhoneNumbers/MetadataFilter.cs
+++ b/csharp/PhoneNumbers/MetadataFilter.cs
@@ -107,14 +107,14 @@ namespace PhoneNumbers
         public override bool Equals(object obj)
 #endif
         {
-            if (obj == null)
+            if (obj is not MetadataFilter other)
             {
                 return false;
             }
 
-            return blacklist.Count == ((MetadataFilter)obj)?.blacklist?.Count &&
+            return blacklist.Count == other.blacklist.Count &&
                    blacklist.All(kvp =>
-                       ((MetadataFilter)obj).blacklist.TryGetValue(kvp.Key, out var value2) && kvp.Value.SetEquals(value2));
+                       other.blacklist.TryGetValue(kvp.Key, out var value2) && kvp.Value.SetEquals(value2));
         }
 
         public override int GetHashCode()
@@ -263,20 +263,20 @@ namespace PhoneNumbers
             }
 
             foreach (var wildcardChild in wildcardChildren)
-			{
-				foreach (var parent in ExcludableParentFields)
-				{
-					if (!fieldMap.TryGetValue(parent, out var children))
-					{
-						children = new SortedSet<string>();
-						fieldMap.Add(parent, children);
-					}
-					if (!children.Add(wildcardChild)
-						&& children.Count != ExcludableChildFields.Count)
-						throw new Exception(
-							wildcardChild + " is present by itself so remove it from " + parent + "'s group");
-				}
-			}
+            {
+                foreach (var parent in ExcludableParentFields)
+                {
+                    if (!fieldMap.TryGetValue(parent, out var children))
+                    {
+                        children = new SortedSet<string>();
+                        fieldMap.Add(parent, children);
+                    }
+                    if (!children.Add(wildcardChild)
+                        && children.Count != ExcludableChildFields.Count)
+                        throw new Exception(
+                            wildcardChild + " is present by itself so remove it from " + parent + "'s group");
+                }
+            }
 
             return fieldMap;
         }

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -118,7 +118,7 @@ namespace PhoneNumbers
         {
             lock (ThisLock)
             {
-                return instance ?? (instance = new PhoneNumberOfflineGeocoder(MAPPING_DATA_DIRECTORY));
+                return instance ??= new PhoneNumberOfflineGeocoder(MAPPING_DATA_DIRECTORY);
             }
         }
 
@@ -153,7 +153,7 @@ namespace PhoneNumbers
                 {
                     // If the number has already been found valid for one region, then we don't know
                     // which region it belongs to so we return nothing.
-                    if (!regionWhereNumberIsValid.Equals("ZZ"))
+                    if (regionWhereNumberIsValid != "ZZ")
                         return "";
                     regionWhereNumberIsValid = regionCode;
                 }
@@ -166,8 +166,7 @@ namespace PhoneNumbers
         /// </summary>
         private static string GetRegionDisplayName(string regionCode, Locale language)
         {
-            return regionCode == null || regionCode.Equals("ZZ") ||
-                   regionCode.Equals(PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY)
+            return regionCode is null or "ZZ" or PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY
                 ? ""
                 : new Locale("", regionCode).GetDisplayCountry(language.Language);
         }
@@ -248,7 +247,7 @@ namespace PhoneNumbers
             // description, if one exists - if no description exists, we will show the region(country) name
             // for the number.
             var regionCode = phoneUtil.GetRegionCodeForNumber(number);
-            if (userRegion.Equals(regionCode))
+            if (userRegion == regionCode)
             {
                 return GetDescriptionForValidNumber(number, languageCode);
             }

--- a/csharp/PhoneNumbers/PhoneNumberToCarrierMapper.cs
+++ b/csharp/PhoneNumbers/PhoneNumberToCarrierMapper.cs
@@ -105,8 +105,8 @@ namespace PhoneNumbers
         }
 
         private static bool IsMobile(PhoneNumberType numberType) =>
-            numberType == PhoneNumberType.MOBILE
-            || numberType == PhoneNumberType.FIXED_LINE_OR_MOBILE
-            || numberType == PhoneNumberType.PAGER;
+            numberType is PhoneNumberType.MOBILE
+                or PhoneNumberType.FIXED_LINE_OR_MOBILE
+                or PhoneNumberType.PAGER;
     }
 }

--- a/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
+++ b/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
@@ -91,8 +91,8 @@ namespace PhoneNumbers
         /// </returns>
         public List<string> GetTimeZonesForNumber(PhoneNumber number)
         {
-            PhoneNumberType numberType = phoneUtil.GetNumberType(number);
-            if (PhoneNumberType.UNKNOWN == numberType)
+            var numberType = phoneUtil.GetNumberType(number);
+            if (numberType == PhoneNumberType.UNKNOWN)
                 return UNKNOWN_TIMEZONE.ToList();
             else if (!phoneUtil.IsNumberGeographical(numberType, number.CountryCode))
             {
@@ -141,12 +141,7 @@ namespace PhoneNumbers
         {
             lock (lockObj)
             {
-                if (null == instance)
-                {
-                    instance = Create(TZMAP_DATA_DIRECTORY);
-                }
-
-                return instance;
+                return instance ??= Create(TZMAP_DATA_DIRECTORY);
             }
         }
     }

--- a/csharp/PhoneNumbers/PrefixFileReader.cs
+++ b/csharp/PhoneNumbers/PrefixFileReader.cs
@@ -109,7 +109,7 @@ namespace PhoneNumbers
         }
 
         private static bool MayFallBackToEnglish(string lang) =>
-            !lang.Equals("zh") && !lang.Equals("ja") && !lang.Equals("ko");
+            lang is not "zh" and not "ja" and not "ko";
 
         private AreaCodeMap GetPhonePrefixDescriptions(int prefixMapKey, string language, string script, string region)
         {


### PR DESCRIPTION
## Summary
A handful of small, low-risk readability cleanups in older `csharp/PhoneNumbers/` files that still read like a 2011-era line-by-line Java port. Not chasing Java parity, not fixing bugs (with one minor exception noted below) — just more idiomatic C#. Kept every change local to its statement/expression so nothing drifts from the Java source's method-level structure.

- **`PhoneNumberOfflineGeocoder.cs`**: `instance ?? (instance = ...)` → `instance ??= ...`; `.Equals("ZZ")` / `== null` string checks → `==` and `is null or "..."` patterns.
- **`MappingFileProvider.cs`**: collapsed a nested `TryGetValue` + `if` into one condition with an inline `out var`; replaced a 3-call `StringBuilder` chain with string interpolation for the simple `"<lang>.<cc>"` case.
- **`MetadataFilter.cs`**: `Equals(object)` cast `obj` to `MetadataFilter` twice via `?.`, which throws `InvalidCastException` for a non-null argument of a different type instead of returning `false` per the `Equals` contract — replaced with an `is not MetadataFilter other` pattern match, which is both more idiomatic and correct. Also fixed a block that had drifted to tab indentation while the rest of the file uses spaces.
- **`PhoneNumberToTimeZonesMapper.cs`**: dropped Yoda conditions (`null == instance`, `PhoneNumberType.UNKNOWN == numberType`) and folded the singleton null-check/assign into `??=`.
- **`PhoneNumberToCarrierMapper.cs` / `PrefixFileReader.cs`**: turned an OR-chain and an AND-chain of equality checks into `is ... or ...` / `is not ... and not ...` patterns.
- **`AreaCodeMap.cs`**: two one-line methods made expression-bodied.

## Test plan
- [x] `dotnet build csharp` — clean build, no new warnings (repo has `TreatWarningsAsErrors`)
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 409+23 passing on both net8.0 and net10.0