### PR TITLE
perf: sparse-checkout the two workflows that only read a handful of files

### DIFF
--- a/.github/workflows/finalize_metadata_release.yml
+++ b/.github/workflows/finalize_metadata_release.yml
@@ -37,11 +37,13 @@ jobs:
       # by GITHUB_TOKEN, so creating the tag alone cannot start the publish run.
       actions: write
     steps:
-      # Only checked out for lib/*.sh - the release and dispatch are plain api calls
-      # carrying GITHUB_TOKEN themselves, so nothing here needs a git credential.
+      # Only checked out for lib/*.sh - the release and dispatch are plain api calls carrying
+      # GITHUB_TOKEN themselves, so nothing here needs a git credential, and nothing outside
+      # lib/ is read at all, so there is no reason to materialize the resources/ tree.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          sparse-checkout: lib
       - name: Create release and dispatch publish
         # head.ref is attacker-controlled - a branch name may contain shell
         # metacharacters - so both values are handed to the step through the

--- a/.github/workflows/triage_metadata_issues.yml
+++ b/.github/workflows/triage_metadata_issues.yml
@@ -47,11 +47,14 @@ jobs:
       # GITHUB_TOKEN; see the header comment.
       copilot-requests: write
     steps:
-      # Only checked out for .github/triage/*.md - the branch, commit and PR below are made
-      # through the rest api by github-script, never by git, so no credential is needed here.
+      # Only checked out for .github/triage/*.md - those three prompt fragments, concatenated
+      # in "Build classifier system prompt" below, are the sole thing this job reads off disk.
+      # The branch, commit and PR it opens are made through the rest api by github-script rather
+      # than by git, so it needs no credential either.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          sparse-checkout: .github/triage
 
       - name: Read issue
         id: issue


### PR DESCRIPTION
Two workflows do a full `actions/checkout` — roughly 81 MiB of working tree, about 80 MiB of it `resources/` — and then read a few kilobytes off disk. `sparse-checkout:` (cone mode) restricts each to the paths its job actually opens.

## Changed

| Workflow | Sparse pattern | What the job actually reads | Checkout size |
| --- | --- | --- | --- |
| `finalize_metadata_release.yml` | `lib` | `lib/finalize-metadata-release.sh` plus the `lib/github-release-helpers.sh` it sources. Everything the script does is a `curl` against the GitHub api — create the release, dispatch `publish_nuget.yml` — so nothing else in the tree is touched. | ~81 MiB → ~168 KiB |
| `triage_metadata_issues.yml` | `.github/triage` | Only the "Build classifier system prompt" step reads the tree, `cat`-ing `.github/triage/system_prompt.md`, `metadata_examples.md` and `system_prompt_footer.md`. Every other step goes through `actions/github-script`, `actions/ai-inference`, or `npm install -g`; the examples-list PR is written with `repos.createOrUpdateFileContents`, not a local commit. | ~81 MiB → ~148 KiB |

Both patterns were verified against a real cone-mode sparse checkout of `main`: `lib` yields all six `lib/` files, and `.github/triage` yields all three prompt fragments (cone mode also brings the root-level files and `.github/*` in both cases, which is why the results are ~150 KiB rather than the bare directory size).

## Deliberately left alone

Everything that compiles, runs, packs, fuzzes, scans or benchmarks the tree needs `csharp/` and `resources/`, so a sparse checkout would just break it for a few build-seconds of gain:

- `build_and_run_demo_tests.yml`, `build_and_run_unit_tests_linux.yml`, `run_all_tests_and_upload_code_coverage.yml` — restore/build/test the solution.
- `deploy-demo.yml` — publishes the Blazor WASM demo.
- `publish_nuget.yml` — packs and pushes the packages.
- `fuzz.yml` — builds the fuzz target and the libfuzzer-dotnet bridge from source.
- `codeql.yml` — needs the full source set for the analysis to mean anything.
- `run_performance_tests.yml` — benchmarks, and additionally checks out the PR's base commit (`fetch-depth: 0`).
- `scorecard.yml` — `ossf/scorecard-action` inspects the whole repo tree.
- `create_new_release_on_new_metadata_update.yml` — `lib/github-actions-metadata-update.sh` regenerates `resources/` and commits it, so it is the one `lib/*.sh` workflow that genuinely wants the full checkout.
- `post_performance_test_comment.yml` — does not check out at all.

No other changes: no reformatting, no action re-pinning, comments only where the new setting needed explaining.
