### PR TITLE
refactor: simplify IsLatinLetter range test, document broad catch

### DIFF
--- a/csharp/PhoneNumbers.MetadataBuilder/Program.cs
+++ b/csharp/PhoneNumbers.MetadataBuilder/Program.cs
@@ -57,6 +57,12 @@ internal static class Program
             try { return Run(args); }
             finally { mutex.ReleaseMutex(); }
         }
+        // Deliberately broad: this is the process-wide handler for a build-time tool, and the
+        // work it guards reaches XML parsing, file I/O and named-mutex code that between them
+        // can throw a dozen unrelated types. Nothing is swallowed — the full exception goes to
+        // stderr and the non-zero exit code fails the MSBuild target that invoked us — so
+        // narrowing this would only trade a readable one-line diagnostic for an unhandled-
+        // exception crash dump, with no change to whether the build fails.
         catch (Exception ex)
         {
             Console.Error.WriteLine($"PhoneNumbers.MetadataBuilder failed: {ex.Message}");

--- a/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers.Test/TestPhoneNumberMatcher.cs
@@ -247,6 +247,11 @@ namespace PhoneNumbers.Test
             Assert.True(PhoneNumberMatcher.IsLatinLetter('C'));
             Assert.True(PhoneNumberMatcher.IsLatinLetter('\u00C9'));
             Assert.True(PhoneNumberMatcher.IsLatinLetter('\u0301'));  // Combining acute accent
+            // One letter from each remaining accepted block, so every arm of the range test is
+            // exercised: these were the blocks no assertion reached.
+            Assert.True(PhoneNumberMatcher.IsLatinLetter('\u0100'));  // Latin Extended-A
+            Assert.True(PhoneNumberMatcher.IsLatinLetter('\u0180'));  // Latin Extended-B
+            Assert.True(PhoneNumberMatcher.IsLatinLetter('\u1E00'));  // Latin Extended Additional
             // Punctuation, digits and white-space are not considered "latin letters".
             Assert.False(PhoneNumberMatcher.IsLatinLetter(':'));
             Assert.False(PhoneNumberMatcher.IsLatinLetter('5'));

--- a/csharp/PhoneNumbers/PhoneNumberMatcher.cs
+++ b/csharp/PhoneNumbers/PhoneNumberMatcher.cs
@@ -217,14 +217,15 @@ namespace PhoneNumbers
             // Combining marks are a subset of non-spacing-mark.
             if (!char.IsLetter(letter) && CharUnicodeInfo.GetUnicodeCategory(letter) != UnicodeCategory.NonSpacingMark)
                 return false;
-            return
-                letter <= 0x007F                             // BASIC_LATIN
-                || letter >= 0x0080 && letter <= 0x00FF     // LATIN_1_SUPPLEMENT
-                || letter >= 0x0100 && letter <= 0x017F     // LATIN_EXTENDED_A
-                || letter >= 0x1E00 && letter <= 0x1EFF     // LATIN_EXTENDED_ADDITIONAL
-                || letter >= 0x0180 && letter <= 0x024F     // LATIN_EXTENDED_B
-                || letter >= 0x0300 && letter <= 0x036F     // COMBINING_DIACRITICAL_MARKS
-                ;
+            // The Unicode blocks Java's isLatinLetter() accepts, expressed as the code point
+            // ranges that define them (C# has no Character.UnicodeBlock equivalent).
+            return letter is
+                <= '\u007F'                            // BASIC_LATIN
+                or (>= '\u0080' and <= '\u00FF')       // LATIN_1_SUPPLEMENT
+                or (>= '\u0100' and <= '\u017F')       // LATIN_EXTENDED_A
+                or (>= '\u1E00' and <= '\u1EFF')       // LATIN_EXTENDED_ADDITIONAL
+                or (>= '\u0180' and <= '\u024F')       // LATIN_EXTENDED_B
+                or (>= '\u0300' and <= '\u036F');      // COMBINING_DIACRITICAL_MARKS
         }
 
         private static bool IsInvalidPunctuationSymbol(char character)


### PR DESCRIPTION
The four note-severity maintainability alerts. Two produced changes; two are deliberately declined, because a note-level style hint is not worth making the code worse.

## Fixed

**`cs/complex-condition` - `PhoneNumberMatcher.cs:221`.** `IsLatinLetter`'s six chained `letter >= x && letter <= y` clauses joined by `||` became a single relational pattern — `return letter is <= BASIC_LATIN or (>= ... and <= ...) or ...` — one arm per Unicode block, using `'\uXXXX'` char literals.

All operands are pure comparisons on a `char`, so short-circuit order is irrelevant to behavior, and `and` binds tighter than `or` exactly as `&&` binds tighter than `||` - the original grouping is preserved. Ranges, their order, and the Unicode block comments are unchanged. Char literals replaced the hex ints because relational patterns require a constant of the matched type; that form already appears elsewhere in this file. Pattern combinators are already used elsewhere in the library (`PrefixFileReader.MayFallBackToEnglish`).

**`cs/catch-of-all-exceptions` - `PhoneNumbers.MetadataBuilder/Program.cs:60`.** Kept, now documented. This is the process-wide handler in `Main` for a build-time tool, and it was never a silent swallow: it writes `ex.Message` *and* the full exception to stderr and returns exit code 1, failing the invoking MSBuild target. The guarded work spans XML parsing, file I/O, `GZipStream` and named-mutex operations, so a narrowed catch list would be a long guess that converts anything unanticipated into an unhandled-exception crash dump instead of a readable one-line diagnostic - with no change to whether the build fails. A comment now states that. The alert stays open; no `query-filters` exclusion was added for it.

## Declined

**`cs/missed-ternary-operator` - `PhoneNumberUtil.cs:1336`.** The `if` is guarded by a ~17-line condition that is almost entirely comment text explaining the MX/CL/UZ and non-geo dialling rules. The branches are one line each, so a ternary would strand the `?`/`:` arms far below the `formattedNumber =` target at the bottom of a comment block that is the whole point of the construct. The if/else is clearer.

**`cs/linq/missed-select` - `PrefixFileReader.cs:66`.** The loop body is not a projection: it filters malformed resource names (two `continue`s), parses a country calling code, and mutates a `SortedDictionary`. Only its first line maps the iteration variable. This is a startup path - `LoadFileNamesFromManifestResources` is called from the `PrefixFileReader` constructor, which backs `PhoneNumberOfflineGeocoder` / `PhoneNumberToCarrierMapper` / `PhoneNumberToTimeZonesMapper` construction - and AGENTS.md documents cold-start and allocation cost as tracked here. Appending `.Select` to the existing `.Where` would add a delegate plus another enumerator allocation on that path for zero readability gain.

## Verification

- `dotnet build csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` - 0 warnings, 0 errors.
- `PhoneNumbers.csproj` also built across all TFMs (netstandard2.0 + net8.0 + net10.0) to confirm the pattern syntax compiles on the netstandard2.0 leg.
- `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` - 491 passed, 0 failed, 0 skipped.
- Targeted `TestPhoneNumberMatcher` run - 43 passed, including `TestIsLatinLetter`, which covers Latin, accented, combining-mark, CJK, kana, digit and punctuation inputs.
