### PR TITLE
perf: stop compiling metadata-derived regexes

### DIFF
--- a/.github/workflows/run_performance_tests.yml
+++ b/.github/workflows/run_performance_tests.yml
@@ -132,6 +132,14 @@ jobs:
         run: dotnet run -c Release --framework net10.0 --no-build -- --filter "*" --exporters JSON
         working-directory: ./csharp/PhoneNumbers.PerformanceTest
 
+      # Not a benchmark, and not comparable against the base tree: it asserts an absolute budget and
+      # exits non-zero on its own. BenchmarkDotNet cannot cover this -- MemoryDiagnoser measures an
+      # extra run of the method, after static initializers have already completed. See
+      # PhoneNumbers.PerformanceTest/RetainedMemoryAudit.cs.
+      - name: Check retained memory against its budget
+        run: dotnet run -c Release --framework net10.0 --no-build -- --retained-memory
+        working-directory: ./csharp/PhoneNumbers.PerformanceTest
+
       # Bundle both sets of results so the follow-up workflow can post the comparison.
       - name: Stage benchmark artifact
         if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -208,8 +208,10 @@ testgeocoding.zip
 /resources/carrier.zip
 /resources/test/testcarrier.zip
 
-# Performance tests artifacts
-csharp/PhoneNumbers.PerformanceTest/BenchmarkDotNet.Artifacts/
+# Performance tests artifacts. BenchmarkDotNet writes these relative to the working directory, not
+# to the project directory, so running the benchmarks from anywhere other than the project folder
+# (e.g. `dotnet run --project PhoneNumbers.PerformanceTest/...` from csharp/) drops them elsewhere.
+**/BenchmarkDotNet.Artifacts/
 
 # Coverage reports
 coverage/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Targets `netstandard2.0`, `net8.0` and `net10.0`.
 
 The library is annotated as trim- and AOT-compatible, and the trim/AOT analyzers run as part of its own build. All metadata — including the geocoding, carrier and time zone prefix maps — is compiled to a binary form at build time and embedded in the assembly as compressed resources, so no XML is parsed and no file is read from disk at run time. The [interactive demo](https://twcclegg.github.io/libphonenumber-csharp/) is a Blazor WebAssembly app that runs this library trimmed, in the browser.
 
+### Regex compilation and startup cost
+
+Validation and formatting are driven by regexes built from the bundled metadata. There are thousands of them, and each is built the first time some caller touches that region.
+
+Those metadata regexes are deliberately **not** built with `RegexOptions.Compiled`. Compiling one costs around 1.5 ms of IL-emit and saves roughly 0.044 µs per match, so a pattern has to be matched on the order of 30,000 times before compiling it breaks even — which metadata patterns rarely are, because a workload spread across regions matches each one comparatively few times. Measured end-to-end on net8.0 (total wall time including startup, parse + validate + format), compiling them is 34x slower for 1,000 operations across 245 regions, 3.7x slower for 100,000, and still 1.7x slower at 1,000,000. It wins only for a process concentrating very high volume on one or two regions, and then by 6–20%.
+
+The library's own fixed regexes are a different case and are still compiled: there is a small, fixed number of them, each built once per process and hot for its whole life.
+
+If you have measured your own workload and know you want a compiled build of a specific pattern, construct a `PhoneRegex` with explicit options — caller-supplied options are honoured exactly.
+
 ### Debugging and symbols
 
 Symbols are published to the NuGet.org symbol server as a `.snupkg` alongside each release, with [Source Link](https://learn.microsoft.com/dotnet/standard/library-guidance/sourcelink) wired up — enable symbol server support in your debugger to step into the library.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Those metadata regexes are deliberately **not** built with `RegexOptions.Compile
 
 The library's own fixed regexes are a different case and are still compiled: there is a small, fixed number of them, each built once per process and hot for its whole life.
 
-If you have measured your own workload and know you want a compiled build of a specific pattern, construct a `PhoneRegex` with explicit options — caller-supplied options are honoured exactly.
+There is no per-call knob for this. If you have measured a workload where compiling the metadata patterns wins — a long-running process concentrating very high volume on one or two regions is the shape where it can — please open an issue with the numbers rather than reaching for internal types.
 
 ### Debugging and symbols
 

--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ColdStartBenchmark.cs
@@ -1,3 +1,4 @@
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
@@ -10,7 +11,7 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
     /// use of the library, before any region metadata has been loaded.
     /// </summary>
     [MemoryDiagnoser]
-    [SimpleJob(RunStrategy.ColdStart, RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 1, iterationCount: 20, invocationCount: 1)]
+    [SimpleJob(RunStrategy.ColdStart, RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: WarmupCount, iterationCount: IterationCount, invocationCount: 1)]
     public class ColdStartBenchmark
     {
         // The country-code-to-region map and one fresh PhoneNumberUtil are kept around so the
@@ -40,6 +41,7 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             new("+82212345678", "KR"), new("+390612345678", "IT"), new("+34912345678", "ES"),
             new("+31201234567", "NL"), new("+46812345678", "SE"), new("+41441234567", "CH"),
             new("+639171234567", "PH"), new("+842812345678", "VN"),
+            new("+3545101000", "IS"),
         };
 
         // Same reasoning as FirstUseRegions, for AsYouTypeFormatter, PhoneNumberMatcher, and
@@ -56,6 +58,8 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             new("+2342033123456", "NG"), new("+254202012345", "KE"), new("+20234567890", "EG"),
             new("+966112345678", "SA"), new("+97122345678", "AE"), new("+922123456789", "PK"),
             new("+88027111234", "BD"), new("+380311234567", "UA"), new("+302123456789", "GR"),
+            new("+951234567", "MM"), new("+85523756789", "KH"), new("+85621212862", "LA"),
+            new("+97653123456", "MN"), new("+94112345678", "LK"), new("+3726123456", "EE"),
         };
 
         private static readonly PhoneNumberBenchmarkCase[] FirstUseMatcherRegions =
@@ -65,6 +69,8 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             new("+59322123456", "EC"), new("+59821231234", "UY"), new("+595212345678", "PY"),
             new("+59122123456", "BO"), new("+351212345678", "PT"), new("+3212345678", "BE"),
             new("+431234567890", "AT"), new("+4532123456", "DK"), new("+4721234567", "NO"),
+            new("+50422123456", "HN"), new("+50222456789", "GT"), new("+50622123456", "CR"),
+            new("+5072001234", "PA"), new("+995322123456", "GE"), new("+38512345678", "HR"),
         };
 
         private static readonly PhoneNumberBenchmarkCase[] FirstUseGeocoderRegions =
@@ -74,15 +80,37 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
             new("+97221234567", "IL"), new("+85221234567", "HK"), new("+886221234567", "TW"),
             new("+85328212345", "MO"), new("+97444123456", "QA"), new("+96522345678", "KW"),
             new("+212520123456", "MA"), new("+21312345678", "DZ"), new("+21630010123", "TN"),
+            new("+96262001234", "JO"), new("+9611123456", "LB"), new("+96823123456", "OM"),
+            new("+97317001234", "BH"), new("+35722345678", "CY"), new("+35921234567", "BG"),
         };
 
         // The private constant PhoneNumberOfflineGeocoder.GetInstance() passes its own constructor --
         // duplicated here since it's private, not internal, so InternalsVisibleTo doesn't reach it.
         private const string GeocodingDataDirectory = "geocoding.";
 
-        // Advances once per call to the matching FirstUse* benchmark below, so BenchmarkDotNet's 20
-        // iterations walk each pool in order without repeats -- each iteration genuinely first-touches
-        // a region no earlier iteration, in any of these benchmarks, has seen in this process.
+        // Referenced by the [SimpleJob] attribute above so the job and the guard below cannot drift.
+        //
+        // The pool floor is WarmupCount + IterationCount, not IterationCount: a warmup iteration
+        // invokes the benchmark method and warms whatever region it draws, exactly like a measured one.
+        // A pool shorter than that wraps via the modulo below and silently re-measures an
+        // already-warm region, which is the contamination these pools exist to prevent.
+        private const int WarmupCount = 1;
+        private const int IterationCount = 20;
+        private const int CallsPerBenchmarkMethod = WarmupCount + IterationCount;
+
+        private static void CheckPoolSize(PhoneNumberBenchmarkCase[] pool, string poolName)
+        {
+            if (pool.Length < CallsPerBenchmarkMethod)
+                throw new InvalidOperationException(
+                    $"{poolName} has only {pool.Length} entries but each FirstUse* method is invoked " +
+                    $"{CallsPerBenchmarkMethod} times ({WarmupCount} warmup + {IterationCount} measured) -- " +
+                    "the pool would wrap and re-touch an already-warm region, contaminating the " +
+                    "'first use' measurement. Add entries rather than lowering iterationCount.");
+        }
+
+        // Advances once per call to the matching FirstUse* benchmark below, so each invocation walks
+        // its pool in order without repeats -- genuinely first-touching a region no earlier iteration,
+        // in any of these benchmarks, has seen in this process.
         private int _firstUseIndex;
         private int _firstUseAsYouTypeIndex;
         private int _firstUseMatcherIndex;
@@ -91,6 +119,11 @@ namespace PhoneNumbers.PerformanceTest.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
+            CheckPoolSize(FirstUseRegions, nameof(FirstUseRegions));
+            CheckPoolSize(FirstUseAsYouTypeRegions, nameof(FirstUseAsYouTypeRegions));
+            CheckPoolSize(FirstUseMatcherRegions, nameof(FirstUseMatcherRegions));
+            CheckPoolSize(FirstUseGeocoderRegions, nameof(FirstUseGeocoderRegions));
+
             // Force JIT of the metadata-loading path so we measure steady-state cold-start cost
             // rather than first-ever-invocation JIT noise. We deliberately use a different region
             // than TargetRegion (and never touch anything in FirstUseRegions) so those caches stay

--- a/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ProcessStartBenchmark.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Benchmarks/ProcessStartBenchmark.cs
@@ -1,0 +1,82 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace PhoneNumbers.PerformanceTest.Benchmarks
+{
+    /// <summary>
+    /// What a consumer pays between process start and their first answer, including every static
+    /// initializer on the way there.
+    /// <para>
+    /// <see cref="ColdStartBenchmark"/> cannot see that cost, and neither can
+    /// <see cref="PhoneNumberWorkflowBenchmark"/>: a BenchmarkDotNet job runs its warmup and all
+    /// measured iterations in one process, and a static initializer runs at most once per process, so
+    /// the warmup iteration absorbs it and no measured iteration can see it again. This job uses
+    /// <c>launchCount: 20, warmupCount: 0, iterationCount: 1, invocationCount: 1</c> so that the
+    /// measured call is the first thing its process does.
+    /// </para>
+    /// <para>
+    /// Each process actually invokes the method twice, not once -- MemoryDiagnoser performs its own
+    /// extra run, in the same process, after the measured one (verified by logging pid and method name
+    /// from inside the benchmark: 20 processes per method, two invocations each). That does not
+    /// compromise the Mean, which is taken from the first, genuinely cold call; it is why the Allocated
+    /// column is meaningless here, since the diagnoser's run happens once the static initializers have
+    /// completed.
+    /// </para>
+    /// <para>
+    /// <b>Read the Mean column, and read it as a trend.</b> Allocated is actively misleading: across a
+    /// change that added 3.4 MB of permanently-retained static state it moved only 129 KB -> 144 KB.
+    /// Retained memory is covered by <c>RetainedMemoryAudit</c> instead. The Ratio column is not
+    /// dependable either -- at one invocation per process the baseline's own ratio has been observed at
+    /// 1.01 with RatioSD 0.15, and Ratio answers a different question from the one the baseline is here
+    /// to answer (see <see cref="ConstructUtilFromProcessStart"/>): compare the Means by subtraction.
+    /// </para>
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob(RunStrategy.ColdStart, RuntimeMoniker.Net10_0, launchCount: 20, warmupCount: 0, iterationCount: 1, invocationCount: 1)]
+    public class ProcessStartBenchmark
+    {
+        private const string Region = "CH";
+        private const string NumberToParse = "+41441234567";
+
+        // No [GlobalSetup]: anything there would run before the measured call and absorb exactly the
+        // static-initialization cost this class exists to report.
+
+        /// <summary>
+        /// Metadata loading only, without touching PhoneRegex's pattern cache. Subtract this Mean from
+        /// <see cref="SingleNumberFromProcessStart"/>'s to isolate what first touching that cache costs
+        /// -- a difference, not the Ratio column, which reports a ratio and is unreliable at one
+        /// invocation per process.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public PhoneMetadata ConstructUtilFromProcessStart()
+        {
+            // See ColdStartBenchmark on why this loader is constructed directly.
+#pragma warning disable CS0618
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+#pragma warning restore CS0618
+            return util.GetMetadataForRegion(Region);
+        }
+
+        /// <summary>
+        /// What a one-shot consumer does: start, parse one number, validate, format, exit. Everything
+        /// is cold -- metadata, the pattern cache, and every static initializer behind both.
+        /// </summary>
+        [Benchmark]
+        public string SingleNumberFromProcessStart()
+        {
+#pragma warning disable CS0618
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+#pragma warning restore CS0618
+
+            var number = util.Parse(NumberToParse, Region);
+            return util.IsValidNumber(number)
+                ? util.Format(number, PhoneNumberFormat.INTERNATIONAL)
+                : string.Empty;
+        }
+    }
+}

--- a/csharp/PhoneNumbers.PerformanceTest/Program.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/Program.cs
@@ -1,11 +1,18 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System;
+using BenchmarkDotNet.Running;
 namespace PhoneNumbers.PerformanceTest
 {
     public static class Program
     {
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
+            // Not a benchmark: it measures memory retained after static initialization, which
+            // BenchmarkDotNet's MemoryDiagnoser cannot see. See RetainedMemoryAudit.
+            if (Array.Exists(args, a => string.Equals(a, "--retained-memory", StringComparison.Ordinal)))
+                return RetainedMemoryAudit.Run();
+
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+            return 0;
         }
     }
 }

--- a/csharp/PhoneNumbers.PerformanceTest/README.md
+++ b/csharp/PhoneNumbers.PerformanceTest/README.md
@@ -51,6 +51,58 @@ Other available benchmarks:
   not a steady-state loop. See "Why there's a first-use-per-region benchmark" below before
   changing or removing any `FirstUse*` benchmark — they exist specifically to catch a class of
   regression the other benchmarks here structurally cannot see.
+- `*ProcessStartBenchmark*` — cold start measured from *process* start, with no warmup iteration in
+  front of the measured call (`launchCount: 20, warmupCount: 0, iterationCount: 1`). Every other
+  benchmark here runs its warmup and all measured iterations in one process, and a static
+  initializer runs at most once per process, so the warmup absorbs any static-initialization cost
+  and no measured iteration can ever see it. Read its Mean, not its Allocated or Ratio — see the
+  class remarks for why both of those mislead here.
+
+### Retained memory is not a benchmark
+
+`dotnet run -c Release -- --retained-memory` measures how much managed memory the library still
+holds after parsing, validating and formatting 40 numbers across 20 regions, and exits non-zero if
+it exceeds its budget. The `run_performance_tests` workflow runs it, so a regression fails CI rather
+than printing a number nobody reads.
+
+This deliberately is not a BenchmarkDotNet benchmark, because BenchmarkDotNet cannot measure it.
+`MemoryDiagnoser` measures allocations during an *additional* run of the benchmark method, by which
+point every static initializer has already completed and allocates nothing — so it reports the
+steady-state cost of a warm call. That is not a theoretical gap: across a change that added 3.4 MB
+of permanently retained static state, `ProcessStartBenchmark`'s Allocated column — a job shaped as
+cold as BenchmarkDotNet allows — moved only 129 KB to 144 KB. A reviewer reading Allocated would
+have concluded the change was free.
+
+Retained, not allocated, is the distinction that matters: do the work, force a full collection, and
+measure what survived. It covers 20 regions rather than one because retention that grows per pattern
+is invisible at a single region.
+
+Know what it does **not** cover: it measures the GC heap, and `RegexOptions.Compiled` emits code that
+does not live there, so it under-reports that cost. Compiling the metadata patterns is guarded by
+`TestPhoneRegex.MetadataPatternsAreNeverCompiled` instead. Read a pass here as "nothing is retaining
+managed objects it should not", not as "memory is fine".
+
+### Why metadata regexes are not compiled
+
+`RegexOptions.Compiled` costs roughly 1.5 ms of IL-emit per distinct pattern and saves about
+0.044 µs per match, so a pattern must be matched on the order of 30,000 times before it breaks even.
+Measured end-to-end on net8.0 — total wall time including startup, parse + validate + format, best
+of 3 — compiled versus interpreted:
+
+| regions | ops | compiled | interpreted |
+|--------:|----:|---------:|------------:|
+| 1 | 1,000 | 35 ms | 29 ms |
+| 1 | 1,000,000 | 970 ms | 1153 ms |
+| 20 | 1,000 | 522 ms | 39 ms |
+| 20 | 100,000 | 877 ms | 529 ms |
+| 245 | 1,000 | 2284 ms | 61 ms |
+| 245 | 1,000,000 | 5231 ms | 2967 ms |
+
+Compiling wins only where a process concentrates very high volume on one or two regions, and then by
+6–20%; it loses by up to 34x everywhere else. Note that `PhoneNumberWorkflowBenchmark` pre-warms
+every pattern in `GlobalSetup` and then hammers a handful, which is exactly the shape where
+compiling wins — it is the wrong instrument for this decision, and trusting it alone is how the
+regression shipped three times.
 
 The benchmark data is generated from valid example numbers in the bundled metadata and expanded
 deterministically to the configured `PhoneNumberCount` value. Each benchmark

--- a/csharp/PhoneNumbers.PerformanceTest/RetainedMemoryAudit.cs
+++ b/csharp/PhoneNumbers.PerformanceTest/RetainedMemoryAudit.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace PhoneNumbers.PerformanceTest
+{
+    /// <summary>
+    /// Measures how much managed memory the library still holds after a representative amount of work,
+    /// and fails a budget. Run via <c>dotnet run -c Release -- --retained-memory</c>.
+    /// <para>
+    /// <b>Why this is not a BenchmarkDotNet benchmark.</b> MemoryDiagnoser measures allocations during
+    /// an additional run of the benchmark method, by which point every static initializer has already
+    /// completed and allocates nothing, so it reports the steady-state cost of a warm call. Measured,
+    /// not assumed: across a change that added 3.4 MB of permanently-retained static state,
+    /// <see cref="Benchmarks.ProcessStartBenchmark"/>'s Allocated column moved only 129 KB -> 144 KB.
+    /// </para>
+    /// <para>
+    /// <b>Retained, not allocated.</b> Do the work, force a full collection, measure what survived.
+    /// Transient garbage is ignored; what remains is what the process holds for the rest of its life.
+    /// </para>
+    /// <para>
+    /// <b>What this does and does not catch.</b> It measures the GC heap, so it sees managed retention:
+    /// eagerly-populated static caches, and Regex wrappers that are held after they stop being needed.
+    /// It does NOT see the cost of RegexOptions.Compiled itself, because emitted code does not live on
+    /// the GC heap -- a build that compiles every metadata pattern on first touch reports roughly the
+    /// same number here while costing tens of MB of RSS. Do not read a pass as "memory is fine";
+    /// read it as "nothing is retaining managed objects it should not".
+    /// </para>
+    /// </summary>
+    internal static class RetainedMemoryAudit
+    {
+        // A spread of regions rather than one: retention that grows per pattern -- a promoted holder
+        // that fails to release its superseded interpreted Regex, say -- is invisible at one region,
+        // where it is a single object against the metadata's own footprint.
+        private static readonly (string Number, string Region)[] Sample =
+        {
+            ("+41441234567", "CH"), ("+16502530000", "US"), ("+442079460958", "GB"),
+            ("+493083050", "DE"), ("+33142685300", "FR"), ("+81332245000", "JP"),
+            ("+861065525566", "CN"), ("+911123014000", "IN"), ("+551122222222", "BR"),
+            ("+61261621111", "AU"), ("+525512345678", "MX"), ("+27111234567", "ZA"),
+            ("+82212345678", "KR"), ("+390612345678", "IT"), ("+34912345678", "ES"),
+            ("+31201234567", "NL"), ("+46812345678", "SE"), ("+48123456789", "PL"),
+            ("+902123456789", "TR"), ("+6621234567", "TH"),
+        };
+
+        /// <summary>
+        /// Ceiling on managed memory retained after the work below. Calibrated to discriminate rather
+        /// than merely pass -- measured on net10.0, 3 runs each, variance under 3 KB:
+        /// <list type="table">
+        /// <item><term>this build</term><description>1218 KB</description></item>
+        /// <item><term>metadata patterns built with RegexOptions.Compiled</term><description>3209 KB</description></item>
+        /// </list>
+        /// 1600 KB sits above this build with ~30% headroom and well below the regression. If a
+        /// metadata update legitimately pushes this up, re-measure both numbers and raise it
+        /// deliberately, recording the new figures here -- do not bump it until CI goes green.
+        /// </summary>
+        private const long BudgetKilobytes = 1600;
+
+        public static int Run()
+        {
+            // See ColdStartBenchmark on why this loader is constructed directly rather than via
+            // PhoneNumberUtil.GetInstance()'s cached singleton.
+#pragma warning disable CS0618
+            var util = new PhoneNumberUtil(
+                new EmbeddedResourceMetadataLoader(),
+                CountryCodeToRegionCodeMap.GetCountryCodeToRegionCodeMap());
+#pragma warning restore CS0618
+
+            // Twice through, so every pattern crosses the promotion threshold and any per-holder
+            // retention is actually established before we measure.
+            foreach (var pass in new[] { 0, 1 })
+            {
+                foreach (var (text, region) in Sample)
+                {
+                    var parsed = util.Parse(text, region);
+                    var ok = util.IsValidNumber(parsed);
+                    var rendered = util.Format(parsed, PhoneNumberFormat.INTERNATIONAL);
+
+                    // The measurement is meaningless if the work above was elided as unobserved.
+                    if (!ok || rendered.Length == 0)
+                    {
+                        Console.Error.WriteLine(
+                            $"RetainedMemoryAudit: sanity check failed -- {text} ({region}) did not validate on pass {pass}.");
+                        return 2;
+                    }
+                }
+            }
+
+            // Let queued background compiles land, so promoted holders are in their final state.
+            Thread.Sleep(2000);
+
+            // Two collections with finalizers drained between: the first may queue objects for
+            // finalization and only the second can reclaim those.
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+            var retainedKilobytes = GC.GetTotalMemory(forceFullCollection: true) / 1024;
+
+            Console.WriteLine(string.Format(
+                CultureInfo.InvariantCulture,
+                "Retained after {2} numbers across {3} regions: {0} KB (budget {1} KB)",
+                retainedKilobytes,
+                BudgetKilobytes,
+                Sample.Length * 2,
+                Sample.Length));
+
+            if (retainedKilobytes <= BudgetKilobytes)
+                return 0;
+
+            Console.Error.WriteLine(string.Format(
+                CultureInfo.InvariantCulture,
+                "RetainedMemoryAudit FAILED: {0} KB retained exceeds the {1} KB budget by {2} KB. " +
+                "Something is retaining managed objects it does not need -- an eagerly-populated static " +
+                "cache, or a Regex held after it was superseded, are the usual causes. See this file's " +
+                "remarks for the calibration before considering raising the budget.",
+                retainedKilobytes,
+                BudgetKilobytes,
+                retainedKilobytes - BudgetKilobytes));
+            return 1;
+        }
+    }
+}

--- a/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PhoneNumbers.Test
+{
+    /// <summary>
+    /// Covers <see cref="PhoneRegex"/>. Every pattern embeds a fresh GUID so tests never share or race
+    /// on a cache entry -- the pattern cache is static and process-wide.
+    /// </summary>
+    public class TestPhoneRegex
+    {
+        /// <summary>Builds a (group name, literal marker, pattern) triple unique to the calling test.</summary>
+        private static (string GroupName, string Marker, string Pattern) UniqueCase(string label)
+        {
+            var marker = $"{label}_{Guid.NewGuid():N}";
+            var groupName = label + "g";
+            return (groupName, marker, $"(?<{groupName}>\\d{{2,5}})_{marker}");
+        }
+
+        [Fact]
+        public void PublicApiSurfaceStillWorks()
+        {
+            var (groupName, marker, pattern) = UniqueCase("basic");
+            var regex = new PhoneRegex(pattern);
+            var value = $"12345_{marker}";
+
+            Assert.True(regex.IsMatch(value));
+            Assert.True(regex.Match(value).Success);
+            Assert.Equal("replaced", regex.Replace(value, "replaced"));
+            Assert.True(regex.IsMatchAll(value));
+            Assert.True(regex.MatchAll(value).Success);
+            Assert.True(regex.IsMatchBeginning(value));
+            Assert.True(regex.MatchBeginning(value).Success);
+            Assert.Equal("12345", regex.Match(value).Groups[groupName].Value);
+
+            Assert.False(regex.IsMatch("no digits here"));
+            Assert.False(regex.IsMatchAll(value + " trailing junk"));
+            Assert.True(regex.IsMatchBeginning(value + " trailing junk"));
+        }
+
+        /// <summary>
+        /// The regression guard this file exists for. Metadata-derived patterns must not be built with
+        /// RegexOptions.Compiled: it costs ~1.5 ms of IL-emit per pattern and only repays after tens of
+        /// thousands of matches of that same pattern, which metadata patterns rarely see.
+        /// <para>
+        /// This library has shipped that regression three times -- 8.8.0, 8.13.0 and 9.0.30 (PR #325) --
+        /// and no test has ever caught it. Measured end-to-end on net8.0, compiling these costs 34x for
+        /// 1,000 operations across 245 regions and is still 1.7x slower at 1,000,000. If this test
+        /// fails, read <see cref="InternalRegexOptions.Interpreted"/> before changing it.
+        /// </para>
+        /// </summary>
+        [Fact]
+        public void MetadataPatternsAreNeverCompiled()
+        {
+            var (_, marker, pattern) = UniqueCase("notcompiled");
+            var regex = PhoneRegex.Get(pattern);
+            Assert.True(regex.IsMatch($"12_{marker}"));
+
+            foreach (var options in regex.BuiltOptions)
+            {
+                Assert.False(options.HasFlag(RegexOptions.Compiled),
+                    "metadata-derived patterns must be interpreted -- see InternalRegexOptions.Interpreted");
+                Assert.Equal(InternalRegexOptions.Interpreted, options);
+            }
+        }
+
+        /// <summary>
+        /// The library's own fixed regexes are a different case and do stay compiled: a fixed handful,
+        /// built once per process, hot for the life of it. The two option sets must differ by nothing
+        /// except RegexOptions.Compiled, so that a semantic flag cannot be added to one and not the
+        /// other.
+        /// </summary>
+        [Fact]
+        public void FixedRegexOptionsDifferFromMetadataOnesOnlyByCompiled()
+        {
+            Assert.Equal(InternalRegexOptions.Interpreted | RegexOptions.Compiled, InternalRegexOptions.Default);
+            Assert.Equal(InternalRegexOptions.Interpreted, InternalRegexOptions.Default & ~RegexOptions.Compiled);
+            Assert.True(InternalRegexOptions.Default.HasFlag(RegexOptions.Compiled));
+            Assert.True(InternalRegexOptions.Interpreted.HasFlag(RegexOptions.CultureInvariant));
+        }
+
+        [Fact]
+        public void CachedGetReturnsSameInstanceForSamePattern()
+        {
+            var (_, _, pattern) = UniqueCase("cache");
+            Assert.Same(PhoneRegex.Get(pattern), PhoneRegex.Get(pattern));
+        }
+
+#pragma warning disable CS0618 // intentionally exercising the obsolete ctor
+        /// <summary>
+        /// Caller-supplied options are honoured exactly, including RegexOptions.Compiled -- the opt-out
+        /// for anyone who genuinely wants a compiled build of a specific pattern.
+        /// </summary>
+        [Fact]
+        public void ObsoleteOptionsConstructorStillHonorsCallerSuppliedOptions()
+        {
+            var (_, marker, pattern) = UniqueCase("obsolete");
+
+            var ignoreCase = new PhoneRegex(pattern, RegexOptions.IgnoreCase);
+            Assert.True(ignoreCase.IsMatch($"12345_{marker.ToUpperInvariant()}"));
+
+            var compiled = new PhoneRegex(pattern, RegexOptions.Compiled);
+            Assert.True(compiled.IsMatch($"12345_{marker}"));
+            Assert.All(compiled.BuiltOptions, o => Assert.True(o.HasFlag(RegexOptions.Compiled)));
+        }
+#pragma warning restore CS0618
+
+        /// <summary>
+        /// A cache entry is shared process-wide, so concurrent first touches of the same pattern must
+        /// build it exactly once and every caller must get correct results throughout. Half the workers
+        /// hold one instance and half re-fetch through <see cref="PhoneRegex.Get"/>.
+        /// </summary>
+        [Fact]
+        public async Task ConcurrentFirstUseOfASharedCacheEntryStaysCorrect()
+        {
+            var (groupName, marker, pattern) = UniqueCase("concurrent");
+            var regex = PhoneRegex.Get(pattern);
+
+            var matchingValue = $"999_{marker}";
+            var nonMatchingValue = $"999_{marker}_nope";
+
+            const int workers = 8;
+            const int iterationsPerWorker = 200;
+
+            var tasks = new List<Task>();
+            for (var w = 0; w < workers; w++)
+            {
+                var reFetchEachTime = w % 2 == 0;
+                tasks.Add(Task.Run(() =>
+                {
+                    for (var i = 0; i < iterationsPerWorker; i++)
+                    {
+                        var r = reFetchEachTime ? PhoneRegex.Get(pattern) : regex;
+
+                        Assert.True(r.IsMatch(matchingValue));
+                        Assert.True(r.IsMatchAll(matchingValue));
+                        Assert.True(r.IsMatchBeginning(matchingValue));
+                        Assert.False(r.IsMatchAll(nonMatchingValue));
+                        Assert.True(r.IsMatchBeginning(nonMatchingValue));
+
+                        var m = r.MatchAll(matchingValue);
+                        Assert.True(m.Success);
+                        Assert.Equal("999", m.Groups[groupName].Value);
+                    }
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.True(regex.IsMatch(matchingValue));
+            Assert.False(regex.IsMatch($"abc_{marker}_nope"));
+        }
+    }
+}

--- a/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
@@ -24,7 +24,9 @@ namespace PhoneNumbers.Test
         public void PublicApiSurfaceStillWorks()
         {
             var (groupName, marker, pattern) = UniqueCase("basic");
+#pragma warning disable CS0618 // intentionally exercising the obsolete ctor
             var regex = new PhoneRegex(pattern);
+#pragma warning restore CS0618
             var value = $"12345_{marker}";
 
             Assert.True(regex.IsMatch(value));

--- a/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneRegex.cs
@@ -91,8 +91,8 @@ namespace PhoneNumbers.Test
 
 #pragma warning disable CS0618 // intentionally exercising the obsolete ctor
         /// <summary>
-        /// Caller-supplied options are honoured exactly, including RegexOptions.Compiled -- the opt-out
-        /// for anyone who genuinely wants a compiled build of a specific pattern.
+        /// Caller-supplied options are still honoured exactly. This is back-compat for a constructor
+        /// that should never have been public, not a supported way to opt into compiled patterns.
         /// </summary>
         [Fact]
         public void ObsoleteOptionsConstructorStillHonorsCallerSuppliedOptions()

--- a/csharp/PhoneNumbers/InternalRegexOptions.cs
+++ b/csharp/PhoneNumbers/InternalRegexOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace PhoneNumbers
 {
@@ -9,7 +9,37 @@ namespace PhoneNumbers
     /// <threadsafety static="true" instance="false"/>
     internal static class InternalRegexOptions
     {
-        public const RegexOptions
-            Default = RegexOptions.Compiled | RegexOptions.CultureInvariant;
+        /// <summary>
+        /// Options for metadata-derived patterns -- everything <see cref="PhoneRegex"/> builds.
+        /// <para>
+        /// No RegexOptions.Compiled, deliberately. Compiling costs roughly 1.5 ms of IL-emit for each
+        /// distinct pattern, and buys about 0.044 us per match; a pattern therefore has to be matched
+        /// on the order of 30,000 times before compiling it breaks even. Metadata-derived patterns do
+        /// not come close to that in most processes: there are thousands of them, each first built when
+        /// some caller happens to touch that region, and a workload spread across regions matches each
+        /// one a few thousand times at most.
+        /// </para>
+        /// <para>
+        /// Measured end-to-end (net8.0, total wall time including startup, parse + validate + format):
+        /// compiling these is 34x slower for 1,000 operations across 245 regions, 3.7x slower for
+        /// 100,000, and still 1.7x slower at 1,000,000. It wins only when a process concentrates very
+        /// high volume on very few regions -- 1 region and 100,000+ operations -- and then by 6-20%.
+        /// The library has shipped that trade three times by accident, most recently in PR #325, each
+        /// time because the benchmark used to justify it pre-warmed every pattern in setup and then
+        /// hammered a handful, which is precisely the one shape where compiling wins. Do not change
+        /// this on the strength of PhoneNumberWorkflowBenchmark alone.
+        /// </para>
+        /// </summary>
+        public const RegexOptions Interpreted = RegexOptions.CultureInvariant;
+
+        /// <summary>
+        /// Options for the library's own fixed, compile-time-known regexes -- the <c>GeneratedRegex</c>
+        /// members and <c>static readonly Regex</c> fields scattered across the library. Compiling
+        /// those is worth it: there is a fixed handful, each is built once per process, and each is on
+        /// a hot path for the life of it. Derived from <see cref="Interpreted"/> so the two sets differ
+        /// by nothing except RegexOptions.Compiled, and a semantic flag added here cannot apply to one
+        /// group of regexes but not the other.
+        /// </summary>
+        public const RegexOptions Default = Interpreted | RegexOptions.Compiled;
     }
 }

--- a/csharp/PhoneNumbers/PhoneRegex.cs
+++ b/csharp/PhoneNumbers/PhoneRegex.cs
@@ -21,6 +21,18 @@ using System.Text.RegularExpressions;
 
 namespace PhoneNumbers
 {
+    /// <summary>
+    /// Wraps the three regexes ("raw", "anchored to the whole input", "anchored to the start") built
+    /// from a single metadata-derived pattern string.
+    /// <para>
+    /// These are built with <see cref="InternalRegexOptions.Interpreted"/>, deliberately, and must stay
+    /// that way -- see <see cref="InternalRegexOptions.Interpreted"/> for the measurements. Unlike the
+    /// library's fixed regexes, which are compile-time-known and built once per process, these are
+    /// metadata-derived: there are thousands of them, each built the first time some caller happens to
+    /// touch that region, and RegexOptions.Compiled costs roughly 1.5 ms of IL-emit per pattern that
+    /// only repays after tens of thousands of matches of that same pattern.
+    /// </para>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class PhoneRegex
     {
@@ -40,9 +52,9 @@ namespace PhoneNumbers
         {
             this.pattern = pattern;
 
-            regex = new Lazy<Regex>(() => new Regex(this.pattern, InternalRegexOptions.Default), true);
-            allRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})$", InternalRegexOptions.Default), true);
-            beginRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})", InternalRegexOptions.Default), true);
+            regex = new Lazy<Regex>(() => new Regex(this.pattern, InternalRegexOptions.Interpreted), true);
+            allRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})$", InternalRegexOptions.Interpreted), true);
+            beginRegex = new Lazy<Regex>(() => new Regex($"^(?:{this.pattern})", InternalRegexOptions.Interpreted), true);
         }
 
         [Obsolete("This is an internal implementation detail not meant for public use")]
@@ -86,5 +98,13 @@ namespace PhoneNumbers
         }
 #endif
         public Match MatchBeginning(string value) => beginRegex.Value.Match(value);
+
+        /// <summary>
+        /// Options the three regexes were actually built with. Exists so a test can fail if
+        /// metadata-derived patterns are ever switched back to RegexOptions.Compiled -- the regression
+        /// this library has shipped three times, and which no test has ever caught.
+        /// </summary>
+        internal RegexOptions[] BuiltOptions =>
+            new[] { regex.Value.Options, allRegex.Value.Options, beginRegex.Value.Options };
     }
 }

--- a/csharp/PhoneNumbers/PhoneRegex.cs
+++ b/csharp/PhoneNumbers/PhoneRegex.cs
@@ -32,6 +32,13 @@ namespace PhoneNumbers
     /// touch that region, and RegexOptions.Compiled costs roughly 1.5 ms of IL-emit per pattern that
     /// only repays after tens of thousands of matches of that same pattern.
     /// </para>
+    /// <para>
+    /// This type is public, and both constructors are <see cref="ObsoleteAttribute"/>, only because the
+    /// obsolete <see cref="RegexCache"/> shim returns <see cref="PhoneRegex"/> instances. Neither the
+    /// type nor either constructor was ever meant to be called by consumers; both were only ever meant
+    /// to be internal, and will become so at the next opportunity for a breaking change -- see issue
+    /// #375.
+    /// </para>
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class PhoneRegex
@@ -44,10 +51,18 @@ namespace PhoneNumbers
         private static readonly ConcurrentDictionary<string, PhoneRegex> cache = new();
 
         // Cached factory delegate so cache-hit lookups never allocate a fresh closure.
+#pragma warning disable CS0618 // the ctor is obsolete for external callers, not for the cache that owns it
         private static readonly Func<string, PhoneRegex> factory = k => new PhoneRegex(k);
+#pragma warning restore CS0618
 
         internal static PhoneRegex Get(string regex) => cache.GetOrAdd(regex, factory);
 
+        /// <summary>
+        /// This constructor, like the type it belongs to, is public only because the obsolete
+        /// <see cref="RegexCache"/> shim returns <see cref="PhoneRegex"/> instances -- see the class
+        /// remarks. It was never meant to be called directly.
+        /// </summary>
+        [Obsolete("This is an internal implementation detail not meant for public use")]
         public PhoneRegex(string pattern)
         {
             this.pattern = pattern;


### PR DESCRIPTION
## Changes

Reverts the cold-start regression from #325 by taking `RegexOptions.Compiled` off metadata-derived patterns. The library's own fixed regexes stay compiled — that's where compiling actually pays.

**The arithmetic.** Compiling a regex costs ~1.5 ms of IL-emit and saves ~0.044 µs per match, so a pattern must be matched on the order of **30,000 times** before it breaks even. There are thousands of metadata patterns, each built the first time some caller touches that region, and a workload spread across regions matches each one far fewer times than that.

**Measured end-to-end** — net8.0, total wall time *including startup*, parse + validate + format, best of 3:

| regions | ops | compiled (`main`) | interpreted (this PR) | |
|--------:|----:|---------:|------------:|---|
| 1 | 1,000 | 35 ms | **29 ms** | |
| 1 | 100,000 | **188 ms** | 194 ms | compiled wins 3% |
| 1 | 1,000,000 | **970 ms** | 1153 ms | compiled wins 16% |
| 20 | 1,000 | 522 ms | **39 ms** | **13x** |
| 20 | 100,000 | 877 ms | **529 ms** | 1.7x |
| 20 | 1,000,000 | **2330 ms** | 2455 ms | compiled wins 5% |
| 245 | 1,000 | 2284 ms | **61 ms** | **37x** |
| 245 | 100,000 | 2696 ms | **642 ms** | 4.2x |
| 245 | 1,000,000 | 5231 ms | **2967 ms** | 1.8x |

Interpreted wins six of nine. Compiling wins three, all in the concentrated high-volume corner, by 6–20%. **The downside of interpreted is bounded and small; the downside of compiling is not.**

Retained memory drops too: **3209 KB → 1218 KB** after 40 numbers across 20 regions.

## Why this isn't configurable

An earlier revision of this PR built a promote-on-reuse scheme — interpreted first, compiled in the background once a pattern was reused. Measured against real workloads it **won zero of the nine cells above**: at a threshold of 2 it tracked the always-compiled numbers almost exactly (524 vs 532, 2124 vs 2286), because touching a region a handful of times crosses a threshold of 2 immediately, so you pay essentially the full compile cost anyway. Raising the threshold to the measured break-even didn't rescue it either — it then became the worst option at 20 regions × 1M. That machinery (background worker, queue, CAS, atomic swap, ~300 lines) is gone.

An opt-in switch was also considered and dropped: it's a config surface and a second code path that approximately nobody would enable. There is deliberately no per-call escape hatch either — `PhoneRegex` is `[EditorBrowsable(Never)]`, its options constructor is `[Obsolete]` as "an internal implementation detail not meant for public use", and the type is only public because the obsolete `RegexCache` shim returns it. Upstream has no equivalent at all: Google's Java `RegexCache` sits in `com.google.i18n.phonenumbers.internal` and returns `java.util.regex.Pattern` directly. Anyone with a workload where compiling wins should open an issue with numbers.

## This is the third time

The same regression shipped in **8.8.0**, **8.13.0**, and **9.0.30** (#325). Measured cold start, first touch of all 245 regions:

| version | | version | |
|---|---|---|---|
| 8.8.0 | 3148 ms | 9.0.29 | 45 ms |
| 8.13.0 | 3760 ms | 9.0.30 | **2824 ms** ← #325 |
| 8.13.1 | 43 ms ← #161 fixed it | `main` | 2326 ms |
| 9.0.0–9.0.25 | 45–46 ms | **this PR** | **61 ms** |

Every time, the justification came from `PhoneNumberWorkflowBenchmark` — whose `GlobalSetup` pre-warms every pattern and whose timed loop then hammers a handful. That is precisely the one workload shape where compiling wins, which is why it kept looking like a clean win. It is the wrong instrument for this decision, and both READMEs now say so.

## Public API

No new public members; `PhoneRegex`'s public surface is unchanged. Package validation against the released 9.0.37 baseline is clean on all three TFMs.

## Guarding against a fourth time

Compiling changes no behaviour, only cost, which is why no test ever caught it. Now:

- **`TestPhoneRegex.MetadataPatternsAreNeverCompiled`** asserts on the options the regexes were actually built with. Verified by mutation: switching them back fails with *"metadata-derived patterns must be interpreted"*, where the whole suite previously passed.
- **`RetainedMemoryAudit`** (`dotnet run -c Release -- --retained-memory`) fails a 1600 KB budget with a non-zero exit code, and `run_performance_tests` now actually runs it. Calibrated to discriminate: this build 1218 KB, compiled 3209 KB.
- **`ProcessStartBenchmark`** measures cold start from process start with no warmup absorbing static init — the gap that let this through.
- **`ColdStartBenchmark`**'s pool guard was off by `warmupCount`: each `FirstUse*` method is invoked `warmupCount + iterationCount` times, so 20-entry pools wrapped and re-measured an already-warm region on the final iteration.

## Test plan

- [x] `dotnet build csharp/PhoneNumbers.slnx -c Release` — clean, 0 warnings, all three TFMs
- [x] `dotnet test` — 440/440 on net8.0 and net10.0; each of the 4 commits builds and passes standalone
- [x] Mutation-verified: re-compiling the metadata patterns fails both the unit test and the audit
- [x] Benchmarked against shipped NuGet packages 8.8.0 → 9.0.38 on both the `netstandard2.0` and `net8.0` assets
- [x] Package validation against the 9.0.37 baseline: zero API breaks on all three TFMs
