### PR TITLE
fix: make MetadataFilter.GetHashCode agree with Equals for non-empty blacklists

### DIFF
--- a/csharp/PhoneNumbers.Test/TestMetadataFilter.cs
+++ b/csharp/PhoneNumbers.Test/TestMetadataFilter.cs
@@ -915,6 +915,21 @@ namespace PhoneNumbers.Test
             Assert.Equal(filter.GetHashCode(), same.GetHashCode());
         }
 
+        [Fact]
+        public void TestGetHashCodeAgreesWithEqualsForNonEmptyBlacklists()
+        {
+            // Two independently built instances whose blacklists have equal content but are not the
+            // same SortedSet<string> instances: SortedSet<T> doesn't override GetHashCode, so hashing
+            // it directly is reference-identity, while Equals above compares with SetEquals - content
+            // equality. That mismatch would let content-equal filters compare equal but hash
+            // differently, which is exactly what ForLiteBuild() produces here on every call.
+            var filter = MetadataFilter.ForLiteBuild();
+            var same = MetadataFilter.ForLiteBuild();
+
+            Assert.True(filter.Equals(same));
+            Assert.Equal(filter.GetHashCode(), same.GetHashCode());
+        }
+
         private static PhoneMetadata.Builder FakeArmeniaPhoneMetadata()
         {
             var metadata = new PhoneMetadata.Builder();

--- a/csharp/PhoneNumbers/MetadataFilter.cs
+++ b/csharp/PhoneNumbers/MetadataFilter.cs
@@ -124,9 +124,29 @@ namespace PhoneNumbers
                 // Seeded, because the seedless Aggregate throws on an empty sequence and an empty
                 // blacklist is a normal filter - EmptyFilter() is exactly that. XOR-ing from 0
                 // leaves the hash of every non-empty blacklist unchanged.
+                //
+                // Uses SetHashCode(kvp.Value) rather than kvp.Value.GetHashCode(): SortedSet<T>
+                // does not override GetHashCode, so the latter is reference-identity, while Equals
+                // above compares blacklists with SetEquals - content equality. Two independently
+                // built MetadataFilter instances with equal-content but distinct SortedSet<string>
+                // values (e.g. two ForLiteBuild() calls) would compare equal but hash differently.
                 return blacklist.GetType().GetHashCode() ^ blacklist
-                           .Select(kvp => kvp.Key.GetHashCode() * 17 ^ kvp.Value.GetHashCode() * 23)
+                           .Select(kvp => kvp.Key.GetHashCode() * 17 ^ SetHashCode(kvp.Value) * 23)
                            .Aggregate(0, (a, b) => a ^ b);
+            }
+        }
+
+        // Order-independent, matching SortedSet<T>.SetEquals's content-based equality.
+        private static int SetHashCode(SortedSet<string> set)
+        {
+            unchecked
+            {
+                var hash = 0;
+                foreach (var item in set)
+                {
+                    hash ^= item.GetHashCode();
+                }
+                return hash;
             }
         }
 


### PR DESCRIPTION
## Changes

- Fixes a latent `Equals`/`GetHashCode` contract violation in `MetadataFilter` left over after #462 (which fixed `GetHashCode` throwing on an *empty* blacklist, but didn't touch the non-empty path).

## Problem

`MetadataFilter.GetHashCode()` folds each blacklist entry's value via `kvp.Value.GetHashCode()`. `kvp.Value` is a `SortedSet<string>`, which does not override `GetHashCode` — so that call hashes by reference identity. `Equals`, a few lines above in the same file, compares the same values with `SetEquals` — content equality.

That mismatch means two independently built `MetadataFilter` instances with equal-content but distinct `SortedSet<string>` instances compare `Equal` but can hash differently — a real violation of the `Equals`/`GetHashCode` contract. This isn't a hypothetical: `ParseFieldMapFromString` builds fresh `SortedSet<string>` instances on every call, so `MetadataFilter.ForLiteBuild()` (or `ForSpecialBuild()`) called twice produces exactly this case.

Nothing in the current codebase places a `MetadataFilter` in a hash-based collection, so this is currently inert rather than actively wrong. But the type is a `public sealed class` (construction is `internal`), and any future use of one in a `HashSet<MetadataFilter>` or as a `Dictionary` key would silently fail to deduplicate or look up correctly, with no obvious symptom pointing back at this.

## Fix

Added a `SetHashCode` helper that XOR-folds each element's hash order-independently, matching `SetEquals`'s content-based, order-independent equality, and use it instead of `kvp.Value.GetHashCode()`.

## Tests

Added `TestGetHashCodeAgreesWithEqualsForNonEmptyBlacklists`, which reproduces the bug directly: two `MetadataFilter.ForLiteBuild()` calls are `Equal` (existing behavior, unaffected), and now also produce equal hash codes (the actual fix). Before this fix, there's no reason for `kvp.Value`'s reference-hash to agree between the two independently-built sets, so this test exercises the exact case the bug lived in.

## Note for reviewers

This change was made in a sandbox with no .NET SDK and no network access to install one, so `dotnet build`/`dotnet test` could not be run here to confirm compilation or a pass. The fix was checked by hand-tracing both `Equals` and the new `GetHashCode` against the same `ParseFieldMapFromString`-produced data, and the new test is written to fail against the pre-fix code (reference-identity hashing of two distinct `SortedSet<string>` instances has no reason to coincide) and pass against the fix (content-based hashing of equal-content sets always agrees). CI on this PR is the actual gate.


---
