### PR TITLE
feat: add automated smoke test for the published NuGet packages

### DIFF
--- a/.github/workflows/package_smoke_test.yml
+++ b/.github/workflows/package_smoke_test.yml
@@ -22,13 +22,6 @@ on:
       version:
         description: 'Package version to test (must already be published on nuget.org), e.g. 9.0.38'
         required: true
-  # TEMPORARY, removed before merge: workflow_dispatch only recognizes a workflow once it exists on
-  # the default branch, so a brand-new workflow file can't be dispatched pre-merge. `push` has no
-  # such restriction - GitHub reads the workflow straight off the pushed ref - which makes it the
-  # only way to get a real run of this file on this branch before opening the PR. See the "Resolve
-  # version to test" step below for the matching temporary fallback.
-  push:
-    branches: [ feat/package-smoke-test ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
@@ -40,9 +33,8 @@ permissions:
 jobs:
   package_smoke_test:
     # workflow_run fires on every conclusion (success, failure, cancelled) - only act on success.
-    # A workflow_dispatch/push run has no `workflow_run` context at all, so it is unaffected by this.
-    # TEMPORARY, removed before merge: the `push' arm goes with the temporary trigger above.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
+    # A workflow_dispatch run has no `workflow_run` context at all, so it is unaffected by this.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 25
     steps:
@@ -66,10 +58,6 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
           then
             version="${{ github.event.inputs.version }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]
-          then
-            # TEMPORARY, removed before merge: see the `push` trigger above.
-            version="9.0.38"
           else
             tag="${{ github.event.workflow_run.head_branch }}"
             if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]

--- a/.github/workflows/package_smoke_test.yml
+++ b/.github/workflows/package_smoke_test.yml
@@ -1,0 +1,138 @@
+name: package_smoke_test
+
+# End-to-end validation of the *published* NuGet packages, not the in-repo source: restores
+# libphonenumber-csharp and libphonenumber-csharp.extensions from nuget.org the way a real consumer
+# would (see csharp/PhoneNumbers.PackageSmokeTest/), then exercises both a normal managed run and a
+# Native AOT publish-and-execute. PhoneNumbers.csproj's own IsAotCompatible setting only catches
+# static trim/AOT analyzer warnings at library-build time - it never restores a packed .nupkg or
+# runs a published executable, so it cannot catch a problem in the packed output itself or one that
+# only surfaces once a consumer's own code is compiled/AOT-analyzed against the library's public
+# surface. See csharp/PhoneNumbers.PackageSmokeTest/README.md for what the checks cover and why.
+#
+# Runs automatically after a successful publish_nuget (tag-triggered release), and on demand via
+# workflow_dispatch against any version already on nuget.org - which is also how this workflow was
+# validated before being merged (see the PR description for the run that proved it against 9.0.38).
+
+on:
+  workflow_run:
+    workflows: [ "publish_nuget" ]
+    types: [ completed ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to test (must already be published on nuget.org), e.g. 9.0.38'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  package_smoke_test:
+    # workflow_run fires on every conclusion (success, failure, cancelled) - only act on success.
+    # A workflow_dispatch run has no `workflow_run` context at all, so it is unaffected by this.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.x
+
+      # Manual dispatch names the version directly. A workflow_run only gives us the triggering
+      # run's branch/tag: publish_nuget.yml is fired either by a vX.Y.Z tag push (the normal case)
+      # or by dispatching it directly against such a tag to retry a failed publish (see the comment
+      # in publish_nuget.yml) - in both cases head_branch is the tag name. Anything else (e.g. someone
+      # dispatches publish_nuget from a branch) has no version to derive, so skip rather than guess.
+      - name: Resolve version to test
+        id: resolve_version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
+          then
+            version="${{ github.event.inputs.version }}"
+          else
+            tag="${{ github.event.workflow_run.head_branch }}"
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+            then
+              echo "publish_nuget run was not for a vX.Y.Z tag (head_branch='${tag}'); nothing to test." \
+                | tee -a "${GITHUB_STEP_SUMMARY}"
+              echo "skip=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            version="${tag#v}"
+          fi
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+            echo "error: expected a X.Y.Z version, got '${version}'" >&2
+            exit 1
+          fi
+          echo "skip=false" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "testing package version ${version}" | tee -a "${GITHUB_STEP_SUMMARY}"
+
+      # NuGet propagation can lag a few seconds to a few minutes behind `dotnet nuget push`
+      # returning, so restoring immediately after publish_nuget completes can 404. Poll the flat
+      # container endpoint (what restore itself uses) for both packages before touching dotnet.
+      - name: Wait for packages to become available on nuget.org
+        if: steps.resolve_version.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.resolve_version.outputs.version }}
+        run: |
+          for pkg in libphonenumber-csharp libphonenumber-csharp.extensions
+          do
+            url="https://api.nuget.org/v3-flatcontainer/${pkg}/${VERSION}/${pkg}.nuspec"
+            echo "waiting for ${pkg} ${VERSION} (${url})"
+            for attempt in $(seq 1 20)
+            do
+              status=$(curl -s -o /dev/null -w '%{http_code}' "${url}")
+              if [[ "${status}" == "200" ]]
+              then
+                echo "  available after ${attempt} attempt(s)"
+                break
+              fi
+              if [[ "${attempt}" == "20" ]]
+              then
+                echo "error: ${pkg} ${VERSION} did not become available within 5 minutes (last HTTP status ${status})" >&2
+                exit 1
+              fi
+              echo "  attempt ${attempt}: HTTP ${status}, retrying in 15s"
+              sleep 15
+            done
+          done
+
+      # Single explicit source for the same reason as publish_nuget.yml: the restore whose output
+      # gets executed below must not be able to pick up a package from a feed the runner happens to
+      # have configured, on top of nuget.config already scoping the repo to nuget.org only.
+      - name: Managed smoke test (dotnet run)
+        if: steps.resolve_version.outputs.skip != 'true'
+        env:
+          PACKAGE_UNDER_TEST_VERSION: ${{ steps.resolve_version.outputs.version }}
+        run: |
+          dotnet run --project csharp/PhoneNumbers.PackageSmokeTest -c Release \
+            -p:PackageUnderTestVersion="${PACKAGE_UNDER_TEST_VERSION}" \
+            --source https://api.nuget.org/v3/index.json \
+            -- "${PACKAGE_UNDER_TEST_VERSION}"
+
+      - name: Native AOT smoke test (dotnet publish)
+        if: steps.resolve_version.outputs.skip != 'true'
+        env:
+          PACKAGE_UNDER_TEST_VERSION: ${{ steps.resolve_version.outputs.version }}
+        run: |
+          dotnet publish csharp/PhoneNumbers.PackageSmokeTest -c Release -p:PublishAot=true \
+            -p:PackageUnderTestVersion="${PACKAGE_UNDER_TEST_VERSION}" \
+            --source https://api.nuget.org/v3/index.json \
+            -o aot-smoke-test-publish
+
+      - name: Native AOT smoke test (execute)
+        if: steps.resolve_version.outputs.skip != 'true'
+        env:
+          PACKAGE_UNDER_TEST_VERSION: ${{ steps.resolve_version.outputs.version }}
+        run: ./aot-smoke-test-publish/PhoneNumbers.PackageSmokeTest "${PACKAGE_UNDER_TEST_VERSION}"

--- a/.github/workflows/package_smoke_test.yml
+++ b/.github/workflows/package_smoke_test.yml
@@ -22,6 +22,13 @@ on:
       version:
         description: 'Package version to test (must already be published on nuget.org), e.g. 9.0.38'
         required: true
+  # TEMPORARY, removed before merge: workflow_dispatch only recognizes a workflow once it exists on
+  # the default branch, so a brand-new workflow file can't be dispatched pre-merge. `push` has no
+  # such restriction - GitHub reads the workflow straight off the pushed ref - which makes it the
+  # only way to get a real run of this file on this branch before opening the PR. See the "Resolve
+  # version to test" step below for the matching temporary fallback.
+  push:
+    branches: [ feat/package-smoke-test ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
@@ -33,8 +40,9 @@ permissions:
 jobs:
   package_smoke_test:
     # workflow_run fires on every conclusion (success, failure, cancelled) - only act on success.
-    # A workflow_dispatch run has no `workflow_run` context at all, so it is unaffected by this.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # A workflow_dispatch/push run has no `workflow_run` context at all, so it is unaffected by this.
+    # TEMPORARY, removed before merge: the `push' arm goes with the temporary trigger above.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 25
     steps:
@@ -58,6 +66,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
           then
             version="${{ github.event.inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]
+          then
+            # TEMPORARY, removed before merge: see the `push` trigger above.
+            version="9.0.38"
           else
             tag="${{ github.event.workflow_run.head_branch }}"
             if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ FakesAssemblies/
 .vs/
 .DS_Store
 .idea
+.claude/
 
 # Zipped Geocoding Data
 geocoding.zip

--- a/csharp/PhoneNumbers.PackageSmokeTest/PhoneNumbers.PackageSmokeTest.csproj
+++ b/csharp/PhoneNumbers.PackageSmokeTest/PhoneNumbers.PackageSmokeTest.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>PhoneNumbers.PackageSmokeTest</AssemblyName>
+    <RootNamespace>PhoneNumbers.PackageSmokeTest</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!--
+      Deliberately not in PhoneNumbers.slnx: this project exists only to restore the *published*
+      libphonenumber-csharp / libphonenumber-csharp.extensions packages from nuget.org (never the
+      in-repo source - see the PackageReference below, and nuget.config at the repo root, which
+      already limits every restore in this repo to nuget.org) and exercise them both as a normal
+      managed app and as a Native AOT publish. Nothing else in the solution needs that, and letting
+      it sit in the normal build/test graph risks it silently resolving something local instead.
+      Built directly by .github/workflows/package_smoke_test.yml, which is the only thing that
+      needs it.
+    -->
+    <!--
+      Opt out of central package management. Every other project pins one version per package for
+      the whole repo in Directory.Packages.props (see the comment there); this project is the
+      opposite on purpose - the version under test is a parameter supplied per run (the newest
+      release today, an arbitrary past release on a manual re-run), never a value to freeze here.
+    -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <!--
+      The version of the two packages to restore and test. Overridable from the command line with
+      -p:PackageUnderTestVersion=X.Y.Z, or by setting the PACKAGE_UNDER_TEST_VERSION environment
+      variable (MSBuild imports environment variables as properties automatically, so the assignment
+      below only fires when the -p: form was not used). Left blank by default so a forgotten
+      override fails restore with a clear "invalid version" error instead of quietly resolving
+      whatever the SDK's package cache happens to already have.
+    -->
+    <PackageUnderTestVersion Condition="'$(PackageUnderTestVersion)' == ''">$(PACKAGE_UNDER_TEST_VERSION)</PackageUnderTestVersion>
+  </PropertyGroup>
+
+  <!-- Fail fast, before restore, with a message that says exactly what to pass. NuGet's own error
+       for an empty/invalid Version on a PackageReference does not make that obvious. -->
+  <Target Name="CheckPackageUnderTestVersion" BeforeTargets="Restore;CollectPackageReferences">
+    <Error Condition="'$(PackageUnderTestVersion)' == ''"
+           Text="PackageUnderTestVersion is not set. Pass -p:PackageUnderTestVersion=X.Y.Z (or set the PACKAGE_UNDER_TEST_VERSION environment variable) to the version of libphonenumber-csharp / libphonenumber-csharp.extensions on nuget.org to test." />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="libphonenumber-csharp" Version="$(PackageUnderTestVersion)" />
+    <PackageReference Include="libphonenumber-csharp.extensions" Version="$(PackageUnderTestVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/PhoneNumbers.PackageSmokeTest/Program.cs
+++ b/csharp/PhoneNumbers.PackageSmokeTest/Program.cs
@@ -1,0 +1,215 @@
+// Smoke test for the *published* NuGet packages, not the in-repo source: this project restores
+// libphonenumber-csharp / libphonenumber-csharp.extensions from nuget.org via a PackageReference
+// (see the .csproj), so a run here proves what a real consumer gets after `dotnet add package`.
+//
+// It runs unmodified under two modes (see .github/workflows/package_smoke_test.yml):
+//   1. `dotnet run`                                  - normal managed execution.
+//   2. `dotnet publish -p:PublishAot=true` + execute - Native AOT, exercising the trim/AOT
+//      annotations the library ships (IsAotCompatible) end to end, not just the static analyzer
+//      warnings that PhoneNumbers.csproj's own build already checks.
+//
+// Every check funnels through Check()/CheckEqual(), which print PASS/FAIL and tally failures;
+// Main returns 1 if anything failed, so CI fails loudly instead of on a swallowed exception.
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PhoneNumbers;
+// Both namespaces define a type named "PhoneNumber" (the data type here, the static
+// TryParse/TryParseValid helper in Extensions) - having both `using`s active is what forces every
+// reference to either below to be fully qualified (CS0104 otherwise), which is deliberate: it is
+// the exact ambiguity a real consumer hits combining these two packages.
+using PhoneNumbers.Extensions;
+
+var failures = 0;
+
+void Check(bool condition, string description)
+{
+    if (condition)
+    {
+        Console.WriteLine($"PASS: {description}");
+    }
+    else
+    {
+        Console.WriteLine($"FAIL: {description}");
+        failures++;
+    }
+}
+
+void CheckEqual<T>(T expected, T actual, string description)
+{
+    Check(Equals(expected, actual), $"{description} (expected '{expected}', got '{actual}')");
+}
+
+// --- Version check -----------------------------------------------------------------------------
+// Confirms restore actually resolved the version this run was asked to test, rather than a stale
+// or cached one - the "expected" here is not what the library reports about itself, it's what CI
+// (or a human dispatching the workflow) requested via the environment/argument.
+
+var expectedVersion = Environment.GetEnvironmentVariable("PACKAGE_UNDER_TEST_VERSION")
+    ?? (args.Length > 0 ? args[0] : null);
+
+var informationalVersion = typeof(PhoneNumberUtil).Assembly
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+    ?.InformationalVersion;
+Console.WriteLine($"PhoneNumbers.dll AssemblyInformationalVersion: {informationalVersion}");
+
+if (string.IsNullOrEmpty(expectedVersion))
+{
+    Console.WriteLine("WARN: no expected version supplied (PACKAGE_UNDER_TEST_VERSION env var or " +
+                       "argv[0]) - skipping the version-match check.");
+}
+else
+{
+    // The informational version can carry a build-metadata suffix (e.g. "9.0.38+abcdef123"); only
+    // the part before '+' is the package version.
+    var reportedVersion = informationalVersion?.Split('+')[0];
+    CheckEqual(expectedVersion, reportedVersion, "restored package version matches the requested one");
+}
+
+// --- Parse / format / validate across a few regions ---------------------------------------------
+
+var phoneUtil = PhoneNumberUtil.GetInstance();
+
+void CheckNumber(string raw, string region, string expectedE164, string expectedNational)
+{
+    var number = phoneUtil.Parse(raw, region);
+    Check(phoneUtil.IsValidNumber(number), $"{raw} ({region}) parses as valid");
+    CheckEqual(expectedE164, phoneUtil.Format(number, PhoneNumberFormat.E164),
+        $"{raw} ({region}) formats as E164");
+    CheckEqual(expectedNational, phoneUtil.Format(number, PhoneNumberFormat.NATIONAL),
+        $"{raw} ({region}) formats as NATIONAL");
+    Check(phoneUtil.Format(number, PhoneNumberFormat.INTERNATIONAL).StartsWith('+'),
+        $"{raw} ({region}) formats as INTERNATIONAL starting with '+'");
+}
+
+CheckNumber("(650) 253-0000", "US", "+16502530000", "(650) 253-0000");
+CheckNumber("020 7031 3000", "GB", "+442070313000", "020 7031 3000");
+CheckNumber("030 901820", "DE", "+4930901820", "030 901820");
+
+// --- AsYouTypeFormatter --------------------------------------------------------------------------
+
+var formatter = phoneUtil.GetAsYouTypeFormatter("US");
+var lastFormatted = "";
+// No leading '+': this exercises the NANP trunk-prefix path (a bare "1" read as the country code
+// digit), not the international-prefix path - typing a leading '+' takes a different branch and
+// keeps it in the output instead.
+foreach (var c in "16502530000")
+{
+    lastFormatted = formatter.InputDigit(c);
+}
+CheckEqual("1 (650) 253-0000", lastFormatted, "AsYouTypeFormatter formats a US number as it is typed");
+
+// --- ShortNumberInfo (separate metadata file) ---------------------------------------------------
+
+var shortNumberInfo = ShortNumberInfo.GetInstance();
+var shortNumber = phoneUtil.Parse("911", "US");
+Check(shortNumberInfo.IsValidShortNumber(shortNumber), "911 (US) is a valid short number");
+
+// --- Offline geocoder / carrier / timezone mappers (embedded binary metadata) --------------------
+// These are the point of this test: they read the gzip-compressed binary resources embedded in the
+// published assembly, which nothing in the library's own build-time AOT/trim analysis exercises.
+
+var geocoder = PhoneNumberOfflineGeocoder.GetInstance();
+var geocodedNumber = phoneUtil.Parse("+16502530000", "US");
+var description = geocoder.GetDescriptionForNumber(geocodedNumber, Locale.English);
+Check(!string.IsNullOrEmpty(description), $"offline geocoder returns a description ('{description}')");
+
+var carrierMapper = PhoneNumberToCarrierMapper.GetInstance();
+// Carrier data is sparse by design (most numbers are ported/MVNO and have no known carrier), so
+// this only checks that the lookup runs against the embedded data without throwing - not that it
+// returns a non-empty name.
+var carrierName = carrierMapper.GetNameForNumber(geocodedNumber, Locale.English);
+Console.WriteLine($"PASS: carrier mapper ran without throwing (name: '{carrierName}')");
+
+var timeZoneMapper = PhoneNumberToTimeZonesMapper.GetInstance();
+var timeZones = timeZoneMapper.GetTimeZonesForNumber(geocodedNumber);
+Check(timeZones.Count > 0, $"timezone mapper returns at least one zone ({string.Join(", ", timeZones)})");
+
+// --- FindNumbers on free text ---------------------------------------------------------------------
+
+var freeText = "Call us on +1 650-253-0000 or +44 20 7031 3000 for support.";
+var matches = phoneUtil.FindNumbers(freeText, "US").ToList();
+CheckEqual(2, matches.Count, "FindNumbers finds both numbers in free text");
+
+// --- Extensions package: TryParse / TryParseValid -------------------------------------------------
+// PhoneNumbers.Extensions.PhoneNumber (static helper) and PhoneNumbers.PhoneNumber (the data type)
+// share a simple name, so with both namespaces `using`'d every reference below must be fully
+// qualified - that ambiguity (CS0104) is deliberately exercised here, not avoided.
+
+Check(PhoneNumbers.Extensions.PhoneNumber.TryParse("+16502530000", out PhoneNumbers.PhoneNumber? parsed) && parsed is not null,
+    "Extensions.PhoneNumber.TryParse succeeds on a well-formed E164 number");
+Check(!PhoneNumbers.Extensions.PhoneNumber.TryParse("not a number", "US", out _),
+    "Extensions.PhoneNumber.TryParse fails on garbage input");
+Check(PhoneNumbers.Extensions.PhoneNumber.TryParseValid("+16502530000", out _),
+    "Extensions.PhoneNumber.TryParseValid succeeds on a valid number");
+Check(!PhoneNumbers.Extensions.PhoneNumber.TryParseValid("+1 555-000-0000", out _),
+    "Extensions.PhoneNumber.TryParseValid rejects a syntactically-parseable but invalid number");
+
+// --- Extensions package: PhoneNumberConverter under System.Text.Json, AOT-safe -------------------
+// Under PublishAot, JsonSerializer.Serialize/Deserialize<T>(value, options) without a
+// TypeInfoResolver hits IL2026/IL3050 (reflection-based serialization is disabled) and throws at
+// run time. The fix is a source-generated JsonSerializerContext wired in through
+// options.TypeInfoResolver - NOT JsonSerializer.Serialize(value, SomeContext.Default.PhoneNumber)
+// directly, which bypasses options.Converters (PhoneNumberConverter never runs) and recurses into
+// the source-generated serializer instead, overflowing the stack. Routing both calls through
+// `options` keeps the custom converter in charge.
+
+var jsonOptions = new JsonSerializerOptions
+{
+    TypeInfoResolver = SmokeTestJsonContext.Default,
+};
+jsonOptions.Converters.Add(new PhoneNumbers.Extensions.PhoneNumberConverter());
+
+var numberToSerialize = phoneUtil.Parse("+16502530000", "US");
+var json = SerializeNumber(numberToSerialize, jsonOptions);
+// Compare the decoded string value, not the raw JSON text: System.Text.Json's default encoder
+// escapes '+' (and other ASCII punctuation) with a \uXXXX sequence for HTML-embedding safety, so
+// the literal JSON text is not "+16502530000" even though the value it represents is.
+CheckEqual("+16502530000", JsonDocument.Parse(json).RootElement.GetString(),
+    "PhoneNumberConverter serializes to an E164 JSON string");
+
+var deserialized = DeserializeNumber(json, jsonOptions);
+Check(deserialized is not null && phoneUtil.IsValidNumber(deserialized),
+    "PhoneNumberConverter deserializes back into a valid PhoneNumber");
+
+// The generic/Type-based JsonSerializer overloads are annotated RequiresUnreferencedCode /
+// RequiresDynamicCode unconditionally - the trim/AOT analyzer has no way to know, just from the
+// call site, that options.TypeInfoResolver plus a matching entry in options.Converters means the
+// actual value work happens in PhoneNumberConverter, not via reflection. That is exactly what was
+// verified by hand against the published package before wiring this project into CI, so the
+// suppression below is deliberate and narrow, not a blanket opt-out: it only holds because
+// PhoneNumberConverter (registered by the caller) takes precedence over the source-generated
+// contract for PhoneNumbers.PhoneNumber specifically. A `#pragma warning disable` at the call site
+// is not enough here - ilc (the Native AOT compiler) re-runs this same analysis over the published
+// IL independently of the Roslyn compiler, and only respects UnconditionalSuppressMessageAttribute
+// metadata, not source-level pragmas.
+[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification =
+    "Serialization goes through the PhoneNumberConverter registered in options.Converters, not reflection.")]
+[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AotAnalysis", "IL3050", Justification =
+    "Serialization goes through the PhoneNumberConverter registered in options.Converters, not reflection.")]
+static string SerializeNumber(PhoneNumbers.PhoneNumber number, JsonSerializerOptions options)
+    => JsonSerializer.Serialize(number, options);
+
+[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification =
+    "Deserialization goes through the PhoneNumberConverter registered in options.Converters, not reflection.")]
+[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AotAnalysis", "IL3050", Justification =
+    "Deserialization goes through the PhoneNumberConverter registered in options.Converters, not reflection.")]
+static PhoneNumbers.PhoneNumber? DeserializeNumber(string json, JsonSerializerOptions options)
+    => (PhoneNumbers.PhoneNumber?)JsonSerializer.Deserialize(json, typeof(PhoneNumbers.PhoneNumber), options);
+
+// --- Summary --------------------------------------------------------------------------------------
+
+Console.WriteLine();
+Console.WriteLine(failures == 0
+    ? "All checks passed."
+    : $"{failures} check(s) FAILED.");
+
+return failures == 0 ? 0 : 1;
+
+// JsonSerializerContext must be a partial class at the top level (source-generated); PhoneNumber is
+// PhoneNumbers.PhoneNumber, disambiguated from PhoneNumbers.Extensions.PhoneNumber by full name.
+[JsonSerializable(typeof(PhoneNumbers.PhoneNumber))]
+internal partial class SmokeTestJsonContext : JsonSerializerContext
+{
+}

--- a/csharp/PhoneNumbers.PackageSmokeTest/README.md
+++ b/csharp/PhoneNumbers.PackageSmokeTest/README.md
@@ -1,0 +1,60 @@
+# Package smoke test
+
+Restores `libphonenumber-csharp` and `libphonenumber-csharp.extensions` from nuget.org as ordinary
+`PackageReference`s (never the in-repo source - see the comment in the `.csproj`) and runs a small
+battery of checks against them: parse/format/validate across a few regions, `AsYouTypeFormatter`,
+`ShortNumberInfo`, the offline geocoder/carrier/timezone mappers (the embedded binary metadata is
+the actual point - nothing else in this repo restores the packages as a consumer would and reads
+that data back out of them), `PhoneNumberUtil.FindNumbers`, and the extensions package's
+`TryParse`/`TryParseValid`/`PhoneNumberConverter`.
+
+`PhoneNumbers.csproj` sets `IsAotCompatible`, which catches static trim/AOT analyzer warnings at
+library-build time. It never restores the packed `.nupkg` as a consumer would or runs a published
+executable, so it cannot catch a problem in the packed output itself, or one that only appears once
+a real app's own code (not the library's) is compiled or AOT-analyzed against the library's public
+surface - the JSON serialization pattern below is exactly such a case.
+
+This project is not in `PhoneNumbers.slnx` - see the comment in the `.csproj`.
+
+## Running it locally
+
+The version to test is a required parameter, not something pinned in the project - pass it with
+`-p:PackageUnderTestVersion=X.Y.Z` or the `PACKAGE_UNDER_TEST_VERSION` environment variable. It
+must already be published on nuget.org.
+
+```bash
+# Normal managed run.
+dotnet run --project csharp/PhoneNumbers.PackageSmokeTest -c Release \
+  -p:PackageUnderTestVersion=9.0.38 -- 9.0.38
+
+# Native AOT: publish, then execute the native binary directly.
+dotnet publish csharp/PhoneNumbers.PackageSmokeTest -c Release -p:PublishAot=true \
+  -p:PackageUnderTestVersion=9.0.38 -o aot-out
+PACKAGE_UNDER_TEST_VERSION=9.0.38 ./aot-out/PhoneNumbers.PackageSmokeTest
+```
+
+Either mode exits non-zero if any check fails, and prints `PASS`/`FAIL` per check plus a summary
+line.
+
+## Why the JSON checks look the way they do
+
+Under `PublishAot`, `JsonSerializer.Serialize`/`Deserialize` without a `JsonSerializerContext` throw
+`InvalidOperationException: Reflection-based serialization has been disabled`. The fix is a
+`[JsonSerializable(typeof(PhoneNumbers.PhoneNumber))] partial class : JsonSerializerContext` wired
+in via `options.TypeInfoResolver`, with calls routed through the `options`-taking overloads
+(`JsonSerializer.Serialize(value, options)`, `JsonSerializer.Deserialize(json, typeof(T), options)`)
+rather than `JsonSerializer.Serialize(value, SomeContext.Default.PhoneNumber)` directly - the latter
+bypasses `options.Converters` entirely, so `PhoneNumberConverter` never runs and the source-generated
+serializer recurses into `PhoneNumber`'s own fields instead, overflowing the stack.
+
+Those `options`-taking overloads are still annotated `RequiresUnreferencedCode`/`RequiresDynamicCode`
+unconditionally (the analyzer cannot see that the registered converter is what actually runs), so
+`Program.cs` isolates them behind two local functions carrying a narrow, justified
+`UnconditionalSuppressMessageAttribute` - a `#pragma warning disable` at the call site is not enough
+here, because `ilc` (the Native AOT compiler) re-runs the same trim/AOT analysis over the published
+IL independently of the Roslyn compiler and only respects the attribute, not source-level pragmas.
+
+## In CI
+
+`.github/workflows/package_smoke_test.yml` runs both modes after a real `publish_nuget` run, and can
+also be dispatched on demand against any already-published version.


### PR DESCRIPTION
## Changes
- We manually validated libphonenumber-csharp/extensions 9.0.38 from nuget.org (managed run + Native AOT publish-and-execute) in a scratch console app. It fully passed, but nothing in CI actually does this - `PhoneNumbers.csproj`'s `IsAotCompatible` only catches static trim/AOT analyzer warnings at library-build time; it never restores the packed `.nupkg` or runs a published executable.
- Adds `csharp/PhoneNumbers.PackageSmokeTest`, deliberately outside `PhoneNumbers.slnx` (same reasoning as `PhoneNumbers.Fuzz`: different lifecycle, nothing else in the solution needs it). It restores both packages as real `PackageReference`s from nuget.org - never the in-repo source - for a version supplied as a parameter (`-p:PackageUnderTestVersion` or `PACKAGE_UNDER_TEST_VERSION`), and exercises:
  - parse/format/validate across a few regions (E164/national/international)
  - `AsYouTypeFormatter`
  - `ShortNumberInfo.IsValidShortNumber`
  - the offline geocoder/carrier/timezone mappers (the embedded binary metadata is the actual point of this project)
  - `PhoneNumberUtil.FindNumbers`
  - the extensions package's `TryParse`/`TryParseValid`/`PhoneNumberConverter`
  - `AssemblyInformationalVersionAttribute` matches the requested version (catches a stale/cached restore)
- The JSON converter check needed the AOT-safe `JsonSerializerContext` + `options.TypeInfoResolver` pattern (routing through `options` so `PhoneNumberConverter` in `options.Converters` takes precedence over the source-generated contract - calling `JsonSerializer.Serialize(value, Context.Default.PhoneNumber)` directly bypasses the converter and recurses into the generated serializer instead, overflowing the stack). Those `options`-taking overloads are still unconditionally annotated `RequiresUnreferencedCode`/`RequiresDynamicCode`, and `TreatWarningsAsErrors` in this repo turns that into a build error under `-p:PublishAot=true` - a `#pragma warning disable` at the call site is not enough because `ilc` re-runs the same analysis over the published IL independently of Roslyn. Fixed by isolating both calls behind local functions carrying a narrow, justified `UnconditionalSuppressMessageAttribute`. See the project's README for details.
- `.github/workflows/package_smoke_test.yml` runs both modes (`dotnet run`, then `dotnet publish -p:PublishAot=true` + execute) after a successful `publish_nuget` run, deriving the version from the release tag (`workflow_run`, gated on `conclusion == 'success'`). Includes a propagation-wait loop against the nuget.org flat-container endpoint before restoring, since `dotnet nuget push` can return before the package is actually resolvable. Also supports `workflow_dispatch` with a required `version` input for on-demand runs against any already-published version.

## Verification
Dispatching this workflow against a version that isn't yet on the default branch isn't possible - GitHub only recognizes `workflow_dispatch` once the workflow file exists on `main`. To get a real run before opening this PR (per the process used for #436), I temporarily added a `push` trigger scoped to this branch with a hardcoded test version, pushed, watched it run, then reverted that scaffolding in a follow-up commit (diff against the pre-verification commit is empty).

Real run on `ubuntu-24.04-arm` against the already-published 9.0.38 - version resolution, the nuget.org wait loop, the managed smoke test (24/24 checks passed), and the Native AOT publish + execute of the real `linux-arm64` native binary (24/24 checks passed again): https://github.com/twcclegg/libphonenumber-csharp/actions/runs/33229276075

Once this merges, `workflow_dispatch` will work normally against `main` for any future on-demand run.

## Tradeoffs / notes
- New workflow file vs. appending a job to `publish_nuget.yml`: went with a separate file so it can also run standalone via `workflow_dispatch` against an arbitrary past version, without needing to fabricate a fake "publish" run. Happy to fold it into `publish_nuget.yml` as a second job if preferred.
- The skip-gracefully branch (a `publish_nuget` `workflow_run` whose `head_branch` isn't a `vX.Y.Z` tag, e.g. someone dispatches `publish_nuget` from a branch to retry) is untested by the run above, since it's a `workflow_dispatch`/`push`-only code path; reasoned through, not exercised on a runner.
- `shellcheck`/YAML-validated via `actionlint` (with shellcheck) locally - zero findings on the new file.


---
