### PR TITLE
perf(test): add first-use-per-region cold-start benchmark

### DIFF
--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
@@ -23,12 +23,37 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
         // payload size is representative of the average region rather than an outlier like US/CN.
         private const string TargetRegion = "CH";
 
+        // Fixed, hardcoded (region, E164 number) pairs for FirstUseValidateAndFormat -- deliberately
+        // NOT derived via GetExampleNumberForType/IsValidNumber/Format at setup time, because calling
+        // those would itself compile and cache that region's regex patterns before the timed run
+        // starts (PhoneRegex's pattern cache is a static, process-wide ConcurrentDictionary -- see
+        // PhoneRegex.cs -- so anything touched in GlobalSetup, or on an earlier iteration of this same
+        // benchmark, is no longer "cold" for the rest of the process). One region per iteration, 20
+        // iterations, 20 distinct regions: nothing here overlaps TargetRegion or anything Setup()
+        // touches, and each entry is used at most once per benchmark run.
+        private static readonly PhoneNumberBenchmarkCase[] FirstUseRegions =
+        {
+            new("+1 6502530000", "US"), new("+442079460958", "GB"), new("+493083050", "DE"),
+            new("+33142685300", "FR"), new("+81332245000", "JP"), new("+861065525566", "CN"),
+            new("+911123014000", "IN"), new("+551122222222", "BR"), new("+61261621111", "AU"),
+            new("+74951234567", "RU"), new("+525512345678", "MX"), new("+27111234567", "ZA"),
+            new("+82212345678", "KR"), new("+390612345678", "IT"), new("+34912345678", "ES"),
+            new("+31201234567", "NL"), new("+46812345678", "SE"), new("+41441234567", "CH"),
+            new("+639171234567", "PH"), new("+842812345678", "VN"),
+        };
+
+        // Advances once per FirstUseValidateAndFormat call, so BenchmarkDotNet's 20 iterations walk
+        // FirstUseRegions in order without repeats -- each iteration genuinely first-touches a region
+        // no earlier iteration in this process has seen.
+        private int _firstUseIndex;
+
         [GlobalSetup]
         public void Setup()
         {
             // Force JIT of the metadata-loading path so we measure steady-state cold-start cost
             // rather than first-ever-invocation JIT noise. We deliberately use a different region
-            // than TargetRegion so the per-region cache stays cold for that one in FirstRegionLookup.
+            // than TargetRegion (and never touch anything in FirstUseRegions) so those caches stay
+            // cold for the benchmarks that measure them.
             _warmInstance = PhoneNumberUtil.GetInstance();
             _supportedRegions = new string[_warmInstance.GetSupportedRegions().Count];
             _warmInstance.GetSupportedRegions().CopyTo(_supportedRegions);
@@ -79,6 +104,44 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
                 new EmbeddedResourceMetadataLoader(),
                 CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
             return util.GetMetadataForRegion(TargetRegion);
+        }
+
+        /// <summary>
+        /// The other three benchmarks in this class only measure metadata *loading*
+        /// (<see cref="PhoneNumberUtil.GetMetadataForRegion"/>) -- not Parse, IsValidNumber, or
+        /// Format. Metadata loading is not where a per-region cold cost actually lives: it's
+        /// consistently sub-millisecond after the first call in this class (see
+        /// <see cref="FirstRegionLookup"/>). The expensive part is each region's *first* use of the
+        /// validation and formatting regex patterns cached by <see cref="PhoneRegex"/> -- a
+        /// process-wide, pattern-keyed cache that a fresh <see cref="PhoneNumberUtil"/> instance does
+        /// not reset. A region visited for the first time anywhere in this process pays the regex
+        /// JIT-compile cost (dozens of ms, not microseconds, when
+        /// <see cref="InternalRegexOptions.Default"/> includes <c>RegexOptions.Compiled</c>); a
+        /// region visited again anywhere in the process, even years later against a brand-new
+        /// PhoneNumberUtil, is already warm.
+        ///
+        /// This is the specific shape of cost this class was missing: it only shows up across many
+        /// *distinct, never-before-touched* regions, which is why the existing benchmarks here
+        /// (single-region, metadata-only) and <see cref="PhoneNumberWorkflowBenchmark"/> (diverse
+        /// regions, but pre-warmed in GlobalSetup before the timed run) both miss it. See the "regex
+        /// cache" and "cold start" sections of README.md for the two real regressions this exact gap
+        /// let through unnoticed for years.
+        /// </summary>
+        [Benchmark]
+        public int FirstUseValidateAndFormat()
+        {
+            var region = FirstUseRegions[_firstUseIndex % FirstUseRegions.Length];
+            _firstUseIndex++;
+
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+
+            var number = util.Parse(region.NumberToParse, region.DefaultRegion);
+            var checksum = util.IsValidNumber(number) ? 1 : 0;
+            checksum += util.Format(number, PhoneNumberFormat.NATIONAL).Length;
+            checksum += util.Format(number, PhoneNumberFormat.E164).Length;
+            return checksum;
         }
     }
 }

--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
@@ -42,10 +42,51 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             new("+639171234567", "PH"), new("+842812345678", "VN"),
         };
 
-        // Advances once per FirstUseValidateAndFormat call, so BenchmarkDotNet's 20 iterations walk
-        // FirstUseRegions in order without repeats -- each iteration genuinely first-touches a region
-        // no earlier iteration in this process has seen.
+        // Same reasoning as FirstUseRegions, for AsYouTypeFormatter, PhoneNumberMatcher, and
+        // PhoneNumberOfflineGeocoder respectively -- each pool is disjoint from FirstUseRegions AND
+        // from every other pool below, since all benchmark classes in this project run inside one
+        // BenchmarkDotNet process: a region touched by one class's cold-start benchmark is no longer
+        // cold for another class's, if they overlap. Numbers generated via
+        // GetExampleNumberForType/Format(E164) against an ad hoc instance outside this project, then
+        // hardcoded here -- the same reason FirstUseRegions doesn't derive them at Setup time applies.
+        private static readonly PhoneNumberBenchmarkCase[] FirstUseAsYouTypeRegions =
+        {
+            new("+48123456789", "PL"), new("+902123456789", "TR"), new("+6621234567", "TH"),
+            new("+62218350123", "ID"), new("+60323856789", "MY"), new("+6561234567", "SG"),
+            new("+2342033123456", "NG"), new("+254202012345", "KE"), new("+20234567890", "EG"),
+            new("+966112345678", "SA"), new("+97122345678", "AE"), new("+922123456789", "PK"),
+            new("+88027111234", "BD"), new("+380311234567", "UA"), new("+302123456789", "GR"),
+        };
+
+        private static readonly PhoneNumberBenchmarkCase[] FirstUseMatcherRegions =
+        {
+            new("+15062345678", "CA"), new("+541123456789", "AR"), new("+576012345678", "CO"),
+            new("+5111234567", "PE"), new("+56600123456", "CL"), new("+582121234567", "VE"),
+            new("+59322123456", "EC"), new("+59821231234", "UY"), new("+595212345678", "PY"),
+            new("+59122123456", "BO"), new("+351212345678", "PT"), new("+3212345678", "BE"),
+            new("+431234567890", "AT"), new("+4532123456", "DK"), new("+4721234567", "NO"),
+        };
+
+        private static readonly PhoneNumberBenchmarkCase[] FirstUseGeocoderRegions =
+        {
+            new("+420212345678", "CZ"), new("+3612345678", "HU"), new("+40211234567", "RO"),
+            new("+358131234567", "FI"), new("+3532212345", "IE"), new("+6432345678", "NZ"),
+            new("+97221234567", "IL"), new("+85221234567", "HK"), new("+886221234567", "TW"),
+            new("+85328212345", "MO"), new("+97444123456", "QA"), new("+96522345678", "KW"),
+            new("+212520123456", "MA"), new("+21312345678", "DZ"), new("+21630010123", "TN"),
+        };
+
+        // The private constant PhoneNumberOfflineGeocoder.GetInstance() passes its own constructor --
+        // duplicated here since it's private, not internal, so InternalsVisibleTo doesn't reach it.
+        private const string GeocodingDataDirectory = "geocoding.";
+
+        // Advances once per call to the matching FirstUse* benchmark below, so BenchmarkDotNet's 20
+        // iterations walk each pool in order without repeats -- each iteration genuinely first-touches
+        // a region no earlier iteration, in any of these benchmarks, has seen in this process.
         private int _firstUseIndex;
+        private int _firstUseAsYouTypeIndex;
+        private int _firstUseMatcherIndex;
+        private int _firstUseGeocoderIndex;
 
         [GlobalSetup]
         public void Setup()
@@ -142,6 +183,79 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             checksum += util.Format(number, PhoneNumberFormat.NATIONAL).Length;
             checksum += util.Format(number, PhoneNumberFormat.E164).Length;
             return checksum;
+        }
+
+        /// <summary>
+        /// Same gap as <see cref="FirstUseValidateAndFormat"/>, for <see cref="AsYouTypeFormatter"/>.
+        /// <see cref="AsYouTypeFormatterBenchmark"/> warms every region's formatter in GlobalSetup
+        /// before its timed loop starts, so it cannot see this cost either. A fresh formatter is
+        /// still built against the shared <see cref="_warmInstance"/> here (matching how a real
+        /// caller would use <see cref="PhoneNumberUtil.GetInstance"/>) -- what's cold is only the
+        /// region's pattern, on a region <see cref="FirstUseAsYouTypeRegions"/> guarantees no other
+        /// benchmark in this process has touched.
+        /// </summary>
+        [Benchmark]
+        public int FirstUseAsYouType()
+        {
+            var region = FirstUseAsYouTypeRegions[_firstUseAsYouTypeIndex % FirstUseAsYouTypeRegions.Length];
+            _firstUseAsYouTypeIndex++;
+
+            var formatter = _warmInstance.GetAsYouTypeFormatter(region.DefaultRegion);
+            var checksum = 0;
+            var input = region.NumberToParse;
+            for (var c = 0; c < input.Length; c++)
+                checksum += formatter.InputDigit(input[c]).Length;
+            return checksum;
+        }
+
+        /// <summary>
+        /// Same gap as <see cref="FirstUseValidateAndFormat"/>, for <see cref="PhoneNumberUtil.FindNumbers"/>
+        /// (backed by <see cref="PhoneNumberMatcher"/>). <see cref="PhoneNumberMatcherBenchmark"/> warms
+        /// its one fixed default region in GlobalSetup; here each invocation searches text for a number
+        /// from a region <see cref="FirstUseMatcherRegions"/> guarantees is still cold.
+        /// </summary>
+        [Benchmark]
+        public int FirstUseFindNumbers()
+        {
+            var region = FirstUseMatcherRegions[_firstUseMatcherIndex % FirstUseMatcherRegions.Length];
+            _firstUseMatcherIndex++;
+
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+
+            var text = $"Call me at {region.NumberToParse} tomorrow.";
+            var checksum = 0;
+            foreach (var match in util.FindNumbers(text, region.DefaultRegion))
+                checksum += match.RawString.Length;
+            return checksum;
+        }
+
+        /// <summary>
+        /// Same gap as <see cref="FirstUseValidateAndFormat"/>, for
+        /// <see cref="PhoneNumberOfflineGeocoder"/>. Architecturally distinct from the other
+        /// FirstUse* benchmarks -- the geocoder's per-region cost is a lazily-loaded prefix map
+        /// (<see cref="PrefixFileReader"/>'s <c>ConcurrentDictionary&lt;string, Lazy&lt;AreaCodeMap&gt;&gt;</c>),
+        /// not a <see cref="PhoneRegex"/> pattern compile -- but it shares the same structural blind
+        /// spot: <see cref="PhoneNumberOfflineGeocoderBenchmark"/> explicitly warms every prefix map
+        /// in GlobalSetup before its timed loop starts. Included for symmetry/completeness across the
+        /// library's other region-keyed subsystems, using the internal constructor (see
+        /// <c>InternalsVisibleTo</c> in Util.cs) so each invocation gets a geocoder whose prefix-map
+        /// cache has never seen <see cref="FirstUseGeocoderRegions"/>.
+        /// </summary>
+        [Benchmark]
+        public int FirstUseGeocode()
+        {
+            var region = FirstUseGeocoderRegions[_firstUseGeocoderIndex % FirstUseGeocoderRegions.Length];
+            _firstUseGeocoderIndex++;
+
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+            var geocoder = new PhoneNumberOfflineGeocoder(GeocodingDataDirectory);
+
+            var number = util.Parse(region.NumberToParse, region.DefaultRegion);
+            return geocoder.GetDescriptionForNumber(number, Locale.English).Length;
         }
     }
 }

--- a/csharp/PhoneNumbers.PerformanceTest/README.md
+++ b/csharp/PhoneNumbers.PerformanceTest/README.md
@@ -42,11 +42,14 @@ Other available benchmarks:
   backs the fallback path when a number has no finer-grained area description.
 - `*ColdStartBenchmark*` — cost a consumer pays the first time they touch the library: bare
   `PhoneNumberUtil` construction, construction plus lazy-load of every region's metadata, an
-  isolated first-region metadata lookup, and (`FirstUseValidateAndFormat`) a full
-  Parse+IsValidNumber+Format pass against a region no earlier iteration has touched. Uses BDN's
+  isolated first-region metadata lookup, and four `FirstUse*` benchmarks
+  (`FirstUseValidateAndFormat`, `FirstUseAsYouType`, `FirstUseFindNumbers`, `FirstUseGeocode`)
+  that each pair a region-keyed subsystem — Parse/IsValidNumber/Format, `AsYouTypeFormatter`,
+  `PhoneNumberUtil.FindNumbers`, and `PhoneNumberOfflineGeocoder` respectively — with a region no
+  earlier iteration, in any benchmark in this process, has touched. Uses BDN's
   `RunStrategy.ColdStart` with `invocationCount: 1` so each measurement is a genuine first-use,
   not a steady-state loop. See "Why there's a first-use-per-region benchmark" below before
-  changing or removing `FirstUseValidateAndFormat` — it exists specifically to catch a class of
+  changing or removing any `FirstUse*` benchmark — they exist specifically to catch a class of
   regression the other benchmarks here structurally cannot see.
 
 The benchmark data is generated from valid example numbers in the bundled metadata and expanded
@@ -93,9 +96,24 @@ Both regressions share one signature: **they only appear when many *distinct* re
 touched, and only on that first touch.** Every other benchmark in this project either exercises
 one region repeatedly (cheap after the first call, so a cache/compile regression is invisible) or
 warms its whole diverse dataset in `GlobalSetup` before the timed run starts (so the timed loop
-never sees a cold pattern either). `ColdStartBenchmark.FirstUseValidateAndFormat` is the one
-benchmark here built to have neither property: fresh `PhoneNumberUtil` per iteration, a fixed list
-of regions `GlobalSetup` never touches, one previously-unseen region per invocation. If you add a
-new benchmark that touches multiple regions, make sure at least one of them preserves this
-property, or a fourth occurrence of this exact regression will ship unnoticed again.
+never sees a cold pattern either). The four `ColdStartBenchmark.FirstUse*` benchmarks are built to
+have neither property: fresh instances per iteration (or, for `FirstUseAsYouType`, a fresh
+formatter off the shared warm `PhoneNumberUtil` — matching how `GetInstance()` is actually used),
+a fixed list of regions `GlobalSetup` never touches, one previously-unseen region per invocation.
+
+`FirstUseValidateAndFormat` covers Parse/IsValidNumber/Format, the same regex-cache path the two
+regressions above hit directly. `FirstUseAsYouType`, `FirstUseFindNumbers`, and `FirstUseGeocode`
+extend the same coverage to the library's other region-keyed subsystems — `AsYouTypeFormatter` and
+`PhoneNumberMatcher` share `PhoneRegex`'s pattern cache, so they're exposed to the identical class
+of regression; `PhoneNumberOfflineGeocoder` is architecturally different (a lazily-loaded prefix
+map in `PrefixFileReader`, no regex involved) but has the same structural blind spot in its own
+benchmark class, so it's covered for symmetry.
+
+**Each `FirstUse*` benchmark draws from its own region pool, and the four pools are disjoint from
+each other.** All benchmark classes in this project run inside one BenchmarkDotNet process, so a
+region touched by one class's cold-start benchmark is no longer cold for another's if the pools
+overlap — see the pool comments in `ColdStartBenchmark.cs` for the exact set each one owns. If you
+add a new benchmark that touches multiple regions, either reuse an existing disjoint pool or add a
+new one, and make sure at least one benchmark preserves the fresh-instance/never-pre-warmed
+property, or this exact regression will ship unnoticed again.
 

--- a/csharp/PhoneNumbers.PerformanceTest/README.md
+++ b/csharp/PhoneNumbers.PerformanceTest/README.md
@@ -41,9 +41,13 @@ Other available benchmarks:
   end-to-end, plus `Locale.GetDisplayCountry` on its own to isolate the country-name table that
   backs the fallback path when a number has no finer-grained area description.
 - `*ColdStartBenchmark*` — cost a consumer pays the first time they touch the library: bare
-  `PhoneNumberUtil` construction, construction plus lazy-load of every region's metadata,
-  and an isolated first-region lookup. Uses BDN's `RunStrategy.ColdStart` with
-  `invocationCount: 1` so each measurement is a genuine first-use, not a steady-state loop.
+  `PhoneNumberUtil` construction, construction plus lazy-load of every region's metadata, an
+  isolated first-region metadata lookup, and (`FirstUseValidateAndFormat`) a full
+  Parse+IsValidNumber+Format pass against a region no earlier iteration has touched. Uses BDN's
+  `RunStrategy.ColdStart` with `invocationCount: 1` so each measurement is a genuine first-use,
+  not a steady-state loop. See "Why there's a first-use-per-region benchmark" below before
+  changing or removing `FirstUseValidateAndFormat` — it exists specifically to catch a class of
+  regression the other benchmarks here structurally cannot see.
 
 The benchmark data is generated from valid example numbers in the bundled metadata and expanded
 deterministically to the configured `PhoneNumberCount` value. Each benchmark
@@ -54,4 +58,44 @@ Below you can see a sample of what the results might look like
 | Method                              | PhoneNumberCount | Job                | Runtime            | Mean     | Error     | StdDev    | Gen0    | Allocated |
 |------------------------------------ |-----------------:|------------------- |------------------- |---------:|----------:|----------:|--------:|----------:|
 | ParseValidateAndFormatPhoneNumbers  |             1000 | .NET 10.0          | .NET 10.0          | 1.25 ms  | 0.018 ms  | 0.017 ms  | 31.2500 |   512 KB  |
+
+## Why there's a first-use-per-region benchmark
+
+This library has shipped the same class of performance regression three times without this
+benchmark suite catching any of them — twice as an accidental side effect, once as a deliberate,
+benchmarked, tested tradeoff that just wasn't tested against the right shape of workload:
+
+- **2017** (`8.8.0`): adding a `netstandard2.0` build target flipped a `#if NETSTANDARD1_1` switch
+  in `InternalRegexOptions.cs` from `RegexOptions.None` to `RegexOptions.Compiled`. Combined with
+  `RegexCache`'s 100-entry LRU cap (already too small for a diverse-region workload, but harmless
+  under interpreted regex), throughput dropped ~115x for any caller touching more than ~100
+  distinct region/format patterns. Reported independently as
+  [#38](https://github.com/twcclegg/libphonenumber-csharp/issues/38) and
+  [#136](https://github.com/twcclegg/libphonenumber-csharp/issues/136); [#136] led to
+  [PR #161](https://github.com/twcclegg/libphonenumber-csharp/pull/161) (Nov 2022, `8.13.1`),
+  which removed the LRU cap entirely (unbounded `ConcurrentDictionary`) — fixing throughput ~3,800x
+  for the same diverse workload. A second, independent report of the same underlying problem,
+  [#154](https://github.com/twcclegg/libphonenumber-csharp/issues/154), was closed as stale eleven
+  days after #161 had already shipped the fix — nobody connected the two.
+- **2026** (`9.0.30`): [PR #325](https://github.com/twcclegg/libphonenumber-csharp/pull/325)
+  deliberately switched `PhoneRegex`'s per-region patterns from interpreted to
+  `RegexOptions.Compiled`, benchmarked and merged on real numbers — `PhoneNumberWorkflowBenchmark`
+  showed an honest 11-14% steady-state improvement. What that benchmark's `GlobalSetup` couldn't
+  see: it builds its seed data by calling `GetExampleNumberForType`/`IsValidNumber`/`Format`
+  against every supported region *before* the timed run starts, which pre-compiles (and — see
+  `PhoneRegex.cs` — permanently caches, process-wide) every pattern the timed loop will touch. A
+  consumer's *first* Parse/IsValidNumber/Format against a region their process has never seen pays
+  a JIT-compile cost of ~30ms instead of ~0.3ms; cold start across a diverse set of new regions
+  went from ~100ms to ~620-700ms. Not a bug — a real, measured tradeoff nobody's benchmark
+  methodology was shaped to price correctly.
+
+Both regressions share one signature: **they only appear when many *distinct* regions are
+touched, and only on that first touch.** Every other benchmark in this project either exercises
+one region repeatedly (cheap after the first call, so a cache/compile regression is invisible) or
+warms its whole diverse dataset in `GlobalSetup` before the timed run starts (so the timed loop
+never sees a cold pattern either). `ColdStartBenchmark.FirstUseValidateAndFormat` is the one
+benchmark here built to have neither property: fresh `PhoneNumberUtil` per iteration, a fixed list
+of regions `GlobalSetup` never touches, one previously-unseen region per invocation. If you add a
+new benchmark that touches multiple regions, make sure at least one of them preserves this
+property, or a fourth occurrence of this exact regression will ship unnoticed again.
 


### PR DESCRIPTION
## Summary
- Adds four `ColdStartBenchmark.FirstUse*` benchmarks, each doing a real end-to-end call against a fresh instance (or, for `FirstUseAsYouType`, a fresh formatter off the shared warm `PhoneNumberUtil`) targeting one region from a fixed, disjoint pool that `GlobalSetup` never pre-warms — one previously-unseen region per invocation:
  - `FirstUseValidateAndFormat` — `Parse` + `IsValidNumber` + `Format` (20 regions)
  - `FirstUseAsYouType` — `AsYouTypeFormatter.InputDigit`, keystroke by keystroke (15 regions)
  - `FirstUseFindNumbers` — `PhoneNumberUtil.FindNumbers` (15 regions)
  - `FirstUseGeocode` — `PhoneNumberOfflineGeocoder.GetDescriptionForNumber`, via the internal constructor so each invocation gets an un-warmed prefix-map cache (15 regions)
- All four pools are disjoint from each other and from every region `GlobalSetup` touches — necessary because every benchmark class in this project runs inside one process, and `PhoneRegex`'s pattern cache (and the geocoder's prefix-map cache) are process-wide, not per-instance.
- Everything currently in this project is untouched — this is additive only. The existing `ColdStartBenchmark` benchmarks (metadata-loading only) and the other classes' steady-state benchmarks (diverse regions, but pre-warmed in setup) both stay exactly as they are; they're good and valid for what they measure.
- Documents *why* this specific benchmark shape exists in `README.md`, including the two real regressions ([#161](https://github.com/twcclegg/libphonenumber-csharp/pull/161)'s fix for the 2017 issue, and [#325](https://github.com/twcclegg/libphonenumber-csharp/pull/325)'s 2026 cold-start tradeoff) that this exact gap let ship unnoticed, plus the disjoint-pool convention so a future benchmark addition doesn't accidentally re-warm a region another `FirstUse*` benchmark depends on staying cold.

## Why this specific gap
Every existing benchmark here either repeats one region (cheap after the first call) or warms its whole diverse region set in `GlobalSetup` before the timed run starts — e.g. `PhoneNumberWorkflowBenchmark`'s seed-data generation calls `GetExampleNumberForType`/`IsValidNumber`/`Format` against every supported region while building its dataset, and `AsYouTypeFormatterBenchmark`/`PhoneNumberMatcherBenchmark`/`PhoneNumberOfflineGeocoderBenchmark` do the equivalent for their own subsystems. None of these shapes can see the cost of a region's *genuinely first use* in the process. `PhoneRegex`'s pattern cache (`PhoneRegex.cs`) is a `static ConcurrentDictionary`, process-wide — a fresh instance doesn't reset it, only a never-before-touched region does. The geocoder's prefix-map cache (`PrefixFileReader.cs`) is architecturally different (lazy-loaded maps, no regex) but has the identical structural blind spot in its own benchmark class, so it's included for symmetry/completeness across the library's region-keyed subsystems.

Locally, all four `FirstUse*` benchmarks show multi-millisecond medians versus `FirstRegionLookup`'s (metadata-load-only) ~300us — cleanly separating the first-touch regex-compile/lazy-load cost this class was missing from the metadata-load cost it already measured.

## CI wiring — already fully automatic, no changes needed
- **Fails the build on a real regression, in any benchmark, including these new ones.** `run_performance_tests.yml` runs `--filter "*"` for both the branch and the PR base, `lib/compare-benchmarks.js` diffs every matching case (Welch's t-test + a 20% relative-delta floor, chosen well above measured single-launch noise), and `lib/fail-on-benchmark-regression.js` exits 1 — failing the workflow — if `significant-changes.json` has any `regressions` entries, regardless of which specific case regressed.
- **Posts a PR comment on a real improvement, in any benchmark, including these new ones.** `post_performance_test_comment.yml` (a separate `workflow_run`-triggered job) posts/updates a "📊 Statistically significant benchmark improvement" comment with a markdown table whenever `significant-changes.json` has any `improvements` entries, and removes the comment if a later push has none.
- Both operate generically over whatever cases show up in the JSON reports — no allowlist, no per-benchmark configuration. The four new `FirstUse*` cases are picked up automatically.

## Test plan
- [x] `dotnet build csharp` — whole solution builds clean
- [x] `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 451/451 pass, unaffected (PerformanceTest-only change)
- [x] `dotnet run -c Release --framework net10.0 -- --filter "*ColdStartBenchmark*"` locally — all seven benchmarks run cleanly, no exceptions/NA, each `FirstUse*` benchmark shows the expected cold-vs-warm separation