### PR TITLE
style: idiomatic cleanups in mid-size test files

### DIFF
--- a/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
+++ b/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
@@ -37,7 +37,7 @@ namespace PhoneNumbers.Test
             {
                 var exampleNumber =
                 phoneNumberUtil.GetExampleNumberForType(regionCode, exampleNumberRequestedType);
-                if (exampleNumber != null)
+                if (exampleNumber is not null)
                 {
                     if (!phoneNumberUtil.IsValidNumber(exampleNumber))
                     {

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberProperties.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberProperties.cs
@@ -119,7 +119,7 @@ namespace PhoneNumbers.Test
         public void ReadOnlySurfaceNeverThrows(int regionSeed, int digitIndex, int digitValue)
         {
             var number = Candidate(regionSeed, digitIndex, digitValue);
-            if (number == null)
+            if (number is null)
                 return;
 
             PhoneUtil.IsValidNumber(number);
@@ -145,7 +145,7 @@ namespace PhoneNumbers.Test
         public void ValidNumbersRoundTripThroughE164(int regionSeed, int digitIndex, int digitValue)
         {
             var number = Candidate(regionSeed, digitIndex, digitValue);
-            if (number == null || !PhoneUtil.IsValidNumber(number))
+            if (number is null || !PhoneUtil.IsValidNumber(number))
                 return;
 
             var e164 = PhoneUtil.Format(number, PhoneNumberFormat.E164);
@@ -162,7 +162,7 @@ namespace PhoneNumbers.Test
         public void ValidNumbersAreAlsoPossible(int regionSeed, int digitIndex, int digitValue)
         {
             var number = Candidate(regionSeed, digitIndex, digitValue);
-            if (number == null || !PhoneUtil.IsValidNumber(number))
+            if (number is null || !PhoneUtil.IsValidNumber(number))
                 return;
 
             Assert.True(PhoneUtil.IsPossibleNumber(number),
@@ -175,7 +175,7 @@ namespace PhoneNumbers.Test
         {
             var first = Candidate(firstSeed, digitIndex, digitValue);
             var second = Candidate(secondSeed, digitIndex + 1, digitValue + 1);
-            if (first == null || second == null)
+            if (first is null || second is null)
                 return;
 
             Assert.Equal(PhoneUtil.IsNumberMatch(first, second), PhoneUtil.IsNumberMatch(second, first));
@@ -189,7 +189,7 @@ namespace PhoneNumbers.Test
         private static PhoneNumber? Candidate(int regionSeed, int digitIndex, int digitValue)
         {
             var example = PhoneUtil.GetExampleNumber(Regions[Mod(regionSeed, Regions.Length)]);
-            if (example == null)
+            if (example is null)
                 return null;
 
             var digits = example.NationalNumber.ToString(CultureInfo.InvariantCulture).ToCharArray();

--- a/csharp/PhoneNumbers.Test/TestPublicApiRobustness.cs
+++ b/csharp/PhoneNumbers.Test/TestPublicApiRobustness.cs
@@ -175,7 +175,7 @@ namespace PhoneNumbers.Test
             foreach (var regionCode in PhoneUtil.GetSupportedRegions())
             {
                 var example = PhoneUtil.GetExampleNumber(regionCode);
-                if (example == null)
+                if (example is null)
                     continue;
 
                 try
@@ -215,7 +215,7 @@ namespace PhoneNumbers.Test
             {
                 call();
             }
-            catch (Exception e) when (allowed == null || e.GetType() != allowed)
+            catch (Exception e) when (allowed is null || e.GetType() != allowed)
             {
                 failures.Add($"{what}({input}) threw {e.GetType().Name}: {e.Message}");
             }


### PR DESCRIPTION
## Summary
Part of the ongoing idiomatic-C# cleanup sweep (see #409, #412-#419). Very conservative pass over 10 mid-size files in `PhoneNumbers.Test/`: `TestBuildMetadataFromXml.cs`, `TestShortNumberInfo.cs`, `TestPhoneNumberToCarrierMapper.cs`, `TestPhoneNumberToTimeZonesMapper.cs`, `TestPublicApiRobustness.cs`, `TestPhoneNumberOfflineGeocoder.cs`, `TestAreaCodeMap.cs`, `TestPhoneNumberProperties.cs`, `TestBuildPrefixMapFromBin.cs`, `TestExampleNumbers.cs`.

Most of these are near line-by-line ports of upstream Google Java test suites, so this PR intentionally only touches non-assertion helper/setup code — no assertion logic, test data, expected values, or method structure changed. Only 3 files had anything to change:

- `TestPublicApiRobustness.cs`, `TestPhoneNumberProperties.cs`, `TestExampleNumbers.cs`: `== null`/`!= null` guard clauses → `is null`/`is not null`.

The other 7 files were reviewed and left untouched — nothing outside an `Assert.*` call was a safe, unambiguous win.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.slnx` — 0 warnings, 0 errors
- [x] `dotnet test csharp/PhoneNumbers.Test/PhoneNumbers.Test.csproj` — 414/414 passing on net8.0 and net10.0 (same count as before)