### PR TITLE
internal: seal singleton-style types with no accessible constructor

### DIFF
--- a/csharp/PhoneNumbers/MetadataFilter.cs
+++ b/csharp/PhoneNumbers/MetadataFilter.cs
@@ -29,7 +29,7 @@ namespace PhoneNumbers
     /// changes without notice. Any changes are not guaranteed to be reflected in the versioning scheme
     /// of the public API, nor in release notes.
     /// </summary>
-    public class MetadataFilter
+    public sealed class MetadataFilter
     {
         // The following 3 sets comprise all the PhoneMetadata fields as defined at phonemetadata.proto
         // which may be excluded from customized serializations of the binary metadata. Fields that are

--- a/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
+++ b/csharp/PhoneNumbers/PhoneNumberOfflineGeocoder.cs
@@ -92,7 +92,7 @@ namespace PhoneNumbers
     /// files generated at build time by <c>PhoneNumbers.MetadataBuilder</c>, via
     /// <see cref="PrefixFileReader"/>.
     /// </remarks>
-    public class PhoneNumberOfflineGeocoder
+    public sealed class PhoneNumberOfflineGeocoder
     {
         private static PhoneNumberOfflineGeocoder instance;
         private const string MAPPING_DATA_DIRECTORY = "geocoding.";

--- a/csharp/PhoneNumbers/PhoneNumberToCarrierMapper.cs
+++ b/csharp/PhoneNumbers/PhoneNumberToCarrierMapper.cs
@@ -27,7 +27,7 @@ namespace PhoneNumbers
     /// number portability the number might not belong to the returned carrier anymore.
     /// </para>
     /// </summary>
-    public class PhoneNumberToCarrierMapper
+    public sealed class PhoneNumberToCarrierMapper
     {
         // Corresponds to resources/carrier/ embedded with LinkBase="carrier".
         private const string MAPPING_DATA_DIRECTORY = "carrier.";

--- a/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
+++ b/csharp/PhoneNumbers/PhoneNumberToTimeZonesMapper.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace PhoneNumbers
 {
-    public class PhoneNumberToTimeZonesMapper
+    public sealed class PhoneNumberToTimeZonesMapper
     {
         private static readonly string[] UNKNOWN_TIMEZONE = { "Etc/Unknown" };
 

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -53,7 +53,7 @@ namespace PhoneNumbers
     /// @author Lara Rennie
     /// -->
     /// </summary>
-    public partial class PhoneNumberUtil
+    public sealed partial class PhoneNumberUtil
     {
         // The minimum and maximum length of the national significant number.
         private const int MIN_LENGTH_FOR_NSN = 2;

--- a/csharp/PhoneNumbers/ShortNumberInfo.cs
+++ b/csharp/PhoneNumbers/ShortNumberInfo.cs
@@ -32,7 +32,7 @@ namespace PhoneNumbers
     /// @author Shaopeng Jia
     /// @author David Yonge-Mallo
     /// </summary>
-    public class ShortNumberInfo
+    public sealed class ShortNumberInfo
     {
         private static readonly ShortNumberInfo Instance = new();
 


### PR DESCRIPTION
## Summary
Part of the sealing/visibility audit from #375 (comment: https://github.com/twcclegg/libphonenumber-csharp/issues/375#issuecomment-5426707480) — this PR is the "safe now, not blocked on a major version" bucket.

- `PhoneNumberUtil`, `PhoneNumberOfflineGeocoder`, `PhoneNumberToCarrierMapper`, `PhoneNumberToTimeZonesMapper`, `ShortNumberInfo` → `sealed`. All are reached only through a static `GetInstance()`; their constructors are `internal`/`private`, so no external assembly could ever have derived from them, and nothing in this repo does either.
- `MetadataFilter` → `sealed`. Its own doc comment already says it's *"an internal API ... not part of the public API"*; every member except the class declaration and the `object` overrides is already `internal`.

Verified locally that this is genuinely non-breaking: ran `dotnet pack -p:VersionPrefix=9.0.38` against the `9.0.37` `EnablePackageValidation` baseline. `sealed` on a type with no accessible constructor produces zero ApiCompat errors — the `CP0009` "sealed added" rule only fires when the baseline type had a public/protected constructor. (I also tried making `MetadataFilter` `internal` outright, matching its doc comment, but that trips `CP0001` "type removed from the public API surface" regardless of constructor accessibility — so it stays `public`, just sealed. Posted that correction on #375 too.)

No behavior change.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.slnx` — clean, 0 warnings
- [x] `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 450/450 passing (414 PhoneNumbers.Test + 36 PhoneNumbers.Extensions.Test)
- [x] `dotnet pack -c Release csharp/PhoneNumbers -p:VersionPrefix=9.0.38` — ApiCompat clean against the 9.0.37 baseline