### PR TITLE
style: idiomatic cleanups in matcher/formatter/filter test suites

### DIFF
--- a/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
@@ -665,12 +665,12 @@ namespace PhoneNumbers.Test
                 var iterator =
                     FindNumbersForLeniency(test.RawString, test.Region, leniency);
                 var match = iterator.FirstOrDefault();
-                if (match == null)
+                if (match is null)
                 {
                     noMatchFoundCount++;
                     Console.WriteLine("No match found in " + test + " for leniency: " + leniency);
                 }
-                else if (!test.RawString.Equals(match.RawString))
+                else if (test.RawString != match.RawString)
                 {
                     wrongMatchFoundCount++;
                     Console.WriteLine("Found wrong match in test " + test +
@@ -691,7 +691,7 @@ namespace PhoneNumbers.Test
                 var iterator =
                     FindNumbersForLeniency(test.RawString, test.Region, leniency);
                 var match = iterator.FirstOrDefault();
-                if (match != null)
+                if (match is not null)
                 {
                     matchFoundCount++;
                     Console.WriteLine("Match found in " + test + " for leniency: " + leniency);


### PR DESCRIPTION
## Summary
Conservative idiomatic-C# pass over `TestPhoneNumberMatcher.cs`, `TestAsYouTypeFormatter.cs`, and `TestMetadataFilter.cs`. These are near line-by-line ports of the upstream Java test suite, so scope was deliberately narrow: only non-assertion helper code was touched, and no assertion logic, expected values, test data, or test method identity was changed.

- `TestPhoneNumberMatcher.cs`: `== null`/`!= null` → `is null`/`is not null`, and a string `.Equals()` → `!=`, all in the `DoTestNumberMatchesForLeniency`/`DoTestNumberNonMatchesForLeniency` helpers (not inside any `Assert.*` call).
- `TestAsYouTypeFormatter.cs`, `TestMetadataFilter.cs`: reviewed, no safe changes found. `TestMetadataFilter.cs` has one `.Equals(null)` call, but it's `TestEquals_WhenNull_ReturnsFalse` deliberately exercising `MetadataFilter.Equals`'s null-argument behavior — left untouched since that's the point of the test.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.slnx` — 0 warnings, 0 errors
- [x] `dotnet test csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj` — 414/414 passing on net8.0 and net10.0 (same count as before)