### PR TITLE
ci: stop persisting git credentials in checkouts that don't use them

### DIFF
--- a/.github/workflows/finalize_metadata_release.yml
+++ b/.github/workflows/finalize_metadata_release.yml
@@ -37,7 +37,11 @@ jobs:
       # by GITHUB_TOKEN, so creating the tag alone cannot start the publish run.
       actions: write
     steps:
+      # Only checked out for lib/*.sh - the release and dispatch are plain api calls
+      # carrying GITHUB_TOKEN themselves, so nothing here needs a git credential.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create release and dispatch publish
         # head.ref is attacker-controlled - a branch name may contain shell
         # metacharacters - so both values are handed to the step through the

--- a/.github/workflows/triage_metadata_issues.yml
+++ b/.github/workflows/triage_metadata_issues.yml
@@ -47,7 +47,11 @@ jobs:
       # GITHUB_TOKEN; see the header comment.
       copilot-requests: write
     steps:
+      # Only checked out for .github/triage/*.md - the branch, commit and PR below are made
+      # through the rest api by github-script, never by git, so no credential is needed here.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Read issue
         id: issue


### PR DESCRIPTION
`actions/checkout` writes a token into `.git/config` unless told not to, so it stays readable by every later step in the job (and by anything those steps run). Most workflows in this repo already pass `persist-credentials: false`; two did not. Neither of them touches the remote with git, so this is just closing the gap. It is also what OpenSSF Scorecard's Token-Permissions / Dangerous-Workflow checks look for.

Change is one setting per file, nothing else.

## Changed

- **`.github/workflows/finalize_metadata_release.yml`** — the checkout only supplies `lib/*.sh`. `finalize-metadata-release.sh` creates the release and dispatches the publish through `curl` against the REST api (`createRelease` / `dispatchPublish` in `lib/github-release-helpers.sh`), authenticating with `GITHUB_TOKEN` from the step env. No git command runs against the remote, so the persisted credential was pure surface area — and this job holds `contents: write` + `actions: write`, which is exactly where you don't want a spare push credential lying around.
- **`.github/workflows/triage_metadata_issues.yml`** — the checkout only supplies the `.github/triage/*.md` prompt fragments. The "Propose adding this issue to the examples list" step creates the branch, the commit and the PR entirely through `actions/github-script` (`git.createRef`, `repos.createOrUpdateFileContents`, `pulls.create`), which uses the api token, not the checkout's. Nothing in the job shells out to git.

## Deliberately left alone

- **`.github/workflows/create_new_release_on_new_metadata_update.yml`** — checks out with `token: ${{ secrets.BOT_ACCESS_TOKEN }}`, and `lib/github-actions-metadata-update.sh` then does `git fetch`, `git commit` and `git push --force origin HEAD:refs/heads/${BRANCH}` against that remote. This one genuinely needs the credential persisted; adding the flag would break the metadata-update flow.
- **`.github/workflows/post_performance_test_comment.yml`** — no `actions/checkout` step at all.
- Every other workflow (`build_and_run_demo_tests`, `build_and_run_unit_tests_linux`, `codeql`, `deploy-demo`, `fuzz`, `publish_nuget`, `run_all_tests_and_upload_code_coverage`, `run_performance_tests`, `scorecard`) already passes `persist-credentials: false` — untouched.

That is the full set: 13 workflows, 12 checkout steps, all accounted for.

## Note on #467

#467 (`perf/workflow-sparse-checkout`) adds a `with:` block to the same checkout step in `finalize_metadata_release.yml`. This branch is based on `origin/main` and the edit there is kept to the two added lines, so whichever merges second needs a one-line rebase — move `persist-credentials: false` into the `with:` block the other PR introduces (or add the `with:` block, in the other direction). No other overlap.
