### PR TITLE
fix: replace non-existent min() with the && / || ternary idiom in fuzz.yml

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,7 +32,12 @@ jobs:
       # doesn't make libFuzzer stop later - it makes the runner hard-cancel the job instead, which
       # skips the "Upload crashes" step (it only runs `if: failure()`, not on a cancelled job) and
       # loses whatever crash was found.
-      DURATION: ${{ min(fromJSON(github.event.inputs.duration || '900'), 3000) }}
+      #
+      # GitHub Actions expressions have no min()/max() - this is the documented ternary substitute
+      # (cond && then || else). A real min() call here fails every run at workflow-parse time with
+      # zero jobs created ("Unrecognized function: 'min'"), which is what happened from the commit
+      # that introduced it until this fix.
+      DURATION: ${{ (fromJSON(github.event.inputs.duration || '900') < 3000) && (github.event.inputs.duration || '900') || 3000 }}
       PUBLISH_DIR: fuzz-out
       CORPUS_DIR: csharp/PhoneNumbers.Fuzz/corpus
     steps:


### PR DESCRIPTION
## Changes
- `GitHub Actions expressions have no `min()`/`max()` function. `min(fromJSON(github.event.inputs.duration || '900'), 3000)`, added in the "cap manual duration" change (part of #429), fails every run at workflow-parse time with zero jobs ever created (`Unrecognized function: 'min'`) — not a flaky fuzz job. This is the source of the recent run of "fuzz job failed" notification emails: every push since that commit landed has hit this, on every branch.
- Replaced with GitHub's documented `cond && then || else` ternary substitute, since there's no native ternary or min/max.

## Testing
This exact file was broken by an unverified expression landing without ever actually being exercised, so this time I verified before merging rather than after:
- Confirmed the actual root cause from the real failed-run output (`Unrecognized function: 'min'`), not assumed from reading the YAML.
- Verified the `&&`/`||` ternary substitute against GitHub's own community docs before using it.
- Pushed this fix to its branch and manually dispatched `fuzz.yml` against it directly (`workflow_dispatch`, `duration: 10`) before opening this PR: the job now actually starts (9 real steps executed, vs. 0 before), and the "Fuzz" step measured ran for ~11s — matching the 10s input, confirming `DURATION` resolves correctly rather than silently falling back to 0 or the 3000s cap. Full job succeeded: https://github.com/twcclegg/libphonenumber-csharp/actions/runs/33212762845


---
