### PR TITLE
ci: skip dotnet's first-time-experience setup in run_performance_tests

### DIFF
--- a/.github/workflows/run_performance_tests.yml
+++ b/.github/workflows/run_performance_tests.yml
@@ -41,6 +41,17 @@ jobs:
   run_performance_tests:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    env:
+      # The "Build both benchmark trees" step below runs two `dotnet build` invocations
+      # concurrently, and this is the only workflow that does - everywhere else, an earlier
+      # sequential `dotnet restore`/`build` step already completes the SDK's one-time setup
+      # (NuGet migrations, telemetry sentinel) before anything runs in parallel. Here, both
+      # concurrent invocations can race to perform that setup at once, racing on the same
+      # mkdir/mutex and failing with "The system cannot open the device or file specified" /
+      # EEXIST. Skipping first-time setup entirely removes the race instead of reordering
+      # around it.
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_NOLOGO: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
`run_performance_tests.yml`'s "Build both benchmark trees" step runs two `dotnet build` invocations concurrently via `&` — the only workflow that does, since everywhere else an earlier sequential `dotnet restore`/`build` step already completes the .NET SDK's one-time first-use setup (NuGet migrations, telemetry sentinel) before anything runs in parallel. Here, both concurrent invocations can race to perform that setup at once, both trying to create the same `NuGet-Migrations` mutex/directory, and one loses with:

```
System.IO.IOException: The system cannot open the device or file specified. : 'NuGet-Migrations'.
One or more system calls failed: mkdir("/tmp/.dotnet/shm/session...", ...) == -1; errno == EEXIST;
```

Seen failing PR #409's `run_performance_tests` check — unrelated to that PR's actual diff, purely this race.

`DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true` (plus `DOTNET_NOLOGO: true` for consistency) removes the race by skipping the setup entirely rather than reordering around it.

## Test plan
- [x] Validated workflow YAML parses correctly
- [x] Root cause confirmed by log inspection: no other workflow parallelizes `dotnet build` invocations, and none currently set these env vars