### PR TITLE
Fix path traversal in BuildLocaleNames and uncaught parse exception in PhoneNumberTypeConverter

### DIFF
--- a/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions.Test/TestPhoneNumberTypeConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace PhoneNumbers.Extensions.Test
@@ -13,6 +14,14 @@ namespace PhoneNumbers.Extensions.Test
 
             var number = Assert.IsType<PhoneNumbers.PhoneNumber>(result);
             Assert.Equal(6192987704UL, number.NationalNumber);
+        }
+
+        [Fact]
+        public void ConvertFrom_InvalidString_ThrowsFormatException()
+        {
+            var ex = Assert.Throws<FormatException>(() => Converter.ConvertFrom("not-a-number"));
+
+            Assert.IsType<NumberParseException>(ex.InnerException);
         }
 
         [Fact]

--- a/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
+++ b/csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs
@@ -17,9 +17,21 @@ namespace PhoneNumbers.Extensions
             => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-            => value is string stringValue
-                ? Util.Parse(stringValue, null)
-                : base.ConvertFrom(context, culture, value);
+        {
+            if (value is not string stringValue)
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
+
+            try
+            {
+                return Util.Parse(stringValue, null);
+            }
+            catch (NumberParseException ex)
+            {
+                throw new FormatException($"'{stringValue}' is not a valid phone number.", ex);
+            }
+        }
 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
             => destinationType == typeof(string) || base.CanConvertTo(context, destinationType);

--- a/csharp/PhoneNumbers.MetadataBuilder/Program.cs
+++ b/csharp/PhoneNumbers.MetadataBuilder/Program.cs
@@ -189,7 +189,7 @@ internal static class Program
         var byCountry = ParseLocaleText(inputFile);
         foreach (var country in byCountry)
         {
-            var outPath = Path.Join(outputDir, country.Key);
+            var outPath = Path.Join(outputDir, Path.GetFileName(country.Key));
             using var gz = new GZipStream(File.Create(outPath), CompressionLevel.SmallestSize);
             BuildPrefixMapFromBin.WriteLocaleNames(gz, country.Value);
         }


### PR DESCRIPTION
## Changes
Found during an aggressive re-review of the full diff from `v9.0.37` to `main` (~113 files, everything since the last release — style cleanups, the metadata triage bot, benchmark CI changes, the LocaleData/LocaleNames refactor, new Extensions features).

- **`csharp/PhoneNumbers.MetadataBuilder/Program.cs`**: `BuildLocaleNames` wrote its per-country output file at `Path.Join(outputDir, country.Key)` without the `Path.GetFileName` guard its two sibling call sites (`BuildGeocoding`, the metadata writer) already got elsewhere in this same range. `country.Key` comes from `resources/locale/country_names.txt`, which — unlike every other resource file — is hand-generated locally (`lib/DumpLocale.java`) rather than copied verbatim from upstream, so it's more exposed to a bad regeneration or manual edit writing outside `outputDir`. Confirmed the fix is a no-op for real data: still 249 files, same names (`US`, `GB`, `CA`, ...).
- **`csharp/PhoneNumbers.Extensions/PhoneNumberTypeConverter.cs`**: `ConvertFrom` let `PhoneNumbers.NumberParseException` propagate straight out of a generic `TypeConverter` API on invalid input. Reproduced directly — `ConvertFrom("not-a-number")` threw the raw internal exception type. Standard `TypeConverter` convention, and this repo's own `PhoneNumberAttribute` (via `PhoneNumber.TryParseValid`), is to convert a failed parse into a predictable outcome rather than leak an implementation-specific exception type to callers (WPF/WinForms data binding, `TypeDescriptor` consumers, etc. won't be catching `PhoneNumbers.NumberParseException`). Now wraps it in a `FormatException` with the original as `InnerException`, plus a test for the invalid-input path that had no coverage before.

## Test plan
- [x] `dotnet build csharp` — clean, 0 warnings.
- [x] `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 451/451 passing, including the new `ConvertFrom_InvalidString_ThrowsFormatException` test.
- [x] Manually inspected `obj/locale` output after the `BuildLocaleNames` fix — still exactly 249 files with unchanged names, confirming the `Path.GetFileName` wrap is behavior-preserving for legitimate data.


---
