### PR TITLE
ci: harden metadata release and triage workflow permissions

### DIFF
--- a/.github/workflows/finalize_metadata_release.yml
+++ b/.github/workflows/finalize_metadata_release.yml
@@ -29,14 +29,24 @@ jobs:
       github.event.pull_request.user.login == 'libphonenumber-csharp-bot'
     runs-on: ubuntu-latest
     permissions:
+      # createRelease (lib/github-release-helpers.sh) POSTs /repos/.../releases, which
+      # creates the vX.Y.Z tag as well as the release entry - that needs contents: write.
       contents: write
+      # dispatchPublish POSTs /repos/.../actions/workflows/publish_nuget.yml/dispatches,
+      # and workflow_dispatch needs actions: write. github suppresses push events raised
+      # by GITHUB_TOKEN, so creating the tag alone cannot start the publish run.
       actions: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create release and dispatch publish
-        run: |
-          bash lib/finalize-metadata-release.sh \
-            "${{ github.event.pull_request.head.ref }}" \
-            "${{ github.event.pull_request.merge_commit_sha }}"
+        # head.ref is attacker-controlled - a branch name may contain shell
+        # metacharacters - so both values are handed to the step through the
+        # environment and referenced as quoted shell variables. Interpolating
+        # ${{ }} straight into the run body would let a crafted branch name run as
+        # code. The script still receives the same two positional arguments.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          bash lib/finalize-metadata-release.sh "$HEAD_REF" "$MERGE_SHA"

--- a/.github/workflows/triage_metadata_issues.yml
+++ b/.github/workflows/triage_metadata_issues.yml
@@ -17,11 +17,9 @@ on:
   issues:
     types: [opened]
 
+# Read-only by default; the triage job below raises exactly what it needs.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  copilot-requests: write
+  contents: read
 
 concurrency:
   group: triage-metadata-issue-${{ github.event.issue.number }}
@@ -35,6 +33,19 @@ jobs:
     # Don't second-guess the maintainers' own issues (e.g. tracking/planning
     # issues like #375), only third-party bug reports.
     if: github.event.issue.author_association != 'OWNER' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'COLLABORATOR'
+    permissions:
+      # "Propose adding this issue to the examples list" creates the
+      # triage/metadata-example-issue-* branch and commits
+      # .github/triage/metadata_examples.md onto it.
+      contents: write
+      # "Act on classification" creates/adds the metadata label, comments, and closes
+      # the issue.
+      issues: write
+      # ...and the examples-list step opens the follow-up PR.
+      pull-requests: write
+      # actions/ai-inference calls the Copilot inference api with the built-in
+      # GITHUB_TOKEN; see the header comment.
+      copilot-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## 1. Script injection in `finalize_metadata_release.yml` (Scorecard: Dangerous-Workflow, critical)

The release step interpolated event data straight into a `run:` body:

```yaml
run: |
  bash lib/finalize-metadata-release.sh \
    "${{ github.event.pull_request.head.ref }}" \
    "${{ github.event.pull_request.merge_commit_sha }}"
```

`head.ref` is attacker-supplied text, and the expression engine substitutes it *before* bash parses the line — so a branch name containing shell metacharacters executes as code, in a job holding `contents: write` and `actions: write`.

Both values now reach the step through `env:` and are referenced as quoted shell variables. The script receives the same two positional arguments in the same order.

The existing `if:` gates (merged PR, base `main`, `metadata-update/*` prefix, author `libphonenumber-csharp-bot`) made this hard to reach but did not remove it. They are unchanged.

## 2. Over-broad token permissions in `triage_metadata_issues.yml` (Scorecard: Token-Permissions, high)

The top-level block granted `contents`/`issues`/`pull-requests`/`copilot-requests: write` to every job in the file. Top level is now `contents: read`, with the four writes moved onto the single `triage` job that needs them, each commented with the step that requires it. No future job added to this file silently inherits write access.

## Deliberately not changed: the two `finalize_metadata_release.yml` job permissions

Scorecard also flags `contents: write` (line 32) and `actions: write` (line 33) on that job. Both are the minimum for the flow, verified against `lib/finalize-metadata-release.sh`, `lib/github-release-helpers.sh` and `publish_nuget.yml`:

- **`contents: write`** — `createRelease` POSTs `/repos/.../releases` with `target_commitish`, which creates the `vX.Y.Z` tag as well as the release. There is no finer-grained release scope, and `contents: read` cannot create a ref.
- **`actions: write`** — `dispatchPublish` POSTs to `/actions/workflows/publish_nuget.yml/dispatches`, which requires it. The dispatch cannot be dropped: GitHub suppresses `push` events raised by `GITHUB_TOKEN`, so the tag created above will not fire `publish_nuget.yml`'s `push: tags: ['v*']` trigger on its own — which is what the `# github suppresses push events from GITHUB_TOKEN` comment in the helper records.

Both permissions now carry a comment naming the exact API call that needs them. Suggest dismissing those two alerts as used-as-designed rather than weakening the release path.

## Verification

- Both files parse as YAML.
- Interpolation scan across every `run:` body in both files: the only remaining `${{ }}` is `${{ runner.temp }}`, which is runner-provided, not event-controlled. (`actions/github-script` `script:` blocks still use `${{ toJSON(...) }}`, the correct JS-context-safe pattern — not a shell body.)
- Effective permissions after the change — finalize: top `contents: read`, job `contents: write, actions: write`; triage: top `contents: read`, job `contents/issues/pull-requests/copilot-requests: write`.