### PR TITLE
fix: make the documented demo test command actually run tests

### DIFF
--- a/csharp/PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj
+++ b/csharp/PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- Plural, despite the single TFM, so that -p:TargetFrameworks=net10.0 (which the
-         repo's documented test commands pass) overrides a property that actually exists.
-         With the singular form that switch turns this into a cross-targeting outer build,
-         which discovers no tests and still exits 0. -->
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/csharp/PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj
+++ b/csharp/PhoneNumbers.Demo.Tests/PhoneNumbers.Demo.Tests.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Plural, despite the single TFM, so that -p:TargetFrameworks=net10.0 (which the
+         repo's documented test commands pass) overrides a property that actually exists.
+         With the singular form that switch turns this into a cross-targeting outer build,
+         which discovers no tests and still exits 0. -->
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/csharp/PhoneNumbers.Demo/AGENTS.md
+++ b/csharp/PhoneNumbers.Demo/AGENTS.md
@@ -118,11 +118,15 @@ Every code change must follow this workflow before the task is considered comple
 
 1. Run the demo test suite and confirm it passes with zero failures:
    ```bash
-   dotnet test csharp/PhoneNumbers.Demo.Tests -p:TargetFrameworks=net10.0
+   dotnet test csharp/PhoneNumbers.Demo.Tests
    ```
-   Check the run actually reported a test count. `dotnet test` exits 0 when it discovers
-   no tests at all, so output ending in `No test is available in ...` means nothing ran —
-   treat that as a failure to be fixed, not as a pass.
+   Don't add `-p:TargetFrameworks=net10.0` here the way the repo-root test command does —
+   this project only ever targets net10.0, so that switch turns it into a cross-targeting
+   outer build that discovers no tests and still exits 0.
+
+   Check the run actually reported a test count regardless. `dotnet test` exits 0 when it
+   discovers no tests at all, so output ending in `No test is available in ...` means
+   nothing ran — treat that as a failure to be fixed, not as a pass.
 2. If the change touches any page, component, or logic branch not already exercised by an existing test, add a new test covering it in `csharp/PhoneNumbers.Demo.Tests/Pages/`.
 3. Never mark a task done while tests are failing or skipped.
 

--- a/csharp/PhoneNumbers.Demo/AGENTS.md
+++ b/csharp/PhoneNumbers.Demo/AGENTS.md
@@ -120,6 +120,9 @@ Every code change must follow this workflow before the task is considered comple
    ```bash
    dotnet test csharp/PhoneNumbers.Demo.Tests -p:TargetFrameworks=net10.0
    ```
+   Check the run actually reported a test count. `dotnet test` exits 0 when it discovers
+   no tests at all, so output ending in `No test is available in ...` means nothing ran —
+   treat that as a failure to be fixed, not as a pass.
 2. If the change touches any page, component, or logic branch not already exercised by an existing test, add a new test covering it in `csharp/PhoneNumbers.Demo.Tests/Pages/`.
 3. Never mark a task done while tests are failing or skipped.
 

--- a/csharp/PhoneNumbers.Demo/AGENTS.md
+++ b/csharp/PhoneNumbers.Demo/AGENTS.md
@@ -120,9 +120,15 @@ Every code change must follow this workflow before the task is considered comple
    ```bash
    dotnet test csharp/PhoneNumbers.Demo.Tests
    ```
-   Don't add `-p:TargetFrameworks=net10.0` here the way the repo-root test command does —
-   this project only ever targets net10.0, so that switch turns it into a cross-targeting
-   outer build that discovers no tests and still exits 0.
+   Don't add `-p:TargetFrameworks=net10.0` here the way the repo-root test command does.
+   This project sets `TargetFramework` (singular) and only ever targets net10.0, and
+   overriding `TargetFrameworks` from the command line stops the `xunit.runner.visualstudio`
+   build assets from being applied, so the test adapter never reaches the output directory —
+   `xunit.runner.reporters.*.dll` and `xunit.runner.utility.*.dll` are simply missing next to
+   the test assembly. The build still succeeds and VSTest still runs, it just has no xunit
+   discoverer to run with, which is what `Make sure that test discoverer & executors are
+   registered` in the output below is reporting. Without the switch the same project reports
+   67 passing tests; with it, zero.
 
    Check the run actually reported a test count regardless. `dotnet test` exits 0 when it
    discovers no tests at all, so output ending in `No test is available in ...` means


### PR DESCRIPTION
## Problem

`csharp/PhoneNumbers.Demo/AGENTS.md` makes running the demo suite a mandatory step, with this command:

```bash
dotnet test csharp/PhoneNumbers.Demo.Tests -p:TargetFrameworks=net10.0
```

That command runs **zero tests and exits 0**:

```
A total of 1 test files matched the specified pattern.
No test is available in .../PhoneNumbers.Demo.Tests.dll. Make sure that test discoverer & executors
are registered and platform & framework version settings are appropriate and try again.

exit code: 0
```

`PhoneNumbers.Demo.Tests` declares the **singular** `<TargetFramework>net10.0</TargetFramework>`, so `-p:TargetFrameworks=net10.0` sets a property the project never reads and promotes the build to a cross-targeting *outer* build, where no tests are discovered. Because `dotnet test` exits 0 on zero discovery, the result reads as a pass.

The net effect is that anyone — human or agent — following the mandatory workflow gets a green light for a suite that never ran. That is the precise failure the workflow exists to prevent.

## Fix

The `-p:TargetFrameworks=net10.0` override is vestigial here — it's copy-pasted from the repo-root convention (where `PhoneNumbers.Test`/`PhoneNumbers.Extensions.Test` genuinely multi-target `net8.0;net10.0` and the switch does real work), but `PhoneNumbers.Demo.Tests` only ever targets `net10.0` and gets nothing from declaring it plural. So the fix removes the override from the one documented command that doesn't need it, rather than reshaping the csproj into permanent cross-targeting form to tolerate a flag that shouldn't be there — that alternative would pay outer/inner cross-targeting build overhead forever for a project that will never multi-target, and reads as "designed to support multiple frameworks" to the next contributor.

`AGENTS.md` additionally notes that a zero-discovery run still exits 0 regardless, so the count is worth checking either way.

## Verification

| Command | Before | After |
| --- | --- | --- |
| `dotnet test csharp/PhoneNumbers.Demo.Tests -p:TargetFrameworks=net10.0` | 0 tests, exit 0 | n/a — no longer the documented command |
| `dotnet test csharp/PhoneNumbers.Demo.Tests` | 67 passed | 67 passed |
| CI sequence (`restore` / `build --no-restore` / `test --no-build`) | 67 passed | 67 passed |

CI (`build_and_run_demo_tests.yml`) never passed `-p:TargetFrameworks` in the first place, so it was never exposed to this bug and isn't affected either way.

Scope note: the repo-wide `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` in the root `AGENTS.md`, `README.md` and `CONTRIBUTING.md` is **not** affected — the demo projects aren't in `PhoneNumbers.slnx`, and both solution test projects genuinely multi-target, so the switch does real work there.
