### PR TITLE
chore: gitignore local Claude Code worktree scratch state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,9 @@ FakesAssemblies/
 .DS_Store
 .idea
 
+# Claude Code local worktrees (background agent scratch state)
+.claude/
+
 # Zipped Geocoding Data
 geocoding.zip
 testgeocoding.zip


### PR DESCRIPTION
## Changes
- Adds `.claude/` to `.gitignore`. It currently only holds `.claude/worktrees/` — isolated git worktrees Claude Code's Agent tool creates for background experiments — but nothing under it is repo content, so it shouldn't ever show up as untracked/stageable.

---
