### PR TITLE
perf: narrow \d to ASCII [0-9] in metadata-matched regex patterns

### DIFF
--- a/csharp/PhoneNumbers.Test/TestBuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers.Test/TestBuildMetadataFromXml.cs
@@ -78,6 +78,86 @@ namespace PhoneNumbers.Test
             Assert.Equal(validPattern, BuildMetadataFromXml.ValidateRE(validPattern, false));
         }
 
+        // Tests NarrowDigitClassToAscii(): the character-class-aware \d -> [0-9] rewrite used for
+        // metadata patterns that are actually matched against (already ASCII-normalized) input --
+        // see ValidateAndNarrowPatternRE's doc comment for exactly which fields that is.
+        [Theory]
+        // Real nationalNumberPattern values, pulled verbatim from resources/PhoneNumberMetadata.xml.
+        [InlineData("6\\d{4}", "6[0-9]{4}")]
+        [InlineData("[2-47]\\d{4}", "[2-47][0-9]{4}")]
+        // Real internationalPrefix values.
+        [InlineData("(?:0|1(?:1[0-69]|2[02-5]|5[13-58]|69|7[0167]|8[018]))0",
+            "(?:0|1(?:1[0-69]|2[02-5]|5[13-58]|69|7[0167]|8[018]))0")]
+        [InlineData("0(?:0|1[3-9]\\d)", "0(?:0|1[3-9][0-9])")]
+        // Real nationalPrefixForParsing values (note the trailing "$" anchor and alternation).
+        [InlineData("(000[2569]\\d{4,6})$|(?:(?:003768)0?)|0",
+            "(000[2569][0-9]{4,6})$|(?:(?:003768)0?)|0")]
+        [InlineData("(5\\d{6})$|1", "(5[0-9]{6})$|1")]
+        // Real numberFormat "pattern" attribute values.
+        [InlineData("(\\d)(\\d{2,3})(\\d{2})(\\d{2})", "([0-9])([0-9]{2,3})([0-9]{2})([0-9]{2})")]
+        [InlineData("(\\d)(\\d{2})(\\d{3,4})", "([0-9])([0-9]{2})([0-9]{3,4})")]
+        // \d already inside a character class must substitute the bare "0-9" in place, not wrap a
+        // second, nested set of brackets around it.
+        [InlineData("[\\d-]", "[0-9-]")]
+        [InlineData("[a\\d-]", "[a0-9-]")]
+        [InlineData("[^\\d]", "[^0-9]")]
+        // A \d immediately after the class-opening bracket (no leading literal ']' or '^' first).
+        [InlineData("[\\d]", "[0-9]")]
+        // A literal ']' as the first class member (POSIX idiom) must not be mistaken for the class
+        // closing, so the \d later in the same class still narrows in place.
+        [InlineData("[]\\d]", "[]0-9]")]
+        [InlineData("[^]\\d]", "[^]0-9]")]
+        // An escaped backslash followed by a literal "d" is not \d and must be left alone.
+        [InlineData("\\\\d", "\\\\d")]
+        // No backslash at all: fast path, unchanged.
+        [InlineData("[0-9]{3}", "[0-9]{3}")]
+        // Escaped literal characters elsewhere in the pattern must survive untouched.
+        [InlineData("\\(\\d{3}\\)", "\\([0-9]{3}\\)")]
+        public void TestNarrowDigitClassToAscii(string input, string expected)
+        {
+            Assert.Equal(expected, BuildMetadataFromXml.NarrowDigitClassToAscii(input));
+            // The result must always be a well-formed regex (this also catches the classic
+            // nested-bracket bug the character-class-aware rewrite exists to avoid: naively wrapping
+            // an in-class \d as "[0-9]" instead of substituting "0-9" produces invalid syntax like
+            // "[[0-9]-]", which would fail to compile here).
+            _ = new System.Text.RegularExpressions.Regex(BuildMetadataFromXml.NarrowDigitClassToAscii(input));
+        }
+
+        [Fact]
+        public void TestNarrowDigitClassToAsciiPreservesMatchSemantics()
+        {
+            // The narrowed pattern must still match/reject exactly the ASCII input the original did --
+            // narrowing only removes the (out-of-scope, for already-normalized input) Unicode digit
+            // categories, it must not change ASCII-digit behavior.
+            const string original = "(000[2569]\\d{4,6})$|(?:(?:003768)0?)|0";
+            var narrowed = BuildMetadataFromXml.NarrowDigitClassToAscii(original);
+            var originalRegex = new System.Text.RegularExpressions.Regex("^(?:" + original + ")$");
+            var narrowedRegex = new System.Text.RegularExpressions.Regex("^(?:" + narrowed + ")$");
+            foreach (var candidate in new[] { "0", "0002569123", "00025691234", "003768", "0037680", "1" })
+                Assert.Equal(originalRegex.IsMatch(candidate), narrowedRegex.IsMatch(candidate));
+        }
+
+        [Fact]
+        public void TestNarrowDigitClassToAsciiThrowsOnDInsideCharacterClass()
+        {
+            // \D cannot in general be soundly unioned into an existing bracket expression's other
+            // members, and this shape does not occur anywhere in the shipped metadata today -- see
+            // NarrowDigitClassToAscii's doc comment. Surfacing it loudly is preferable to silently
+            // emitting an incorrect pattern.
+            Assert.Throws<NotSupportedException>(() => BuildMetadataFromXml.NarrowDigitClassToAscii("[\\D-]"));
+        }
+
+        [Fact]
+        public void TestValidateAndNarrowPatternRENarrowsAndValidates()
+        {
+            Assert.Equal("[0-9]{6}", BuildMetadataFromXml.ValidateAndNarrowPatternRE("\\d{6}"));
+            // removeWhitespace still applies, exactly as for ValidateRE.
+            Assert.Equal("[0-9]{6}", BuildMetadataFromXml.ValidateAndNarrowPatternRE("\t \\d { 6 } ", true));
+            // An invalid pattern still throws, same as ValidateRE (ArgumentException or the more
+            // specific RegexParseException the BCL derives it from).
+            Assert.ThrowsAny<ArgumentException>(() => BuildMetadataFromXml.ValidateAndNarrowPatternRE("["));
+        }
+
         // Tests NationalPrefix.
         [Fact]
         public void TestGetNationalPrefix()
@@ -410,7 +490,9 @@ namespace PhoneNumbers.Test
 
             var phoneNumberDesc = BuildMetadataFromXml.ProcessPhoneNumberDescElement(
                 generalDesc, territoryElement, "fixedLine");
-            Assert.Equal("\\d{6}", phoneNumberDesc.NationalNumberPattern);
+            // \d is narrowed to the ASCII-only [0-9] for patterns that are matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("[0-9]{6}", phoneNumberDesc.NationalNumberPattern);
         }
 
         [Fact]
@@ -438,7 +520,9 @@ namespace PhoneNumbers.Test
 
             var phoneNumberDesc = BuildMetadataFromXml.ProcessPhoneNumberDescElement(
                 null, countryElement, "fixedLine");
-            Assert.Equal("\\d{6}", phoneNumberDesc.NationalNumberPattern);
+            // \d is narrowed to the ASCII-only [0-9] for patterns that are matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("[0-9]{6}", phoneNumberDesc.NationalNumberPattern);
         }
 
         // Tests LoadGeneralDesc().
@@ -476,15 +560,17 @@ namespace PhoneNumbers.Test
             var territoryElement = ParseXmlString(xmlInput);
             var metadata = new PhoneMetadata.Builder();
             BuildMetadataFromXml.LoadGeneralDesc(metadata, territoryElement);
-            Assert.Equal("\\d{1}", metadata.FixedLine.NationalNumberPattern);
-            Assert.Equal("\\d{2}", metadata.Mobile.NationalNumberPattern);
-            Assert.Equal("\\d{3}", metadata.Pager.NationalNumberPattern);
-            Assert.Equal("\\d{4}", metadata.TollFree.NationalNumberPattern);
-            Assert.Equal("\\d{5}", metadata.PremiumRate.NationalNumberPattern);
-            Assert.Equal("\\d{6}", metadata.SharedCost.NationalNumberPattern);
-            Assert.Equal("\\d{7}", metadata.PersonalNumber.NationalNumberPattern);
-            Assert.Equal("\\d{8}", metadata.Voip.NationalNumberPattern);
-            Assert.Equal("\\d{9}", metadata.Uan.NationalNumberPattern);
+            // \d is narrowed to the ASCII-only [0-9] for patterns that are matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("[0-9]{1}", metadata.FixedLine.NationalNumberPattern);
+            Assert.Equal("[0-9]{2}", metadata.Mobile.NationalNumberPattern);
+            Assert.Equal("[0-9]{3}", metadata.Pager.NationalNumberPattern);
+            Assert.Equal("[0-9]{4}", metadata.TollFree.NationalNumberPattern);
+            Assert.Equal("[0-9]{5}", metadata.PremiumRate.NationalNumberPattern);
+            Assert.Equal("[0-9]{6}", metadata.SharedCost.NationalNumberPattern);
+            Assert.Equal("[0-9]{7}", metadata.PersonalNumber.NationalNumberPattern);
+            Assert.Equal("[0-9]{8}", metadata.Voip.NationalNumberPattern);
+            Assert.Equal("[0-9]{9}", metadata.Uan.NationalNumberPattern);
         }
     }
 }

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberUtil.cs
@@ -200,19 +200,21 @@ namespace PhoneNumbers.Test
             Assert.Equal("011", metadata.InternationalPrefix);
             Assert.True(metadata.HasNationalPrefix);
             Assert.Equal(2, metadata.NumberFormatCount);
-            Assert.Equal("(\\d{3})(\\d{3})(\\d{4})",
+            // \d is narrowed to the ASCII-only [0-9] for metadata patterns matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("([0-9]{3})([0-9]{3})([0-9]{4})",
                 metadata.NumberFormatList[1].Pattern);
             Assert.Equal("$1 $2 $3", metadata.NumberFormatList[1].Format);
-            Assert.Equal("[13-689]\\d{9}|2[0-35-9]\\d{8}",
+            Assert.Equal("[13-689][0-9]{9}|2[0-35-9][0-9]{8}",
                 metadata.GeneralDesc.NationalNumberPattern);
-            Assert.Equal("[13-689]\\d{9}|2[0-35-9]\\d{8}",
+            Assert.Equal("[13-689][0-9]{9}|2[0-35-9][0-9]{8}",
                 metadata.FixedLine.NationalNumberPattern);
             Assert.Equal(1, metadata.GeneralDesc.PossibleLengthCount);
             Assert.Equal(10, metadata.GeneralDesc.PossibleLengthList[0]);
             // Possible lengths are the same as the general description, so aren't stored separately in the
             // toll free element as well.
             Assert.Equal(0, metadata.TollFree.PossibleLengthCount);
-            Assert.Equal("900\\d{7}", metadata.PremiumRate.NationalNumberPattern);
+            Assert.Equal("900[0-9]{7}", metadata.PremiumRate.NationalNumberPattern);
             // No shared-cost data is available, so its national number data should not be set.
             Assert.False(metadata.SharedCost.HasNationalNumberPattern);
         }
@@ -228,7 +230,9 @@ namespace PhoneNumbers.Test
             Assert.Equal(6, metadata.NumberFormatCount);
             Assert.Equal(1, metadata.NumberFormatList[5].LeadingDigitsPatternCount);
             Assert.Equal("900", metadata.NumberFormatList[5].LeadingDigitsPatternList[0]);
-            Assert.Equal("(\\d{3})(\\d{3,4})(\\d{4})",
+            // \d is narrowed to the ASCII-only [0-9] for metadata patterns matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("([0-9]{3})([0-9]{3,4})([0-9]{4})",
                 metadata.NumberFormatList[5].Pattern);
             Assert.Equal("$1 $2 $3", metadata.NumberFormatList[5].Format);
             Assert.Equal(2, metadata.GeneralDesc.PossibleLengthLocalOnlyCount);
@@ -237,11 +241,11 @@ namespace PhoneNumbers.Test
             // efficiency reasons we don't store an extra value.
             Assert.Equal(0, metadata.FixedLine.PossibleLengthCount);
             Assert.Equal(2, metadata.Mobile.PossibleLengthCount);
-            Assert.Equal("(?:[24-6]\\d{2}|3[03-9]\\d|[789](?:0[2-9]|[1-9]\\d))\\d{1,8}",
+            Assert.Equal("(?:[24-6][0-9]{2}|3[03-9][0-9]|[789](?:0[2-9]|[1-9][0-9]))[0-9]{1,8}",
                 metadata.FixedLine.NationalNumberPattern);
             Assert.Equal("30123456", metadata.FixedLine.ExampleNumber);
             Assert.Equal(10, metadata.TollFree.PossibleLengthList[0]);
-            Assert.Equal("900([135]\\d{6}|9\\d{7})", metadata.PremiumRate.NationalNumberPattern);
+            Assert.Equal("900([135][0-9]{6}|9[0-9]{7})", metadata.PremiumRate.NationalNumberPattern);
         }
 
         [Fact]
@@ -255,9 +259,11 @@ namespace PhoneNumbers.Test
             Assert.Equal("0(?:(11|343|3715)15)?", metadata.NationalPrefixForParsing);
             Assert.Equal("9$1", metadata.NationalPrefixTransformRule);
             Assert.Equal("$2 15 $3-$4", metadata.NumberFormatList[2].Format);
-            Assert.Equal("(\\d)(\\d{4})(\\d{2})(\\d{4})",
+            // \d is narrowed to the ASCII-only [0-9] for metadata patterns matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("([0-9])([0-9]{4})([0-9]{2})([0-9]{4})",
                      metadata.NumberFormatList[3].Pattern);
-            Assert.Equal("(\\d)(\\d{4})(\\d{2})(\\d{4})",
+            Assert.Equal("([0-9])([0-9]{4})([0-9]{2})([0-9]{4})",
                      metadata.IntlNumberFormatList[3].Pattern);
             Assert.Equal("$1 $2 $3 $4", metadata.IntlNumberFormatList[3].Format);
         }
@@ -269,7 +275,9 @@ namespace PhoneNumbers.Test
             Assert.Equal("001", metadata.Id);
             Assert.Equal(800, metadata.CountryCode);
             Assert.Equal("$1 $2", metadata.NumberFormatList[0].Format);
-            Assert.Equal("(\\d{4})(\\d{4})", metadata.NumberFormatList[0].Pattern);
+            // \d is narrowed to the ASCII-only [0-9] for metadata patterns matched against input --
+            // see BuildMetadataFromXml.NarrowDigitClassToAscii.
+            Assert.Equal("([0-9]{4})([0-9]{4})", metadata.NumberFormatList[0].Pattern);
             Assert.Equal("12345678", metadata.TollFree.ExampleNumber);
         }
 

--- a/csharp/PhoneNumbers/BuildMetadataFromXml.cs
+++ b/csharp/PhoneNumbers/BuildMetadataFromXml.cs
@@ -198,6 +198,122 @@ namespace PhoneNumbers
         }
 
         /// <summary>
+        /// Same contract as <see cref="ValidateRE(string, bool)"/>, but first narrows every
+        /// regex-structural <c>\d</c> (and <c>\D</c>) in the pattern to an ASCII-only equivalent --
+        /// see <see cref="NarrowDigitClassToAscii"/>. Use this (instead of the plain
+        /// <see cref="ValidateRE(string, bool)"/> overloads) only for metadata fields that are
+        /// actually matched against phone-number input at run time (nationalNumberPattern,
+        /// leadingDigits, internationalPrefix, nationalPrefixForParsing, and a numberFormat's
+        /// pattern attribute) -- never for fields that only ever serve as a *replacement* template
+        /// (nationalPrefixTransformRule, nationalPrefixFormattingRule, carrierCodeFormattingRule,
+        /// the format/intlFormat text, preferredInternationalPrefix, preferredExtnPrefix), so those
+        /// keep validating (and echoing back) exactly the text the XML author wrote.
+        /// <para>
+        /// This narrowing is safe specifically because every one of those five matched-against
+        /// fields is only ever matched, at run time, against a string PhoneNumberUtil has already
+        /// normalized to ASCII 0-9 (see PhoneNumberUtil.Normalize/NormalizeDigits and its callers --
+        /// MaybeStripInternationalPrefixAndNormalize, ParseHelper, MaybeStripNationalPrefixAndCarrierCode)
+        /// or that was rebuilt from the numeric NationalNumber field of an already-parsed PhoneNumber
+        /// (GetNationalSignificantNumber*, always ASCII by construction), or -- for AsYouTypeFormatter --
+        /// a buffer fed exclusively through NormalizeAndAccrueDigitsAndPlusSign, which normalizes each
+        /// character as it is accrued. None of these call sites can hand a metadata pattern a raw,
+        /// non-normalized (and therefore potentially non-ASCII-digit) string. The free-text
+        /// candidate-scanning patterns in PhoneNumberMatcher are hand-written C# (not sourced from
+        /// this XML parser) and are deliberately left untouched -- they run against arbitrary raw text
+        /// before normalization and must stay Unicode-digit-aware.
+        /// </para>
+        /// </summary>
+        internal static string ValidateAndNarrowPatternRE(string regex, bool removeWhitespace = false)
+        {
+            if (removeWhitespace && regex.Any(char.IsWhiteSpace))
+                regex = new string(regex.Where(c => !char.IsWhiteSpace(c)).ToArray());
+            return ValidateRE(NarrowDigitClassToAscii(regex), false);
+        }
+
+        /// <summary>
+        /// Rewrites every regex-structural <c>\d</c> in <paramref name="regex"/> to the ASCII-only
+        /// <c>[0-9]</c> (or, for a <c>\d</c> already inside a <c>[...]</c> character class, the bare
+        /// <c>0-9</c> substituted in place of the escape -- e.g. <c>[\d-]</c> becomes <c>[0-9-]</c>,
+        /// never the broken/nested <c>[[0-9]-]</c>). A <c>\D</c> outside any character class narrows
+        /// symmetrically to <c>[^0-9]</c>; a <c>\D</c> found *inside* a character class throws, since
+        /// "not a decimal digit" cannot in general be soundly unioned into an existing bracket
+        /// expression's other members -- this shape does not occur anywhere in the shipped metadata
+        /// today (verified by inspection of PhoneNumberMetadata.xml, ShortNumberMetadata.xml,
+        /// PhoneNumberAlternateFormats.xml and PhoneNumberMetadataForTesting.xml), so surfacing it
+        /// loudly if a future upstream sync ever introduces one is preferable to silently emitting an
+        /// incorrect pattern.
+        /// <para>
+        /// This is structural, not a blind string replace: a backslash is only ever treated as
+        /// starting a fresh escape when it is not itself the second half of one (so <c>\\d</c> --
+        /// an escaped backslash followed by a literal "d" -- is left alone), and entry into/exit
+        /// from a character class tracks the POSIX idiom where a literal <c>]</c> immediately after
+        /// <c>[</c> or <c>[^</c> does not close the class.
+        /// </para>
+        /// </summary>
+        internal static string NarrowDigitClassToAscii(string regex)
+        {
+            if (regex.IndexOf('\\') < 0)
+                return regex;
+
+            var sb = new StringBuilder(regex.Length + 8);
+            var inClass = false;
+            var i = 0;
+            var n = regex.Length;
+            while (i < n)
+            {
+                var c = regex[i];
+                if (c == '\\' && i + 1 < n)
+                {
+                    var next = regex[i + 1];
+                    switch (next)
+                    {
+                        case 'd':
+                            sb.Append(inClass ? "0-9" : "[0-9]");
+                            break;
+                        case 'D' when inClass:
+                            throw new NotSupportedException(
+                                "Cannot narrow \\D to ASCII inside a character class: " + regex);
+                        case 'D':
+                            sb.Append("[^0-9]");
+                            break;
+                        default:
+                            sb.Append(c).Append(next);
+                            break;
+                    }
+                    i += 2;
+                    continue;
+                }
+                if (!inClass && c == '[')
+                {
+                    inClass = true;
+                    sb.Append(c);
+                    i++;
+                    // A leading '^' (negation) and/or an immediately-following ']' are literal
+                    // members of the class, not its close -- the regular ']' handling below only
+                    // applies once we're past this leading special-case position.
+                    if (i < n && regex[i] == '^')
+                    {
+                        sb.Append(regex[i]);
+                        i++;
+                    }
+                    if (i < n && regex[i] == ']')
+                    {
+                        sb.Append(regex[i]);
+                        i++;
+                    }
+                    continue;
+                }
+                if (inClass && c == ']')
+                {
+                    inClass = false;
+                }
+                sb.Append(c);
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Returns the national prefix of the provided country element.
         /// </summary>
         public static string GetNationalPrefix(XElement element)
@@ -214,14 +330,14 @@ namespace PhoneNumbers
             if (element.Attribute(COUNTRY_CODE) is { } a1)
                 metadata.CountryCode = int.Parse(a1.Value, CultureInfo.InvariantCulture);
             if (element.Attribute(LEADING_DIGITS) is { } a2)
-                metadata.LeadingDigits = ValidateRE(a2.Value);
+                metadata.LeadingDigits = ValidateAndNarrowPatternRE(a2.Value);
             if (element.Attribute(INTERNATIONAL_PREFIX) is { } a3)
-                metadata.InternationalPrefix = ValidateRE(a3.Value);
+                metadata.InternationalPrefix = ValidateAndNarrowPatternRE(a3.Value);
             if (element.Attribute(PREFERRED_INTERNATIONAL_PREFIX) is { } a4)
                 metadata.PreferredInternationalPrefix = a4.Value;
             if (element.Attribute(NATIONAL_PREFIX_FOR_PARSING) is { } a5)
             {
-                metadata.NationalPrefixForParsing = ValidateRE(a5.Value, true);
+                metadata.NationalPrefixForParsing = ValidateAndNarrowPatternRE(a5.Value, true);
                 if (element.Attribute(NATIONAL_PREFIX_TRANSFORM_RULE) is { } a6)
                     metadata.NationalPrefixTransformRule = ValidateRE(a6.Value);
             }
@@ -251,7 +367,12 @@ namespace PhoneNumbers
         {
             var intlFormat = new NumberFormat();
             SetLeadingDigitsPatterns(numberFormatElement, intlFormat);
-            intlFormat.Pattern = numberFormatElement.Attribute(PATTERN)?.Value ?? "";
+            // Not run through ValidateRE here (same as before this narrowing was added) -- the same
+            // "pattern" attribute on this numberFormatElement is validated by the sibling
+            // LoadNationalFormat call in the normal LoadAvailableFormats flow. It IS matched against
+            // normalized (ASCII-only) national numbers at run time (ChooseFormattingPatternForNumber,
+            // when metadata.intlNumberFormat_ is in use), so it still needs narrowing.
+            intlFormat.Pattern = NarrowDigitClassToAscii(numberFormatElement.Attribute(PATTERN)?.Value ?? "");
             var intlFormatPattern = numberFormatElement.Elements(INTL_FORMAT).ToList();
             var hasExplicitIntlFormatDefined = false;
 
@@ -287,7 +408,7 @@ namespace PhoneNumbers
         internal static string LoadNationalFormat(PhoneMetadata metadata, XElement numberFormatElement, NumberFormat format)
         {
             SetLeadingDigitsPatterns(numberFormatElement, format);
-            format.Pattern = ValidateRE(numberFormatElement.Attribute(PATTERN)?.Value ?? "");
+            format.Pattern = ValidateAndNarrowPatternRE(numberFormatElement.Attribute(PATTERN)?.Value ?? "");
 
             var formatPattern = numberFormatElement.Elements(FORMAT).ToList();
             if (formatPattern.Count != 1)
@@ -353,7 +474,7 @@ namespace PhoneNumbers
         internal static void SetLeadingDigitsPatterns(XElement numberFormatElement, NumberFormat format)
         {
             foreach (var e in numberFormatElement.Elements(LEADING_DIGITS))
-                format.leadingDigitsPattern_.Add(ValidateRE(e.Value, true));
+                format.leadingDigitsPattern_.Add(ValidateAndNarrowPatternRE(e.Value, true));
         }
 
         public static string GetNationalPrefixFormattingRuleFromElement(XElement element, string nationalPrefix)
@@ -429,7 +550,7 @@ namespace PhoneNumbers
 
             var validPattern = element.Element(NATIONAL_NUMBER_PATTERN);
             if (validPattern is not null)
-                numberDesc.NationalNumberPattern = ValidateRE(validPattern.Value, true);
+                numberDesc.NationalNumberPattern = ValidateAndNarrowPatternRE(validPattern.Value, true);
 
             var exampleNumber = element.Element(EXAMPLE_NUMBER);
             if (exampleNumber is not null)


### PR DESCRIPTION
## Changes
- Narrows `\d` to `[0-9]` in every metadata-derived regex pattern that's actually matched against phone-number input: territory `leadingDigits`, `internationalPrefix`, `nationalPrefixForParsing`, `numberFormat`'s `pattern` attribute (national and the `intlNumberFormat_` copy), per-format `leadingDigits`, and `nationalNumberPattern`.
- **Why this is safe**: .NET's `\d` (without `RegexOptions.ECMAScript`) matches the full Unicode "decimal digit" category — hundreds of non-ASCII characters — which is both broader and more expensive to match than a plain `[0-9]` range check. Upstream Java's `\d` defaults to ASCII-only (`[0-9]`) unless `Pattern.UNICODE_CHARACTER_CLASS` is set, and these patterns were authored/verified against that ASCII-only default, so this also closes a semantic gap from upstream, not just a perf one.
- **Why it's correct**: every one of these patterns is only ever matched against input that's already passed through `PhoneNumberUtil.Normalize`/`NormalizeDigits` (which converts fullwidth/other-script digits to ASCII) or against `GetNationalSignificantNumber`, which is rebuilt from the numeric `NationalNumber` proto field and is ASCII by construction. Traced through the parse path (`MaybeStripInternationalPrefixAndNormalize`, `ParseHelper`/`MaybeStripNationalPrefixAndCarrierCode`), `AsYouTypeFormatter` (`NormalizeAndAccrueDigitsAndPlusSign`), and `PhoneNumberMatcher` (`ParseAndVerify`/`ParseAndKeepRawInput`) — full detail in commit `a1204a2`. `PhoneNumberMatcher`'s free-text candidate-scanning regexes and `PhoneNumberUtil`'s extension-parsing pattern are hand-written, not XML-metadata-derived, and are deliberately left untouched since they run on raw, un-normalized text.
- The rewrite (`BuildMetadataFromXml.NarrowDigitClassToAscii`) is structure-aware, not a blind string replace: it tracks escape pairs and character-class entry/exit so `\d` already nested inside a class (e.g. `[\d-]`) narrows to `[0-9-]` rather than producing broken nested brackets, and handles the POSIX literal-`]`-as-first-member idiom. `\D` narrows to `[^0-9]` outside a class; inside a class it throws rather than silently mishandling it (doesn't occur in shipped metadata today — verified by grep across all four resource XML files).

## Test plan
- [x] `dotnet build csharp` — clean on all three TFMs (netstandard2.0, net8.0, net10.0), zero warnings under `TreatWarningsAsErrors` + trim/AOT analyzers
- [x] `dotnet test csharp/PhoneNumbers.slnx` — 434 + 37 tests pass on net8.0 and net10.0, including new `TestNarrowDigitClassToAscii` theory tests covering real patterns from `resources/PhoneNumberMetadata.xml`, the nested-class case, `[^\d]`, POSIX-literal-bracket shapes, escaped-backslash-before-`d`, and a match-semantics-preservation check
- [x] `dotnet run -c Release --framework net10.0 -- --filter "*PhoneNumberWorkflowBenchmark*"` / `*ColdStartBenchmark*` — modest, directionally consistent steady-state win (~5-9% on `ParseOnly`/`ParseNationalFormat`/`ValidateOnly`/`FormatOnly`, several exceeding their reported confidence margins), cold start flat as expected (this is a matching-cost change, not a JIT-cost change)

---
