### PR TITLE
style: idiomatic cleanups in small metadata/storage utility files

### DIFF
--- a/csharp/PhoneNumbers/AreaCodeMapStorageStrategy.cs
+++ b/csharp/PhoneNumbers/AreaCodeMapStorageStrategy.cs
@@ -60,19 +60,13 @@ namespace PhoneNumbers
         /// The number of entries contained in the area code map.
         /// </summary>
         /// <returns>The number of entries contained in the area code map.</returns>
-        public int GetNumOfEntries()
-        {
-            return NumOfEntries;
-        }
+        public int GetNumOfEntries() => NumOfEntries;
 
         /// <summary>
         /// The set containing the possible lengths of prefixes.
         /// </summary>
         /// <returns>The set containing the possible lengths of prefixes.</returns>
-        public List<int> GetPossibleLengths()
-        {
-            return PossibleLengths;
-        }
+        public List<int> GetPossibleLengths() => PossibleLengths;
 
         public override string ToString()
         {

--- a/csharp/PhoneNumbers/DefaultMapStorage.cs
+++ b/csharp/PhoneNumbers/DefaultMapStorage.cs
@@ -32,20 +32,11 @@ namespace PhoneNumbers
         private int[] phoneNumberPrefixes;
         private string[] descriptions;
 
-        public override int GetPrefix(int index)
-        {
-            return phoneNumberPrefixes[index];
-        }
+        public override int GetPrefix(int index) => phoneNumberPrefixes[index];
 
-        public override int GetStorageSize()
-        {
-            return phoneNumberPrefixes.Length * sizeof(int) + descriptions.Sum(d => d.Length);
-        }
+        public override int GetStorageSize() => phoneNumberPrefixes.Length * sizeof(int) + descriptions.Sum(d => d.Length);
 
-        public override string GetDescription(int index)
-        {
-            return descriptions[index];
-        }
+        public override string GetDescription(int index) => descriptions[index];
 
         public override void ReadFromSortedMap(SortedDictionary<int, string> sortedAreaCodeMap)
         {

--- a/csharp/PhoneNumbers/FlyweightMapStorage.cs
+++ b/csharp/PhoneNumbers/FlyweightMapStorage.cs
@@ -49,16 +49,10 @@ namespace PhoneNumbers
         // The number of bytes used to store a phone number prefix.
         private int prefixSizeInBytes;
 
-        public override int GetPrefix(int index)
-        {
-            return ReadWordFromBuffer(phoneNumberPrefixes, prefixSizeInBytes, index);
-        }
+        public override int GetPrefix(int index) => ReadWordFromBuffer(phoneNumberPrefixes, prefixSizeInBytes, index);
 
-        public override int GetStorageSize()
-        {
-            return phoneNumberPrefixes.GetCapacity() + descriptionIndexes.GetCapacity()
-                   + descriptionPool.Sum(d => d.Length);
-        }
+        public override int GetStorageSize() =>
+            phoneNumberPrefixes.GetCapacity() + descriptionIndexes.GetCapacity() + descriptionPool.Sum(d => d.Length);
 
         /// <summary>
         /// This implementation returns the same string (same identity) when called for multiple indexes
@@ -124,10 +118,8 @@ namespace PhoneNumbers
         /// <summary>
         /// Gets the minimum number of bytes that can be used to store the provided <c>value</c>.
         /// </summary>
-        private static int GetOptimalNumberOfBytesForValue(int value)
-        {
-            return value <= short.MaxValue ? ShortNumBytes : IntNumBytes;
-        }
+        private static int GetOptimalNumberOfBytesForValue(int value) =>
+            value <= short.MaxValue ? ShortNumBytes : IntNumBytes;
 
         /// <summary>
         /// Stores the provided <c>value</c> to the provided byte <c>buffer</c> at the specified <c>index</c> using the provided <c>wordSize</c> in bytes. Note that only integer and short sizes are
@@ -176,30 +168,15 @@ namespace PhoneNumbers
                 bytes = new byte[size];
             }
 
-            public void PutShort(int offset, short value)
-            {
-                BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(offset), value);
-            }
+            public void PutShort(int offset, short value) => BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(offset), value);
 
-            public void PutInt(int offset, int value)
-            {
-                BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset), value);
-            }
+            public void PutInt(int offset, int value) => BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset), value);
 
-            public short GetShort(int offset)
-            {
-                return BinaryPrimitives.ReadInt16LittleEndian(bytes.AsSpan(offset));
-            }
+            public short GetShort(int offset) => BinaryPrimitives.ReadInt16LittleEndian(bytes.AsSpan(offset));
 
-            public int GetInt(int offset)
-            {
-                return BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset));
-            }
+            public int GetInt(int offset) => BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset));
 
-            public int GetCapacity()
-            {
-                return bytes.Length;
-            }
+            public int GetCapacity() => bytes.Length;
         }
     }
 }

--- a/csharp/PhoneNumbers/LeniencyExtensions.cs
+++ b/csharp/PhoneNumbers/LeniencyExtensions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Leniency=PhoneNumbers.PhoneNumberUtil.Leniency;
+﻿using Leniency = PhoneNumbers.PhoneNumberUtil.Leniency;
+
 namespace PhoneNumbers
 {
     public static class LeniencyExtensions
@@ -9,7 +9,7 @@ namespace PhoneNumbers
             PhoneNumber number,
             string candidate,
             PhoneNumberUtil util,
-            PhoneNumberMatcher matcher)=>
+            PhoneNumberMatcher matcher) =>
             util.Verify(leniency, number, candidate, util, matcher);
     }
 }

--- a/csharp/PhoneNumbers/LocaleData.cs
+++ b/csharp/PhoneNumbers/LocaleData.cs
@@ -40,7 +40,7 @@ namespace PhoneNumbers
             foreach (var country in LocaleNames.SupportedCountries())
             {
                 var names = LocaleNames.ForCountry(country);
-                if (names != null)
+                if (names is not null)
                     builder[country] = names.ToImmutableDictionary();
             }
             return builder.ToImmutable();

--- a/csharp/PhoneNumbers/LocaleNames.cs
+++ b/csharp/PhoneNumbers/LocaleNames.cs
@@ -56,12 +56,12 @@ namespace PhoneNumbers
         /// the caller's job, as it was when this data was a single generated dictionary.
         /// </summary>
         internal static Dictionary<string, string> ForCountry(string country) =>
-            country == null ? null : Cache.GetOrAdd(country, LoadFactory);
+            country is null ? null : Cache.GetOrAdd(country, LoadFactory);
 
         private static Dictionary<string, string> Load(string country)
         {
             using var raw = Assembly.GetManifestResourceStream(ResourcePrefix + country);
-            if (raw == null)
+            if (raw is null)
                 return null;
 
             using var gz = new GZipStream(raw, CompressionMode.Decompress);

--- a/csharp/PhoneNumbers/MetadataLoader.cs
+++ b/csharp/PhoneNumbers/MetadataLoader.cs
@@ -129,7 +129,7 @@ namespace PhoneNumbers
             // PhoneNumbers.MetadataBuilder). Decompress on the way out so callers see the plain
             // bin format they already expect.
             var raw = assembly.GetManifestResourceStream(resourcePrefix + fileName);
-            return raw == null ? null : new GZipStream(raw, CompressionMode.Decompress);
+            return raw is null ? null : new GZipStream(raw, CompressionMode.Decompress);
         }
     }
 }

--- a/csharp/PhoneNumbers/MetadataManager.cs
+++ b/csharp/PhoneNumbers/MetadataManager.cs
@@ -56,7 +56,7 @@ namespace PhoneNumbers
         /// <param name="loader">Loader to use for both supplementary metadata file types.</param>
         public static void SetMetadataLoader(IMetadataLoader loader)
         {
-            if (loader == null) throw new ArgumentNullException(nameof(loader));
+            if (loader is null) throw new ArgumentNullException(nameof(loader));
             alternateFormatsSource = new(loader, AlternateFormatsPrefix);
             shortNumberSource = new(loader, ShortNumberMetadataPrefix);
         }

--- a/csharp/PhoneNumbers/MetadataSource.cs
+++ b/csharp/PhoneNumbers/MetadataSource.cs
@@ -62,7 +62,7 @@ namespace PhoneNumbers
         private PhoneMetadata? Load(string key)
         {
             using var stream = loader.LoadMetadata($"{filePrefix}_{key}");
-            return stream == null ? null : BuildMetadataFromBin.ReadMetadata(stream);
+            return stream is null ? null : BuildMetadataFromBin.ReadMetadata(stream);
         }
     }
 }

--- a/csharp/PhoneNumbers/PhoneNumberMatch.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatch.cs
@@ -33,9 +33,9 @@ namespace PhoneNumbers
         {
             if (start < 0)
                 throw new ArgumentException("Start index must be >= 0.", nameof(start));
-            if (rawString == null)
+            if (rawString is null)
                 throw new ArgumentNullException(nameof(rawString));
-            if (number == null)
+            if (number is null)
                 throw new ArgumentNullException(nameof(number));
             Start = start;
             RawString = rawString;
@@ -50,8 +50,7 @@ namespace PhoneNumbers
         {
             if (this == obj)
                 return true;
-            var p = (obj as PhoneNumberMatch);
-            return p != null && RawString == p.RawString && Start == p.Start && Number.Equals(p.Number);
+            return obj is PhoneNumberMatch p && RawString == p.RawString && Start == p.Start && Number.Equals(p.Number);
         }
 
         public override int GetHashCode()
@@ -63,9 +62,6 @@ namespace PhoneNumbers
             return hash;
         }
 
-        public override string ToString()
-        {
-            return "PhoneNumberMatch [" + Start + "," + Length + ") " + RawString;
-        }
+        public override string ToString() => $"PhoneNumberMatch [{Start},{Length}) {RawString}";
     }
 }

--- a/csharp/PhoneNumbers/PhoneNumberMatch.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatch.cs
@@ -50,7 +50,10 @@ namespace PhoneNumbers
         {
             if (this == obj)
                 return true;
-            return obj is PhoneNumberMatch p && RawString == p.RawString && Start == p.Start && Number.Equals(p.Number);
+            if (obj is null || GetType() != obj.GetType())
+                return false;
+            var p = (PhoneNumberMatch)obj;
+            return RawString == p.RawString && Start == p.Start && Number.Equals(p.Number);
         }
 
         public override int GetHashCode()

--- a/csharp/PhoneNumbers/TimezoneMapDataReader.cs
+++ b/csharp/PhoneNumbers/TimezoneMapDataReader.cs
@@ -13,10 +13,10 @@ namespace PhoneNumbers
         private static List<string> LineReader(StreamReader reader, char fieldDelimiter = '|')
         {
             string line;
-            while (null != (line = reader.ReadLine()))
+            while ((line = reader.ReadLine()) != null)
             {
                 line = line.Trim();
-                if (line.Length < 1 || '#' == line[0])
+                if (line.Length < 1 || line[0] == '#')
                     continue;
 
                 var indexOfDelimiter = line.IndexOf(fieldDelimiter);
@@ -38,18 +38,16 @@ namespace PhoneNumbers
         /// <returns></returns>
         internal static IDictionary<long, string[]> GetPrefixMap(Stream fp, char[] splitters)
         {
-            if (null == fp)
+            if (fp is null)
                 return ImmutableDictionary<long, string[]>.Empty;
 
             var tmpMap = new SortedDictionary<long, string[]>();
-            using (var lines = new StreamReader(fp, Encoding.UTF8))
+            using var lines = new StreamReader(fp, Encoding.UTF8);
+            List<string> line;
+            while ((line = LineReader(lines)) != null)
             {
-                List<string> line;
-                while (null != (line = LineReader(lines)))
-                {
-                    var pnPrefix = line[0];
-                    tmpMap[long.Parse(pnPrefix, CultureInfo.InvariantCulture)] = line[1].Split(splitters, StringSplitOptions.RemoveEmptyEntries);
-                }
+                var pnPrefix = line[0];
+                tmpMap[long.Parse(pnPrefix, CultureInfo.InvariantCulture)] = line[1].Split(splitters, StringSplitOptions.RemoveEmptyEntries);
             }
 
             return tmpMap;


### PR DESCRIPTION
## Summary
Part of an ongoing sweep applying idiomatic-C# readability cleanups across the codebase (same spirit as #409): pattern matching (`is null`/`is not null`), dropping Yoda conditions, expression-bodied trivial members. No behavior change, no Java-parity changes — same logic, nicer expression.

Files touched: `AreaCodeMapStorageStrategy.cs`, `DefaultMapStorage.cs`, `FlyweightMapStorage.cs`, `LeniencyExtensions.cs`, `LocaleData.cs`, `LocaleNames.cs`, `MetadataLoader.cs`, `MetadataManager.cs`, `MetadataSource.cs`, `PhoneNumberMatch.cs`, `TimezoneMapDataReader.cs`.

(`Util.cs`, `RegexCache.cs`, `MissingMetadataException.cs`, `PhoneNumberFormat.cs`, `PhoneNumberType.cs`, `InternalRegexOptions.cs`, `PhoneRegex.cs`, `NumberParseException.cs`, `BuildPrefixMapFromBin.cs` were reviewed and left untouched — already idiomatic.)

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.slnx` — clean, 0 warnings (repo has `TreatWarningsAsErrors`)
- [x] `dotnet test csharp/PhoneNumbers.Test` — 414/414 passing on net8.0 and net10.0