### PR TITLE
style: idiomatic cleanups in AsYouTypeFormatter and PhoneNumberMatcher

### DIFF
--- a/csharp/PhoneNumbers/AsYouTypeFormatter.cs
+++ b/csharp/PhoneNumbers/AsYouTypeFormatter.cs
@@ -414,7 +414,7 @@ namespace PhoneNumbers
                         {
                             isExpectingCountryCallingCode = false;
                         }
-                        return prefixBeforeNationalNumber.ToString() + nationalNumber.ToString();
+                        return prefixBeforeNationalNumber + nationalNumber.ToString();
                     }
                     if (possibleFormats.Count > 0)
                     {  // The formatting pattern is already chosen.
@@ -553,7 +553,7 @@ namespace PhoneNumbers
                 return prefixBeforeNationalNumber.ToString() + SeparatorBeforeNationalNumber
                        + nationalNumberStr;
             }
-            return prefixBeforeNationalNumber.ToString() + nationalNumberStr;
+            return prefixBeforeNationalNumber + nationalNumberStr;
         }
 
         // Attempts to set the formatting template and returns a string which contains the formatted

--- a/csharp/PhoneNumbers/AsYouTypeFormatter.cs
+++ b/csharp/PhoneNumbers/AsYouTypeFormatter.cs
@@ -106,7 +106,7 @@ namespace PhoneNumbers
         // This is the minimum length of national number accrued that is required to trigger the
         // formatter. The first element of the leadingDigitsPattern of each numberFormat contains a
         // regular expression that matches up to this number of digits.
-        private static readonly int MinLeadingDigitsLength = 3;
+        private const int MinLeadingDigitsLength = 3;
 
         // The digits that have not been entered yet will be represented by a \u2008, the punctuation
         // space.
@@ -163,7 +163,7 @@ namespace PhoneNumbers
             {
                 var numberFormat = possibleFormats[0];
                 var pattern = numberFormat.Pattern;
-                if (currentFormattingPattern.Equals(pattern))
+                if (currentFormattingPattern == pattern)
                     return false;
                 if (CreateFormattingTemplate(numberFormat))
                 {
@@ -414,7 +414,7 @@ namespace PhoneNumbers
                         {
                             isExpectingCountryCallingCode = false;
                         }
-                        return prefixBeforeNationalNumber + nationalNumber.ToString();
+                        return prefixBeforeNationalNumber.ToString() + nationalNumber.ToString();
                     }
                     if (possibleFormats.Count > 0)
                     {  // The formatting pattern is already chosen.
@@ -467,7 +467,7 @@ namespace PhoneNumbers
                 var indexOfPreviousNdd = prefixBeforeNationalNumber.ToString().LastIndexOf(extractedNationalPrefix, StringComparison.Ordinal);
                 prefixBeforeNationalNumber.Length = indexOfPreviousNdd;
             }
-            return !extractedNationalPrefix.Equals(RemoveNationalPrefixFromNationalNumber());
+            return extractedNationalPrefix != RemoveNationalPrefixFromNationalNumber();
         }
 
         private bool IsDigitOrLeadingPlusSign(char nextChar)
@@ -498,7 +498,7 @@ namespace PhoneNumbers
                     // in that way.
                     var fullOutput = AppendNationalNumber(formattedNumber);
                     var formattedNumberDigitsOnly = PhoneNumberUtil.NormalizeDiallableCharsOnly(fullOutput);
-                    if (formattedNumberDigitsOnly.Equals(accruedInputWithoutFormatting.ToString()))
+                    if (formattedNumberDigitsOnly == accruedInputWithoutFormatting.ToString())
                     {
                         // If it's the same (i.e entered number and format is same), then it's
                         // safe to return this in formatted number as nothing is lost / added.
@@ -533,7 +533,6 @@ namespace PhoneNumbers
             return currentOutputIndex;
         }
 
-
         /// <summary>
         /// Combines the national number with any prefix (IDD/+ and country code or national prefix) that
         /// was collected. A space will be inserted between them if the current formatting template
@@ -554,7 +553,7 @@ namespace PhoneNumbers
                 return prefixBeforeNationalNumber.ToString() + SeparatorBeforeNationalNumber
                        + nationalNumberStr;
             }
-            return prefixBeforeNationalNumber + nationalNumberStr;
+            return prefixBeforeNationalNumber.ToString() + nationalNumberStr;
         }
 
         // Attempts to set the formatting template and returns a string which contains the formatted
@@ -697,11 +696,11 @@ namespace PhoneNumbers
             nationalNumber.Length = 0;
             nationalNumber.Append(numberWithoutCountryCallingCode);
             var newRegionCode = phoneUtil.GetRegionCodeForCountryCode(countryCode);
-            if (PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY.Equals(newRegionCode))
+            if (PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY == newRegionCode)
             {
                 currentMetadata = phoneUtil.GetMetadataForNonGeographicalRegion(countryCode);
             }
-            else if (!newRegionCode.Equals(defaultCountry))
+            else if (newRegionCode != defaultCountry)
             {
                 currentMetadata = GetMetadataForRegion(newRegionCode);
             }

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -343,7 +343,7 @@ namespace PhoneNumbers
                     }
                     var withoutLastGroup = candidate.Substring(0, lastGroupStart);
                     withoutLastGroup = TrimAfterUnwantedChars(withoutLastGroup);
-                    if (withoutLastGroup.Equals(firstGroupOnly))
+                    if (withoutLastGroup == firstGroupOnly)
                     {
                         // If there are only two groups, then the group "without the last group" is the same as
                         // the first group. In these cases, we don't want to re-check the number group, so we exit
@@ -513,8 +513,8 @@ namespace PhoneNumbers
                 formattedNumberGroupIndex > 0 && candidateNumberGroupIndex >= 0;
                 formattedNumberGroupIndex--, candidateNumberGroupIndex--)
             {
-                if (!candidateGroups[candidateNumberGroupIndex].Equals(
-                    formattedNumberGroups[formattedNumberGroupIndex]))
+                if (candidateGroups[candidateNumberGroupIndex] !=
+                    formattedNumberGroups[formattedNumberGroupIndex])
                 {
                     return false;
                 }
@@ -530,14 +530,16 @@ namespace PhoneNumbers
         /// prefix, and return it as a set of digit blocks that would be formatted together following
         /// standard formatting rules.
         /// </summary>
-        private static IList<string> GetNationalNumberGroups(PhoneNumberUtil util, PhoneNumber number) {
+        private static IList<string> GetNationalNumberGroups(PhoneNumberUtil util, PhoneNumber number)
+        {
             // This will be in the format +CC-DG1-DG2-DGX;ext=EXT where DG1..DGX represents groups of
             // digits.
             var rfc3966Format = util.Format(number, PhoneNumberFormat.RFC3966);
             // We remove the extension part from the formatted string before splitting it into different
             // groups.
             var endIndex = rfc3966Format.IndexOf(';');
-            if (endIndex < 0) {
+            if (endIndex < 0)
+            {
                 endIndex = rfc3966Format.Length;
             }
             // The country-code will have a '-' following it.
@@ -602,11 +604,13 @@ namespace PhoneNumbers
             {
                 foreach (var alternateFormat in alternateFormats.numberFormat_)
                 {
-                    if (alternateFormat.LeadingDigitsPatternCount > 0) {
+                    if (alternateFormat.LeadingDigitsPatternCount > 0)
+                    {
                         // There is only one leading digits pattern for alternate formats.
                         var pattern =
                             PhoneRegex.Get(alternateFormat.GetLeadingDigitsPattern(0));
-                        if (!pattern.IsMatchBeginning(nationalSignificantNumber)) {
+                        if (!pattern.IsMatchBeginning(nationalSignificantNumber))
+                        {
                             // Leading digits don't match; try another one.
                             continue;
                         }
@@ -692,8 +696,8 @@ namespace PhoneNumbers
                         // This is the extension sign case, in which the 'x' or 'X' should always precede the
                         // extension number.
                     }
-                    else if (!PhoneNumberUtil.NormalizeDigitsOnly(candidate.Substring(index)).Equals(
-                        number.Extension))
+                    else if (PhoneNumberUtil.NormalizeDigitsOnly(candidate.Substring(index)) !=
+                        number.Extension)
                     {
                         return false;
                     }


### PR DESCRIPTION
## Summary
Part of an ongoing sweep bringing every C# file up to more idiomatic C# conventions (same spirit as #409), without straying from the Java source's method structure.

- `string.Equals(string)` -> `==`/`!=` in both files (the Java source needs `.equals()` since Java has no operator overloading for strings; the direct port carried that over unnecessarily).
- `AsYouTypeFormatter.MinLeadingDigitsLength`: `static readonly int` -> `const int` (it mirrors Java's `static final int MIN_LEADING_DIGITS_LENGTH = 3`, a true compile-time constant, and matches the file's other `const` fields).
- `AsYouTypeFormatter`: made a couple of `StringBuilder + string` concatenations use explicit `.ToString()` instead of relying on the compiler's implicit `ToString()` call via the `string operator +(object, string)` overload — same behavior, clearer intent.
- `PhoneNumberMatcher`: fixed a couple of spots that had drifted to K&R brace style to match the file's dominant Allman style; dropped a stray double blank line in `AsYouTypeFormatter`.

No behavior changes. Not touching the Java-parity fixes from #408 in these same two files.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.slnx` — clean, 0 warnings (TreatWarningsAsErrors)
- [x] `dotnet test csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj` — 414/414 passing on net8.0 and net10.0