### PR TITLE
fix: stop MetadataFilter.GetHashCode throwing on an empty blacklist

### DIFF
--- a/csharp/PhoneNumbers.Test/TestMetadataFilter.cs
+++ b/csharp/PhoneNumbers.Test/TestMetadataFilter.cs
@@ -893,6 +893,28 @@ namespace PhoneNumbers.Test
             Assert.False(result);
         }
 
+        [Fact]
+        public void TestGetHashCodeForEmptyBlacklistDoesNotThrow()
+        {
+            // EmptyFilter() has an empty blacklist, and a seedless Aggregate over an empty sequence
+            // throws InvalidOperationException - so this used to throw rather than return a hash.
+            var filter = MetadataFilter.EmptyFilter();
+
+            var exception = Record.Exception(() => filter.GetHashCode());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void TestGetHashCodeAgreesWithEqualsForEmptyBlacklists()
+        {
+            var filter = MetadataFilter.EmptyFilter();
+            var same = new MetadataFilter(new Dictionary<string, SortedSet<string>>());
+
+            Assert.True(filter.Equals(same));
+            Assert.Equal(filter.GetHashCode(), same.GetHashCode());
+        }
+
         private static PhoneMetadata.Builder FakeArmeniaPhoneMetadata()
         {
             var metadata = new PhoneMetadata.Builder();

--- a/csharp/PhoneNumbers/MetadataFilter.cs
+++ b/csharp/PhoneNumbers/MetadataFilter.cs
@@ -121,9 +121,12 @@ namespace PhoneNumbers
         {
             unchecked
             {
+                // Seeded, because the seedless Aggregate throws on an empty sequence and an empty
+                // blacklist is a normal filter - EmptyFilter() is exactly that. XOR-ing from 0
+                // leaves the hash of every non-empty blacklist unchanged.
                 return blacklist.GetType().GetHashCode() ^ blacklist
                            .Select(kvp => kvp.Key.GetHashCode() * 17 ^ kvp.Value.GetHashCode() * 23)
-                           .Aggregate((a, b) => a ^ b);
+                           .Aggregate(0, (a, b) => a ^ b);
             }
         }
 


### PR DESCRIPTION
## Bug

`MetadataFilter.GetHashCode()` XOR-folds the blacklist with a seedless `Aggregate`:

```csharp
return blacklist.GetType().GetHashCode() ^ blacklist
           .Select(kvp => kvp.Key.GetHashCode() * 17 ^ kvp.Value.GetHashCode() * 23)
           .Aggregate((a, b) => a ^ b);
```

`Enumerable.Aggregate` without a seed throws `InvalidOperationException: Sequence contains no elements` on an empty sequence. An empty blacklist is not a degenerate case — it is the filter that excludes nothing, which is exactly what `MetadataFilter.EmptyFilter()` returns:

```csharp
internal static MetadataFilter EmptyFilter() => new(new Dictionary<string, SortedSet<string>>());
```

So `MetadataFilter.EmptyFilter().GetHashCode()` throws today, on a public method of a `public sealed` class. Anything that puts such a filter in a `Dictionary`/`HashSet`, or calls `GetHashCode()` directly, gets an exception instead of a hash. `Equals` handles the same filter fine, so the type currently violates the equals/hash contract at that input.

## Fix

Seed the fold with `0`. XOR against `0` is the identity, so **every non-empty blacklist keeps exactly the hash it had** — this is not a hash-value change for existing inputs, only a fix for the throwing one.

## Tests

Two tests in `TestMetadataFilter`:

- `TestGetHashCodeForEmptyBlacklistDoesNotThrow`
- `TestGetHashCodeAgreesWithEqualsForEmptyBlacklists` — pins the equals/hash contract for two independently constructed empty filters

Both fail before this change with `System.InvalidOperationException : Sequence contains no elements`, and pass after.

## Verification

- `dotnet build csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — 0 warnings, 0 errors.
- `dotnet test csharp/PhoneNumbers.slnx -p:TargetFrameworks=net10.0` — PhoneNumbers.Test 442 passed (440 before, +2 new), PhoneNumbers.Extensions.Test 51 passed. Zero failures, nothing skipped.

Found while extending the equality tests for the `cs/null-argument-to-equals` alert in #459; no CodeQL rule flags it.
