### PR TITLE
fix: land CodeQL fixes orphaned by a merge race on PRs #412-#418

### DIFF
--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -623,14 +623,13 @@ namespace PhoneNumbers
             // We check that the local-only length isn't also a normal possible length (only relevant for
             // the general-desc, since within elements such as fixed-line we would throw an exception if we
             // saw this) before adding it to the collection of possible local-only lengths.
-            foreach (var length in localOnlyLengths)
-                if (!lengths.Contains(length))
-                    if (parentDesc is null || parentDesc.possibleLengthLocalOnly_.Contains(length)
-                        || parentDesc.possibleLength_.Contains(length))
-                        desc.possibleLengthLocalOnly_.Add(length);
-                    else
-                        throw new Exception(
-                            $"Out-of-range local-only possible length found ({length}), parent length {string.Join(", ", parentDesc.PossibleLengthLocalOnlyList)}.");
+            foreach (var length in localOnlyLengths.Where(length => !lengths.Contains(length)))
+                if (parentDesc is null || parentDesc.possibleLengthLocalOnly_.Contains(length)
+                    || parentDesc.possibleLength_.Contains(length))
+                    desc.possibleLengthLocalOnly_.Add(length);
+                else
+                    throw new Exception(
+                        $"Out-of-range local-only possible length found ({length}), parent length {string.Join(", ", parentDesc.PossibleLengthLocalOnlyList)}.");
         }
 
 

--- a/csharp/PhoneNumbers/PhoneNumberDesc.cs
+++ b/csharp/PhoneNumbers/PhoneNumberDesc.cs
@@ -246,8 +246,8 @@ namespace PhoneNumbers
             var hash = GetType().GetHashCode();
             if (HasNationalNumberPattern) hash ^= NationalNumberPattern.GetHashCode();
 
-            hash = possibleLength_.Aggregate(hash, (current, i) => current ^ i.GetHashCode());
-            hash = possibleLengthLocalOnly_.Aggregate(hash, (current, i) => current ^ i.GetHashCode());
+            hash = possibleLength_.Aggregate(hash, (current, i) => current ^ i);
+            hash = possibleLengthLocalOnly_.Aggregate(hash, (current, i) => current ^ i);
 
             if (HasExampleNumber) hash ^= ExampleNumber.GetHashCode();
             return hash;

--- a/csharp/PhoneNumbers/PhoneNumberMatch.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatch.cs
@@ -59,7 +59,7 @@ namespace PhoneNumbers
         public override int GetHashCode()
         {
             var hash = GetType().GetHashCode();
-            hash ^= Start.GetHashCode();
+            hash ^= Start;
             hash ^= RawString.GetHashCode();
             hash ^= Number.GetHashCode();
             return hash;

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -218,7 +218,7 @@ namespace PhoneNumbers
             if (!char.IsLetter(letter) && CharUnicodeInfo.GetUnicodeCategory(letter) != UnicodeCategory.NonSpacingMark)
                 return false;
             return
-                letter >= 0x0000 && letter <= 0x007F        // BASIC_LATIN
+                letter <= 0x007F                             // BASIC_LATIN
                 || letter >= 0x0080 && letter <= 0x00FF     // LATIN_1_SUPPLEMENT
                 || letter >= 0x0100 && letter <= 0x017F     // LATIN_EXTENDED_A
                 || letter >= 0x1E00 && letter <= 0x1EFF     // LATIN_EXTENDED_ADDITIONAL

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -1312,16 +1312,11 @@ namespace PhoneNumbers
                     // internationally, since that always works, except for numbers which might potentially be
                     // short numbers, which are always dialled in national format.
                     var regionMetadata = GetMetadataForRegion(regionCallingFrom);
-                    if (CanBeInternationallyDialled(numberNoExt)
+                    formattedNumber = CanBeInternationallyDialled(numberNoExt)
                         && TestNumberLength(GetNationalSignificantNumberLength(numberNoExt), regionMetadata)
-                            != ValidationResult.TOO_SHORT)
-                    {
-                        formattedNumber = Format(numberNoExt, PhoneNumberFormat.INTERNATIONAL);
-                    }
-                    else
-                    {
-                        formattedNumber = Format(numberNoExt, PhoneNumberFormat.NATIONAL);
-                    }
+                            != ValidationResult.TOO_SHORT
+                        ? Format(numberNoExt, PhoneNumberFormat.INTERNATIONAL)
+                        : Format(numberNoExt, PhoneNumberFormat.NATIONAL);
                 }
                 else
                 {
@@ -1579,13 +1574,13 @@ namespace PhoneNumbers
             foreach (var numFormat in availableFormats)
             {
                 var size = numFormat.LeadingDigitsPatternCount;
-                if (size == 0 || PhoneRegex.Get(
+                if ((size == 0 || PhoneRegex.Get(
                     // We always use the last leading_digits_pattern, as it is the most detailed.
                     numFormat.GetLeadingDigitsPattern(size - 1))
                     .IsMatchBeginning(nationalNumber))
+                    && PhoneRegex.Get(numFormat.Pattern).IsMatchAll(nationalNumber))
                 {
-                    if (PhoneRegex.Get(numFormat.Pattern).IsMatchAll(nationalNumber))
-                        return numFormat;
+                    return numFormat;
                 }
             }
             return null;
@@ -1670,6 +1665,8 @@ namespace PhoneNumbers
             }
             catch (NumberParseException)
             {
+                // The example number in the metadata failed to parse; treat it the same as no example
+                // number being present rather than surfacing a metadata-quality issue to the caller.
             }
             return null;
         }
@@ -2568,7 +2565,9 @@ namespace PhoneNumbers
             }
             // Attempt to parse the first digits as an international prefix.
             Normalize(number);
-            if (possibleIddPrefix as object == "NonMatch" as object)
+            // Reference equality, not value equality: this only matches the specific sentinel object
+            // assigned above, not any region's real prefix that happens to equal the literal text.
+            if (ReferenceEquals(possibleIddPrefix, "NonMatch"))
                 return PhoneNumber.Types.CountryCodeSource.FROM_DEFAULT_COUNTRY;
 
             var iddPattern = PhoneRegex.Get(possibleIddPrefix);

--- a/csharp/PhoneNumbers/Phonemetadata.cs
+++ b/csharp/PhoneNumbers/Phonemetadata.cs
@@ -556,11 +556,10 @@ namespace PhoneNumbers
             public Builder MergeGeneralDesc(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasGeneralDesc &&
-                    MessageBeingBuilt.GeneralDesc != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.GeneralDesc = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.GeneralDesc)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.GeneralDesc = value;
+                MessageBeingBuilt.GeneralDesc = MessageBeingBuilt.HasGeneralDesc &&
+                    MessageBeingBuilt.GeneralDesc != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.GeneralDesc).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -587,11 +586,10 @@ namespace PhoneNumbers
             public Builder MergeFixedLine(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasFixedLine &&
-                    MessageBeingBuilt.FixedLine != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.FixedLine = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.FixedLine)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.FixedLine = value;
+                MessageBeingBuilt.FixedLine = MessageBeingBuilt.HasFixedLine &&
+                    MessageBeingBuilt.FixedLine != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.FixedLine).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -618,11 +616,10 @@ namespace PhoneNumbers
             public Builder MergeMobile(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasMobile &&
-                    MessageBeingBuilt.Mobile != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Mobile = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Mobile).MergeFrom(value)
-                        .BuildPartial();
-                else MessageBeingBuilt.Mobile = value;
+                MessageBeingBuilt.Mobile = MessageBeingBuilt.HasMobile &&
+                    MessageBeingBuilt.Mobile != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Mobile).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -649,11 +646,10 @@ namespace PhoneNumbers
             public Builder MergeTollFree(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasTollFree &&
-                    MessageBeingBuilt.TollFree != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.TollFree = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.TollFree)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.TollFree = value;
+                MessageBeingBuilt.TollFree = MessageBeingBuilt.HasTollFree &&
+                    MessageBeingBuilt.TollFree != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.TollFree).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -680,11 +676,10 @@ namespace PhoneNumbers
             public Builder MergePremiumRate(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasPremiumRate &&
-                    MessageBeingBuilt.PremiumRate != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.PremiumRate = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.PremiumRate)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.PremiumRate = value;
+                MessageBeingBuilt.PremiumRate = MessageBeingBuilt.HasPremiumRate &&
+                    MessageBeingBuilt.PremiumRate != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.PremiumRate).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -711,11 +706,10 @@ namespace PhoneNumbers
             public Builder MergeSharedCost(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasSharedCost &&
-                    MessageBeingBuilt.SharedCost != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.SharedCost = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.SharedCost)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.SharedCost = value;
+                MessageBeingBuilt.SharedCost = MessageBeingBuilt.HasSharedCost &&
+                    MessageBeingBuilt.SharedCost != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.SharedCost).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -742,11 +736,10 @@ namespace PhoneNumbers
             public Builder MergePersonalNumber(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasPersonalNumber &&
-                    MessageBeingBuilt.PersonalNumber != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.PersonalNumber = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.PersonalNumber)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.PersonalNumber = value;
+                MessageBeingBuilt.PersonalNumber = MessageBeingBuilt.HasPersonalNumber &&
+                    MessageBeingBuilt.PersonalNumber != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.PersonalNumber).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -773,11 +766,10 @@ namespace PhoneNumbers
             public Builder MergeVoip(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasVoip &&
-                    MessageBeingBuilt.Voip != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Voip = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Voip).MergeFrom(value)
-                        .BuildPartial();
-                else MessageBeingBuilt.Voip = value;
+                MessageBeingBuilt.Voip = MessageBeingBuilt.HasVoip &&
+                    MessageBeingBuilt.Voip != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Voip).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -804,11 +796,10 @@ namespace PhoneNumbers
             public Builder MergePager(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasPager &&
-                    MessageBeingBuilt.Pager != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Pager = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Pager).MergeFrom(value)
-                        .BuildPartial();
-                else MessageBeingBuilt.Pager = value;
+                MessageBeingBuilt.Pager = MessageBeingBuilt.HasPager &&
+                    MessageBeingBuilt.Pager != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Pager).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -835,11 +826,10 @@ namespace PhoneNumbers
             public Builder MergeUan(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasUan &&
-                    MessageBeingBuilt.Uan != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Uan = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Uan).MergeFrom(value)
-                        .BuildPartial();
-                else MessageBeingBuilt.Uan = value;
+                MessageBeingBuilt.Uan = MessageBeingBuilt.HasUan &&
+                    MessageBeingBuilt.Uan != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Uan).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -866,11 +856,10 @@ namespace PhoneNumbers
             public Builder MergeEmergency(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasEmergency &&
-                    MessageBeingBuilt.Emergency != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Emergency = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Emergency)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.Emergency = value;
+                MessageBeingBuilt.Emergency = MessageBeingBuilt.HasEmergency &&
+                    MessageBeingBuilt.Emergency != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Emergency).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -897,11 +886,10 @@ namespace PhoneNumbers
             public Builder MergeVoicemail(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasVoicemail &&
-                    MessageBeingBuilt.Voicemail != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.Voicemail = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Voicemail)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.Voicemail = value;
+                MessageBeingBuilt.Voicemail = MessageBeingBuilt.HasVoicemail &&
+                    MessageBeingBuilt.Voicemail != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.Voicemail).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -928,11 +916,10 @@ namespace PhoneNumbers
             public Builder MergeShortCode(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasShortCode &&
-                    MessageBeingBuilt.ShortCode != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.ShortCode = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.ShortCode)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.ShortCode = value;
+                MessageBeingBuilt.ShortCode = MessageBeingBuilt.HasShortCode &&
+                    MessageBeingBuilt.ShortCode != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.ShortCode).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -959,11 +946,10 @@ namespace PhoneNumbers
             public Builder MergeStandardRate(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasStandardRate &&
-                    MessageBeingBuilt.StandardRate != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.StandardRate = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.StandardRate)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.StandardRate = value;
+                MessageBeingBuilt.StandardRate = MessageBeingBuilt.HasStandardRate &&
+                    MessageBeingBuilt.StandardRate != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.StandardRate).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -990,11 +976,10 @@ namespace PhoneNumbers
             public Builder MergeCarrierSpecific(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasCarrierSpecific &&
-                    MessageBeingBuilt.CarrierSpecific != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.CarrierSpecific = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.CarrierSpecific)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.CarrierSpecific = value;
+                MessageBeingBuilt.CarrierSpecific = MessageBeingBuilt.HasCarrierSpecific &&
+                    MessageBeingBuilt.CarrierSpecific != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.CarrierSpecific).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -1021,11 +1006,10 @@ namespace PhoneNumbers
             public Builder MergeSmsServices(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasSmsServices &&
-                    MessageBeingBuilt.SmsServices != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.SmsServices = PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.SmsServices)
-                        .MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.SmsServices = value;
+                MessageBeingBuilt.SmsServices = MessageBeingBuilt.HasSmsServices &&
+                    MessageBeingBuilt.SmsServices != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.SmsServices).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -1052,11 +1036,10 @@ namespace PhoneNumbers
             public Builder MergeNoInternationalDialling(PhoneNumberDesc value)
             {
                 if (value is null) throw new ArgumentNullException(nameof(value));
-                if (MessageBeingBuilt.HasNoInternationalDialling &&
-                    MessageBeingBuilt.NoInternationalDialling != PhoneNumberDesc.DefaultInstance)
-                    MessageBeingBuilt.NoInternationalDialling = PhoneNumberDesc
-                        .CreateBuilder(MessageBeingBuilt.NoInternationalDialling).MergeFrom(value).BuildPartial();
-                else MessageBeingBuilt.NoInternationalDialling = value;
+                MessageBeingBuilt.NoInternationalDialling = MessageBeingBuilt.HasNoInternationalDialling &&
+                    MessageBeingBuilt.NoInternationalDialling != PhoneNumberDesc.DefaultInstance
+                    ? PhoneNumberDesc.CreateBuilder(MessageBeingBuilt.NoInternationalDialling).MergeFrom(value).BuildPartial()
+                    : value;
                 return this;
             }
 
@@ -1333,7 +1316,7 @@ namespace PhoneNumbers
             if (HasSmsServices) hash ^= SmsServices.GetHashCode();
             if (HasNoInternationalDialling) hash ^= NoInternationalDialling.GetHashCode();
             if (HasId) hash ^= Id.GetHashCode();
-            if (HasCountryCode) hash ^= CountryCode.GetHashCode();
+            if (HasCountryCode) hash ^= CountryCode;
             if (HasInternationalPrefix) hash ^= InternationalPrefix.GetHashCode();
             if (HasPreferredInternationalPrefix) hash ^= PreferredInternationalPrefix.GetHashCode();
             if (HasNationalPrefix) hash ^= NationalPrefix.GetHashCode();

--- a/csharp/PhoneNumbers/ShortNumberInfo.cs
+++ b/csharp/PhoneNumbers/ShortNumberInfo.cs
@@ -327,9 +327,8 @@ namespace PhoneNumbers
             }
 
             var cost = ShortNumberCost.TOLL_FREE;
-            foreach (var regionCode in regionCodes)
+            foreach (var costForRegion in regionCodes.Select(regionCode => GetExpectedCostForRegion(number, regionCode)))
             {
-                var costForRegion = GetExpectedCostForRegion(number, regionCode);
                 switch (costForRegion)
                 {
                     case ShortNumberCost.PREMIUM_RATE:


### PR DESCRIPTION
## Summary
PRs #412, #413, #414, #415, #416, #418 got merged while I was still pushing CodeQL cleanup commits to those same branches in a follow-up session, so each branch ended up exactly one commit ahead of the already-merged `main` — the fix commits never made it in. This PR cherry-picks all six orphaned commits (verified: no file overlap between them, no conflicts on cherry-pick):

- `style: map region codes via Select in GetExpectedCost` (ShortNumberInfo.cs, ex-#412)
- `style: filter local-only lengths explicitly via Where` (BuildMetadataFromXml.cs, ex-#413)
- `style: drop redundant int.GetHashCode() call in PhoneNumberMatch` (PhoneNumberMatch.cs, ex-#414)
- `style: ternary builder merges and drop redundant int.GetHashCode() calls` (Phonemetadata.cs, PhoneNumberDesc.cs, ex-#415)
- `style: drop always-true lower bound in IsLatinLetter's BASIC_LATIN check` (PhoneNumberMatcher.cs, ex-#416)
- `style: address remaining CodeQL findings in PhoneNumberUtil.cs` (PhoneNumberUtil.cs, ex-#418)

Each was originally reviewed against the CodeQL alert it addresses (and against upstream Java where relevant) in the earlier PRs; this is purely landing what was already vetted, not new work.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers/PhoneNumbers.csproj -c Release` — all three TFMs (netstandard2.0/net8.0/net10.0) build clean
- [x] `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 450/450 tests pass
- [x] `git diff origin/main --stat` confirms the diff is exactly these 6 commits' changes, nothing else