### PR TITLE
Fuzz: exercise the selected region in FormatOutOfCountryCallingNumber, cap manual duration

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     env:
-      DURATION: ${{ github.event.inputs.duration || '900' }}
+      # Capped well under timeout-minutes: checkout/build/instrument above and crash-upload below
+      # need their own time inside that budget too. Without a cap, a large manual `duration` input
+      # doesn't make libFuzzer stop later - it makes the runner hard-cancel the job instead, which
+      # skips the "Upload crashes" step (it only runs `if: failure()`, not on a cancelled job) and
+      # loses whatever crash was found.
+      DURATION: ${{ min(fromJSON(github.event.inputs.duration || '900'), 3000) }}
       PUBLISH_DIR: fuzz-out
       CORPUS_DIR: csharp/PhoneNumbers.Fuzz/corpus
     steps:

--- a/csharp/PhoneNumbers.Fuzz/Program.cs
+++ b/csharp/PhoneNumbers.Fuzz/Program.cs
@@ -59,7 +59,7 @@ namespace PhoneNumbers.Fuzz
                 return;
             }
 
-            ExerciseReadOnlySurface(number);
+            ExerciseReadOnlySurface(number, region);
         }
 
         private static void FindNumbers(string input, string region)
@@ -80,7 +80,7 @@ namespace PhoneNumbers.Fuzz
                 formatter.InputDigit(input[i]);
         }
 
-        private static void ExerciseReadOnlySurface(PhoneNumber number)
+        private static void ExerciseReadOnlySurface(PhoneNumber number, string callingFromRegion)
         {
             PhoneUtil.IsValidNumber(number);
             PhoneUtil.IsPossibleNumber(number);
@@ -91,7 +91,10 @@ namespace PhoneNumbers.Fuzz
             PhoneUtil.Format(number, PhoneNumberFormat.INTERNATIONAL);
             PhoneUtil.Format(number, PhoneNumberFormat.NATIONAL);
             PhoneUtil.Format(number, PhoneNumberFormat.RFC3966);
-            PhoneUtil.FormatOutOfCountryCallingNumber(number, "US");
+            // Reuses the fuzzer-selected region (rather than a hardcoded "US") so this also covers
+            // the branches for calling from a region sharing the parsed number's country code, or
+            // one with unusual national-prefix/IDD rules.
+            PhoneUtil.FormatOutOfCountryCallingNumber(number, callingFromRegion);
 
             Geocoder.GetDescriptionForNumber(number, Locale.English);
             CarrierMapper.GetNameForNumber(number, Locale.English);


### PR DESCRIPTION
## Changes
Two coverage/UX gaps from the aggressive `v9.0.37..main` re-review — not correctness bugs in the shipped library (`PhoneNumbers.Fuzz` isn't part of the packed NuGet package).

- **`csharp/PhoneNumbers.Fuzz/Program.cs`**: `FormatOutOfCountryCallingNumber` was always fuzzed with a hardcoded `"US"` calling region, so formatting-from-region-specific branches (a region sharing the parsed number's country code, or with unusual national-prefix/IDD rules) got zero coverage regardless of how long the fuzzer ran. It now reuses the same fuzzer-selected region already threaded through `Parse`/`FindNumbers`/`FormatAsYouType`.
- **`.github/workflows/fuzz.yml`**: the `workflow_dispatch` `duration` input (seconds) had no upper bound against the job's 60-minute `timeout-minutes`. An oversized manual value doesn't make libFuzzer stop later — it makes the runner hard-cancel the whole job instead, which skips the "Upload crashes" step (`if: failure()` doesn't fire on a cancellation) and loses whatever crash was found. Capped to 3000s (50 min) via `min(fromJSON(...), 3000)`, leaving headroom for checkout/build/instrument/upload within the 60-minute budget.

## Test plan
- [x] `dotnet build csharp/PhoneNumbers.Fuzz -c Release` — clean, 0 warnings.
- [x] Ran the harness in reproduce mode against all 9 checked-in corpus files — all pass.
- [x] Ran it against a synthetic input with 8 different region-selector byte values (0, 1, 50, 100, 150, 200, 250, 255) covering a spread of regions through `FormatOutOfCountryCallingNumber` — all format without throwing.
- [x] YAML-parsed the workflow file.


---
