### PR TITLE
Fix cs/xmldoc/missing-summary: wrap bare doc comments in <summary>

### DIFF
--- a/csharp/PhoneNumbers/NumberParseException.cs
+++ b/csharp/PhoneNumbers/NumberParseException.cs
@@ -18,15 +18,21 @@ using System;
 
 namespace PhoneNumbers
 {
+    /// <summary>
     /// The reason that a string could not be interpreted as a phone number.
+    /// </summary>
     public enum ErrorType
     {
+        /// <summary>
         /// The country code supplied did not belong to a supported country or non-geographical entity.
+        /// </summary>
         INVALID_COUNTRY_CODE,
+        /// <summary>
         /// This indicates the string passed is not a valid number. Either the string had less than 3
         /// digits in it or had an invalid phone-context parameter. More specifically, the number failed
         /// to match the regular expression VALID_PHONE_NUMBER, RFC3966_GLOBAL_NUMBER_DIGITS, or
         /// RFC3966_DOMAINNAME in PhoneNumberUtil.cs.
+        /// </summary>
         NOT_A_NUMBER,
         // This indicates the string started with an international dialing prefix, but after this was
         // stripped from the number, had less digits than any valid phone number (including country

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -243,11 +243,11 @@ namespace PhoneNumbers
         private static Regex RFC3966_GLOBAL_NUMBER_DIGITS_OR_DOMAINNAME() => _RFC3966_GLOBAL_NUMBER_DIGITS_OR_DOMAINNAME;
 #endif
 
-        ///
+        /// <summary>
         /// Helper initialiser method to create the regular-expression pattern to match extensions.
         /// Note that there are currently six capturing groups for the extension itself. If this number is
         /// changed, MaybeStripExtension needs to be updated.
-        ///
+        /// </summary>
         // Regexp of all possible ways to write extensions, for use when parsing. This will be run as a
         // case-insensitive regexp match. Wide character versions are also provided after each ASCII
         // version.


### PR DESCRIPTION
## Summary

Closes out the gap left open by #423, which flagged the single open CodeQL `cs/xmldoc/missing-summary` alert (#247, `NumberParseException.cs`) but deliberately didn't fix it, reasoning that the bare-prose `///` doc-comment style (no `<summary>` wrapper) was a "pervasive, deliberate convention across 31 files in this repo" and out of scope for that PR.

This PR does the dedicated sweep: it audits every `.cs` file under `csharp/PhoneNumbers/`, `csharp/PhoneNumbers.MetadataBuilder/`, `csharp/PhoneNumbers.Extensions/`, `csharp/PhoneNumbers.Test/`, and `csharp/PhoneNumbers.Extensions.Test/` (77 files) for doc-comment blocks containing prose but no `<summary>`/`<inheritdoc>` tag anywhere in the block.

**Finding:** the "31 files" convention described in #423 has largely already been cleaned up elsewhere on `main` since that PR was written. A full scan turned up only two files with genuinely untagged bare-prose doc comments left:

- `csharp/PhoneNumbers/NumberParseException.cs` — the `ErrorType` enum summary plus the `INVALID_COUNTRY_CODE` and `NOT_A_NUMBER` member comments (this is alert #247)
- `csharp/PhoneNumbers/PhoneNumberUtil.cs` — the helper-initialiser comment above the extension-matching regex constants

Both are fixed by wrapping the existing prose in `<summary>...</summary>` — no wording changes, no `<param>`/`<returns>`/etc. tags touched, no namespace style changes.

## Test plan

- [x] `dotnet build csharp/PhoneNumbers.slnx -c Release` — Build succeeded, 0 Warning(s), 0 Error(s)
- [x] `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 450/450 passed (36 + 414), same as baseline